### PR TITLE
Fix recently-added JPEGs to be served correctly

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,9 +23,9 @@ ErrorDocument 404 /404.html
   ForceType image/png
 </Files>
 
-<Files *.jpeg>
+<FilesMatch ".+\.(jpe?g)$">
   ForceType image/jpeg
-</Files>
+</FilesMatch>
 
 <Files *.json>
   ForceType application/json


### PR DESCRIPTION
14111f62f041fec58a8a622ea042273e12b5f271 introduced a couple JPEG images with file extension .jpg, but we only set the mime type to image/jpeg for .jpeg files, not .jpg ones. This corrects that to allow both.

Thanks @izh1979 for pointing this out in #whatwg.

---

Tested this on a local apache and it works.

Alternate fixes:

- Rename the .jpgs to .jpeg
- Stop doing a top-level ForceType text/html, and just apply that to the "index" file. Then Apache's defaults can take over in most cases.

I went for the easiest thing.