### PR TITLE
Remove <style scoped>

### DIFF
--- a/images/content-venn.svg
+++ b/images/content-venn.svg
@@ -96,7 +96,6 @@
      <li><code>small</code></li>
      <li><code>span</code></li>
      <li><code>strong</code></li>
-     <li><code>style</code>*</li>
      <li><code>sub</code></li>
      <li><code>sup</code></li>
      <li><code>svg</code></li>


### PR DESCRIPTION
This reverts 29cf39d2163cfc85b67409f4e10390619ffb2b40 and many follow-up
refinement commits due to lack of implementer interest. Most of the use
cases served by `<style scoped>` are better served by `<style>` elements
inside a shadow root (although the features do work differently, in
that shadow DOM enforces isolation from the cascade, whereas `<style
scoped>` does not).

Fixes #552.

--

This could use some careful review with regard to the changed examples.