### PR TITLE
Enable Travis for auto-linting PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: generic
+install: git clone --depth 1 https://github.com/whatwg/html-build.git ../html-build
+script: ../html-build/build.sh


### PR DESCRIPTION
This runs full build of the given source, so any problems which might occur on a real CI, will be reflected on the PRs as well.

Example of an execution can be seen here: https://travis-ci.org/RReverser/html/builds/130249854

Unfortunately, `build.whatwg.org` seems to be down at the moment (cc @domenic). Initially I thought it's a problem with the Travis setup, but can't ping it even locally.

Note: This still requires someone with admin rights to enable Travis for this repo, and then everything should just work.

Closes #1250.