### PR TITLE
Rewrite link-fixup.js to adopt fragment-links.json

### DIFF
--- a/link-fixup.js
+++ b/link-fixup.js
@@ -1,12 +1,30 @@
-window.addEventListener('DOMContentLoaded', function () {
-  if (window.location.hash.length < 1)
+(function () {
+  'use strict';
+  if (window.location.hash.length < 1) {
     return;
+  }
+
+  var fragmentLinks = {
+    /* WATTSI_INSERTS_FRAGMENT_LINKS_HERE */
+  };
 
   var fragid = window.location.hash.substr(1);
-  if (fragid && document.getElementById(fragid))
-    return;
 
-  var script = document.createElement('script');
-  script.src = '/multipage/fragment-links.js';
-  document.body.appendChild(script);
-});
+  if (fragid && document.getElementById(fragid)) {
+    return;
+  }
+
+  // handle section-foo.html links from the old old multipage version,
+  // and broken foo.html from the new version
+  if ((!fragid) || !(fragid in fragment_links)) {
+    var m = window.location.pathname.match(/\/(?:section-)?([\w\-]+)\.html/);
+    if (m) {
+      fragid = m[1];
+    }
+  }
+
+  var page = fragmentLinks[fragid];
+  if (page) {
+    window.location.replace(page + '.html#' + fragid);
+  }
+})();


### PR DESCRIPTION
Please note this PR depends on another PR for wattsi (https://github.com/whatwg/wattsi/pull/25).

In https://github.com/whatwg/wattsi/pull/25, I propose to make fragment-links a json. To support fragment-lnks.json, link-fixup.js needs to be rewritten. Additionally, I found there are some rooms to improve in link-fixup.js. Notable changes include:

- Load fragment-links more speculatively

    Current link-fixup.js waits DOMContentLoaded (and other resources and processes which block DOMContentLoaded) before loading fragment-links. However, it should redirect to new page as soon as possible in a situation where redirection is needed. To do so, the new link-fixup.js starts loading fragment-links if there are possibilities of redirection (location.hash is not empty).

    In return for speculative loading, users may load fragment-link.json even if they don't need though browsers cache fragment-links.json in general.

- Make link-fixup.js works with `<script async>`

    Current link-fixup.js uses DOMContentLoaded to check whether DOM is ready.  However DOMContentLoaded cannot be used in `<script async>` because DOMContentLoaded will not be fired in a situation where the script is loaded after DOMContentLoaded. New link-fixup.js uses document.readyState to checker whether DOM is ready.

- Merge redirection logic fragment-links.js into link-fixup.js

    Move redirection logic written https://github.com/whatwg/wattsi/blob/master/src/wattsi.pas#L1566-L1580 to link-fixup.js.

- Use XMLHttpRequest to load fragment-links

    We cannot use `<script>` for JSON, Use XHR instead.

- Use `Promise.all` to manage jobs

    `Promise.all` provides simple job management though IE doesn't support it. The new link-fixup.js doesn't contain any polyfills so that IE users will not be redirected.

    It is not clear for me that it is allowed to include third-party polyfills in link-fixup.js. If it is OK, I will consider to include polyfills such as [es6-promise](https://github.com/lahmatiy/es6-promise-polyfill).
