### PR TITLE
Improve server configs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,34 +1,35 @@
 AddDefaultCharset utf-8
+AddCharset utf-8 .css .js .json
 ForceType text/html
 DirectoryIndex index index.html
 Redirect 301 /complete.html /
 ErrorDocument 404 /404.html
 
-<files print.pdf>
-ForceType application/pdf
-Header add Content-Disposition "inline; filename=html-standard.pdf"
-</files>
+<Files print.pdf>
+  ForceType application/pdf
+  Header add Content-Disposition "inline; filename=html-standard.pdf"
+</Files>
 
-<files *.png>
-ForceType image/png
-</files>
+<Files *.png>
+  ForceType image/png
+</Files>
 
-<files *.json>
-ForceType application/json
-</files>
+<Files *.json>
+  ForceType application/json
+</Files>
 
-<files *.js>
-ForceType application/javascript
-</files>
+<Files *.js>
+  ForceType application/javascript
+</Files>
 
-<files *.txt>
- ForceType text/plain
-</files>
+<Files *.txt>
+  ForceType text/plain
+</Files>
 
-<files *.css>
- ForceType text/css
-</files>
+<Files *.css>
+  ForceType text/css
+</Files>
 
-<files *.html>
- ForceType text/html
-</files>
+<Files *.html>
+  ForceType text/html
+</Files>


### PR DESCRIPTION
Changes: 

* Add server configurations to the `.htaccess` file that make Apache serve certain resources compressed.

   Right now, nothing served from https://html.spec.whatwg.org/ is compressed, e.g.:

   ```bash

$ curl -sSLvv -H 'Accept-Encoding: gzip, deflate' https://html.spec.whatwg.org/ -o /dev/null

*   Trying 208.113.236.128...
* Connected to html.spec.whatwg.org (208.113.236.128) port 443 (#0)
* TLS 1.0 connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
* Server certificate: *.whatwg.org
* Server certificate: StartCom Class 2 Primary Intermediate Server CA
* Server certificate: StartCom Certification Authority
> GET / HTTP/1.1
> Host: html.spec.whatwg.org
> User-Agent: Mozilla/5.0 Gecko
> Accept: */*
> Accept-Encoding: gzip, deflate
> 
< HTTP/1.1 200 OK
< Date: Sat, 05 Sep 2015 20:03:17 GMT
< Server: Apache
< Last-Modified: Sat, 05 Sep 2015 16:39:55 GMT
< ETag: "7ccb43-51f02aa882cc0"
< Accept-Ranges: bytes
< Content-Length: 8178499
< Access-Control-Allow-Origin: *
< Strict-Transport-Security: max-age=31415926; includeSubDomains
< Content-Type: text/html; charset=utf-8
< 
{ [16384 bytes data]
* Connection #0 to host html.spec.whatwg.org left intact
```

    In the case of the `source` file (https://html.spec.whatwg.org/), the saving will be as follows:

  ```
 original size:         8.18 MB
 gzipped size:          1.42 MB
 ──────────────────────────────
 reduction:             6.76 MB [82.6%]
```
  :warning: Notes:
   * [`mod_deflate`](http://httpd.apache.org/docs/current/mod/mod_deflate.html) needs to be [enabled](https://github.com/h5bp/server-configs-apache/wiki/How-to-enable-Apache-modules) for this to take effect.
  * The [`<IfModule ... >`](http://httpd.apache.org/docs/current/mod/core.html#ifmodule) checks are there to ensure that Apache won't try to run the enclosed configs if the required modules are not enabled.
         
* Add server configurations to the `.htaccess` file that make Apache serve certain file types with the media type [`charset` parameter](http://www.w3.org/International/O-HTTP-charset#charset) set to `UTF-8`.

  :warning: Note: [`mod_mime`](http://httpd.apache.org/docs/current/mod/mod_mime.html) needs to be [enabled](https://github.com/h5bp/server-configs-apache/wiki/How-to-enable-Apache-modules) for this to take effect. 

* Make minor consistency improvements in `.htaccess`, namely:
   * Fix indentation.
   * For consistency, use [`Files`]( http://httpd.apache.org/docs/current/mod/core.html#files) instead of `files`.

--

Note: I had a quick chat with @annevk, and he told me that the Apache version used is: `2.2.22-14`.

If I need to change anything, let me know. :)