### PR TITLE
add Dockerfile for local viewing of build output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:sid
+
+## dependency installation: apache, wattsi, and other build tools
+## enable some apache mods (the ln -s lines)
+## install wattsi from specific version of repo
+## cleanup freepascal since it is no longer needed after wattsi build
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl git python subversion unzip libxml-parser-perl fp-compiler-3.0.0 apache2 && \
+    cd /etc/apache2/mods-enabled && \
+    ln -s ../mods-available/headers.load && \
+    ln -s ../mods-available/expires.load && \
+    git clone https://github.com/whatwg/wattsi.git /whatwg/wattsi && \
+    cd /whatwg/wattsi && \
+    git reset --hard 351df15 && \
+    /whatwg/wattsi/build.sh && \
+    cp /whatwg/wattsi/bin/wattsi /bin/ && \
+    apt-get purge -y fp-compiler-3.0.0 && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+## get a known good version of the build repo
+RUN git clone https://github.com/whatwg/html-build.git /whatwg/build
+WORKDIR /whatwg/build
+RUN git reset --hard c37f28ad
+
+ADD . /whatwg/html
+
+## build and copy assets to final apache dir
+RUN /whatwg/build/build.sh && \
+    rm -rf /var/www/html && \
+    mv /whatwg/build/output /var/www/html && \
+    cp /whatwg/html/site.conf /etc/apache2/sites-available/000-default.conf
+
+CMD ["apache2ctl", "-DFOREGROUND"]

--- a/site.conf
+++ b/site.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+
+    <Directory "/var/www/html">
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
This continues the work first described in https://github.com/whatwg/html-build/issues/55

As stated before, the steps to use this dockerfile are as follows:

1. Clone the git@github.com:defunctzombie/html.git repo (again doesn't matter where)
1. In the cloned directory run `docker build -t whatwg-html .`
1. run `docker run --rm -it -p 8080:80 whatwg-html`

This Dockerfile will setup all of the required build tools (including wattsi) and then build the local changes to the html spec files.

I won't repeat my previous comments but many of them are still relevant and can be found here:
https://github.com/whatwg/html-build/issues/55#issuecomment-174147376

Additionally, I agree with the sentiment here (https://github.com/whatwg/html-build/pull/63) and here (https://github.com/whatwg/html-build/issues/62) that the build script needlessly reaches out to the internet to build when you could instead pre-download many of those items earlier in the Dockerfile (like wattsi) so that the actual build is fast. Your build script would better be served as two scripts: 1) fetch and prepare the system dependencies 2) do the actual build using only local files.

I will also recommend here again (I think I did it in an earlier comment on the other issue) that the build repo be de-commissioned and those files moved into a support folder under this repo. I already ran into nice little gotcha because of things like this (https://github.com/whatwg/html-build/commit/ba7553bf832a39d4a0c18bae0804560e1b2e74c5). Fortunately, this Dockerfile now pins the specific wattsi repo version and html-build repo version to avoid this in the future but really the build repo is heavily coupled to this repo from what I can tell.

Anyhow, this Dockerfile is a good first pass at the problem and can likely be a starting point which serves the primary needs first outlined in wanting to have a dockerfile.