### PR TITLE
Add <script type="module"> and module resolution/fetching/evaluation

### DIFF
--- a/images/asyncdefer.svg
+++ b/images/asyncdefer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 690 115" width="690" height="115">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 200" width="820" height="200">
   <style><![CDATA[
     .dividers {
       stroke: rgb(106, 148, 0);
@@ -69,12 +69,16 @@
   ]]></style>
 
   <g class="dividers">
-    <line x1="0" x2="690" y1="33.5" y2="33.5" />
-    <line x1="0" x2="690" y1="67.5" y2="67.5" />
+    <line x1="0" x2="820" y1="33.5" y2="33.5" />
+    <line x1="0" x2="820" y1="66.5" y2="66.5" />
+    <line x1="0" x2="820" y1="99.5" y2="99.5" />
+    <line x1="0" x2="820" y1="132.5" y2="132.5" />
 
-    <line x1="135.5" x2="135.5" y1="1" y2="29" />
-    <line x1="135.5" x2="135.5" y1="38" y2="63" />
-    <line x1="135.5" x2="135.5" y1="71" y2="99" />
+    <line x1="245.5" x2="245.5" y1="1" y2="29" />
+    <line x1="245.5" x2="245.5" y1="38" y2="62" />
+    <line x1="245.5" x2="245.5" y1="68" y2="95" />
+    <line x1="245.5" x2="245.5" y1="104" y2="128" />
+    <line x1="245.5" x2="245.5" y1="137" y2="165" />
   </g>
 
   <defs>
@@ -89,35 +93,88 @@
     </marker>
   </defs>
 
-  <text x="12" y="16.75" class="tag">&lt;script&gt;</text>
-  <text x="142" y="9" class="label">Scripting:</text>
-  <text x="142" y="24" class="label">HTML Parser:</text>
-  <line x1="399" x2="399" y1="9" y2="24" class="connector" />
-  <line x1="546" x2="546" y1="9" y2="24" class="connector" />
-  <line x1="248" x2="399" y1="24" y2="24" class="parser progress first" />
-  <line x1="399" x2="496" y1="9" y2="9" class="fetch progress" />
-  <line x1="496" x2="546" y1="9" y2="9" class="execution progress" />
-  <line x1="546" x2="674" y1="24" y2="24" class="parser progress last" />
+  <g>
+    <text x="12" y="16.75" class="tag">&lt;script&gt;</text>
 
-  <text x="12" y="50.25" class="tag">&lt;script defer&gt;</text>
-  <text x="142" y="42" class="label">Scripting:</text>
-  <text x="142" y="57" class="label">HTML Parser:</text>
-  <line x1="626" x2="626" y1="42" y2="57" class="connector" />
-  <line x1="248" x2="626" y1="57" y2="57" class="parser progress first" />
-  <line x1="399" x2="496" y1="42" y2="42" class="fetch progress" />
-  <line x1="626" x2="674" y1="42" y2="42" class="execution progress last" />
+    <g transform="translate(252,0)">
+      <text x="0" y="9" class="label">Scripting:</text>
+      <text x="0" y="24" class="label">HTML Parser:</text>
+      <line x1="257" x2="257" y1="9" y2="24" class="connector" />
+      <line x1="404" x2="404" y1="9" y2="24" class="connector" />
+      <line x1="106" x2="257" y1="24" y2="24" class="parser progress first" />
+      <line x1="257" x2="354" y1="9" y2="9" class="fetch progress" />
+      <line x1="354" x2="404" y1="9" y2="9" class="execution progress" />
+      <line x1="404" x2="532" y1="24" y2="24" class="parser progress last" />
+    </g>
+  </g>
 
-  <text x="12" y="84.25" class="tag">&lt;script async&gt;</text>
-  <text x="142" y="76" class="label">Scripting:</text>
-  <text x="142" y="91" class="label">HTML Parser:</text>
-  <line x1="496" x2="496" y1="76" y2="91" class="connector" />
-  <line x1="546" x2="546" y1="76" y2="91" class="connector" />
-  <line x1="248" x2="496" y1="91" y2="91" class="parser progress first" />
-  <line x1="399" x2="496" y1="76" y2="76" class="fetch progress" />
-  <line x1="496" x2="546" y1="76" y2="76" class="execution progress" />
-  <line x1="546" x2="674" y1="91" y2="91" class="parser progress last" />
+  <g transform="translate(0,33)">
+    <text x="12" y="16.75" class="tag">&lt;script defer&gt;</text>
 
-  <g class="legend" transform="translate(247.5,105.5)">
+    <g transform="translate(252,0)">
+      <text x="0" y="9" class="label">Scripting:</text>
+      <text x="0" y="24" class="label">HTML Parser:</text>
+      <line x1="484" x2="484" y1="9" y2="24" class="connector" />
+      <line x1="106" x2="484" y1="24" y2="24" class="parser progress first" />
+      <line x1="257" x2="354" y1="9" y2="9" class="fetch progress" />
+      <line x1="484" x2="532" y1="9" y2="9" class="execution progress last" />
+    </g>
+  </g>
+
+  <g transform="translate(0,66)">
+    <text x="12" y="16.75" class="tag">&lt;script async&gt;</text>
+
+    <g transform="translate(252,0)">
+      <text x="0" y="9" class="label">Scripting:</text>
+      <text x="0" y="24" class="label">HTML Parser:</text>
+      <line x1="354" x2="354" y1="9" y2="24" class="connector" />
+      <line x1="404" x2="404" y1="9" y2="24" class="connector" />
+      <line x1="106" x2="354" y1="24" y2="24" class="parser progress first" />
+      <line x1="257" x2="354" y1="9" y2="9" class="fetch progress" />
+      <line x1="354" x2="404" y1="9" y2="9" class="execution progress" />
+      <line x1="404" x2="532" y1="24" y2="24" class="parser progress last" />
+    </g>
+  </g>
+
+  <g transform="translate(0,99)">
+    <text x="12" y="16.75" class="tag">&lt;script type="module"&gt;</text>
+
+    <g transform="translate(252,0)">
+      <text x="0" y="9" class="label">Scripting:</text>
+      <text x="0" y="24" class="label">HTML Parser:</text>
+      <line x1="484" x2="484" y1="9" y2="24" class="connector" />
+      <line x1="106" x2="484" y1="24" y2="24" class="parser progress first" />
+      <line x1="257" x2="354" y1="9" y2="9" class="fetch progress" />
+      <line x1="354" x2="374" y1="9" y2="9" class="fetch progress" />
+      <line x1="354" x2="374" y1="9" y2="16.5" class="fetch progress" />
+      <line x1="374" x2="394" y1="16.5" y2="16.5" class="fetch progress" />
+      <line x1="394" x2="414" y1="16.5" y2="16.5" class="fetch progress" />
+      <line x1="394" x2="414" y1="16.5" y2="9" class="fetch progress" />
+      <line x1="484" x2="532" y1="9" y2="9" class="execution progress last" />
+    </g>
+  </g>
+
+  <g transform="translate(0,132)">
+    <text x="12" y="16.75" class="tag">&lt;script type="module" async&gt;</text>
+
+    <g transform="translate(252,0)">
+      <text x="0" y="9" class="label">Scripting:</text>
+      <text x="0" y="24" class="label">HTML Parser:</text>
+      <line x1="414" x2="414" y1="9" y2="24" class="connector" />
+      <line x1="464" x2="464" y1="9" y2="24" class="connector" />
+      <line x1="106" x2="414" y1="24" y2="24" class="parser progress first" />
+      <line x1="257" x2="354" y1="9" y2="9" class="fetch progress" />
+      <line x1="354" x2="374" y1="9" y2="9" class="fetch progress" />
+      <line x1="354" x2="374" y1="9" y2="16.5" class="fetch progress" />
+      <line x1="374" x2="394" y1="16.5" y2="16.5" class="fetch progress" />
+      <line x1="394" x2="414" y1="16.5" y2="16.5" class="fetch progress" />
+      <line x1="394" x2="414" y1="16.5" y2="9" class="fetch progress" />
+      <line x1="414" x2="464" y1="9" y2="9" class="execution progress" />
+      <line x1="464" x2="532" y1="24" y2="24" class="parser progress last" />
+    </g>
+  </g>
+
+  <g class="legend" transform="translate(357.5,172)">
     <circle cx="3" cy="3" r="3" class="parser" />
     <text x="9" y="3" class="label">parser</text>
 
@@ -128,5 +185,5 @@
     <text x="96" y="3" class="label">execution</text>
   </g>
 
-  <text x="674" y="108.5" text-anchor="end" class="label">runtime →</text>
+  <text x="782" y="175" text-anchor="end" class="label">runtime →</text>
 </svg>


### PR DESCRIPTION
This adds support for `<script type="module">` for loading JavaScript modules, as well as all the infrastructure necessary for resolving, fetching, parsing, and evaluating module graphs rooted at such `<script type="module">`s.

This was spurred on by a request over in https://github.com/whatwg/loader/issues/83#issuecomment-166442597. This should take care of https://github.com/whatwg/loader/issues/83, https://github.com/whatwg/loader/issues/84, and https://github.com/whatwg/loader/issues/82. There is not much overlap with the current loader spec, which is primarily concerned with reflective modules and the author-customizable loading pipeline. This patch is much more about changing HTML's processing model for the script element, and integrating module execution the same way HTML currently integrates script execution. It deals with questions like "when do modules execute relative to HTML parsing" or "how does module fetching/parsing/evaluation integrate with the event loop".

**This needs substantial review! Preferably from implementers!** It is a complicated topic and I am sure I got some details wrong, in addition to the discussion points noted below.

Here are the decisions that I incorporated while speccing this, which might not be immediately obvious. Some are bolded to indicate they need discussion/help/bikeshedding.

- Always use the UTF-8 decoder, ignoring the charset="" attribute or the Content-Type header.
- Disallow module responses which don't have a JavaScript MIME type for their Content-Type header. This is basically building in `X-Content-Type-Options: nosniff` behavior by default for module scripts.
- Always use the "cors" fetch mode, with the crossorigin="" attribute controlling the credentials mode: omitted => "omit", "anonymous" => "same-origin", "use-credentials" => "include".
- Modules are memoized per realm.
- Use `<script defer>`-like semantics: do not execute until parsing is finished, and execute in order. The `async` attribute can be used to opt in to execute as soon as possible (but still no blocking).
- For module resolution:
  - Allow absolute URLs and anything starting with "./" or "../" <ins>or "/"</ins>, with the latter set being then interpreted as relative URLs. Everything else (e.g. bare specifiers like "jquery") fails for now, and no automatic ".js" is appended.
  - **We throw a TypeError for module specifiers that are not parseable as absolute URLs and do not start with "./" or "../".** (Honestly I could see arguments for any of EvalError, ReferenceError, SyntaxError, or URIError [sic]. Maybe we should repurpose EvalError.)
- We use the page base URL as the base URL for resolving relative import specifiers for inline module scripts, and the _response_'s URL (not the request's!) as the base URL for resolving relative import specifiers in external module scripts or imported modules in the tree.
- In contrast, we dedupe fetches based on the _request_'s URL.

**To make review easier, I am hosting a compiled version: [singlepage](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html), [multipage](https://dl.dropboxusercontent.com/u/20140634/script-type-module/multipage/index.html).** Sections of note (links go to singlepage):

- [Main `<script>` section](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#script): largely contains authoring guidance updates. [New diagram](https://dl.dropboxusercontent.com/u/20140634/script-type-module/images/asyncdefer.svg) is also available, although the dropbox view doesn't show it inline since we are using absolute URLs.
- [`<script>` processing model section](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#script-processing-model)
  - Prepare a script is significantly different, and asynchronously creates "the script's script", instead of letting that be done by "execute a script block".
  - Execute a script block is simpler, and mostly delegates to the "run a classic script" or "run a module script" algorithms, surrounded by DOM-related stuff.
  - There is a new concept of "the script is ready" which generalizes the current spec's "The task that the networking task source places on the task queue once fetching has completed must do x", to allow it to work for module trees additionally.
- The scripting section gets a few subsections to do the heavy lifting:
  - [Definitions](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#definitions-2) contains definitions for classic scripts and module scripts as separate types, and adds the module map to all environment settings objects.
  - [Fetching scripts](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#fetching-scripts) now includes algorithms that "asynchronously complete". Let me know what you think of this formulation. I need the algorithms to exit quickly, then run a bunch of steps in parallel or in reaction to a task, but then call back to their caller with a result.
  - [Creating scripts](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#creating-scripts) has a pretty straightforward "create a module script" and "create a classic script"
  - [Calling scripts](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#calling-scripts) has the old "run a classic script" algorithm but also the new "run a module script" algorithm. Fetching is completed by that point.
  - [Integration with the JavaScript module system](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#integration-with-the-javascript-module-system) contains HostResolveImportedModule that is just a lookup in the module map manipulated inside "fetching scripts."
- [Script settings for browsing contexts](https://dl.dropboxusercontent.com/u/20140634/script-type-module/index.html#script-settings-for-browsing-contexts) was not changed but was moved under browsing contexts instead of under scripting.

/cc @whatwg/loader @bterlson @ajklein @Constellation