### PR TITLE
Use absolute URL for fragment-links.js

### DIFF
--- a/link-fixup.js
+++ b/link-fixup.js
@@ -7,6 +7,6 @@ window.addEventListener('DOMContentLoaded', function () {
     return;
 
   var script = document.createElement('script');
-  script.src = 'fragment-links.js';
+  script.src = '/multipage/fragment-links.js';
   document.body.appendChild(script);
 });


### PR DESCRIPTION
We already do this in 404.html. This helps fixing
https://github.com/whatwg/html-build/issues/33.