### PR TITLE
Specify default indentation size in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
+indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Specify a default indentation size of `2` in the `.editorconfig` file, as that size seems to be the one use most often (e.g.: [`.htaccess`](https://github.com/whatwg/html/blob/323b4cc752f8ad47b56a949f942bcdd10a1c93e8/.htaccess), [`json-entities-legacy.inc`](https://github.com/whatwg/html/blob/cb8445520f10e044d23cfd3ff7fc38e064edf1f1/json-entities-legacy.inc), [`link-fixup.js`](https://github.com/whatwg/html/blob/cb8445520f10e044d23cfd3ff7fc38e064edf1f1/link-fixup.js)).