### PR TITLE
Take care of missing custom element reactions

### DIFF
--- a/images/custom-element-reactions.svg
+++ b/images/custom-element-reactions.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 185">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 290 195">
   <style>
     text {
       font-family: sans-serif;
@@ -15,8 +15,21 @@
       stroke: darkgray;
     }
 
+    .backup-element-queue rect {
+      fill: transparent;
+      stroke-dasharray: 1, 1;
+    }
+
+    .backup-element-queue text, .processing-backup-element-queue-flag text {
+      font-size: 7px;
+    }
+
     line, path, rect {
       stroke: black;
+    }
+
+    path[marker-start] {
+      fill: transparent;
     }
   </style>
 
@@ -67,9 +80,29 @@
     </g>
   </g>
 
-  <path d="M80.5,80.5 L120,80.5" marker-start="url(#circle)" marker-end="url(#arrow)" />
+  <path d="M40.5,140 L40,160" marker-start="url(#diamond)" marker-end="url(#arrow)"/>
 
-  <g class="element-queue" transform="translate(125,60)">
+  <g class="backup-element-queue" transform="translate(0.5,159.5)">
+    <text x="40" y="10" style="text-anchor: middle">backup element queue</text>
+    <rect x="0" y="15" width="80" height="20"/>
+  </g>
+
+  <path d="M60.5,140 C60.5,150 70,160 95.5,160" marker-start="url(#diamond)" marker-end="url(#arrow)"/>
+
+  <g class="processing-backup-element-queue-flag" transform="translate(90,150)">
+    <text x="40" y="10" style="text-anchor: middle">processing backup</text>
+    <text x="40" y="18" style="text-anchor: middle">element queue flag</text>
+
+    <g transform="translate(30,20) scale(0.05)">
+      <!-- https://commons.wikimedia.org/wiki/File:White_flag_icon.svg (public domain) -->
+      <path style="fill:none;stroke:#000000;stroke-width:21;stroke-linecap:round" d="M42 327l0 -291"/>
+      <path style="fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-linejoin:round" d="M49 50c70,30 104,28 178,2 -21,42 -21,74 0,116 -72,25 -101,25 -178,0l0 -118z"/>
+    </g>
+  </g>
+
+  <path d="M80.5,80.5 C100.5,80.5 100,80.5 100,60.5 S 100,40.5 124.5,40.5" marker-start="url(#circle)" marker-end="url(#arrow)"/>
+
+  <g class="element-queue" transform="translate(124.5,20)">
     <text x="65" y="0" style="text-anchor: middle">element queue</text>
     <rect x="0" y="5" width="154.5" height="30" fill="transparent"/>
 
@@ -91,9 +124,9 @@
     <text x="135" y="24">⋯</text>
   </g>
 
-  <path d="M192.5,100 C192.5,120 150,110 150,140" marker-start="url(#diamond)" marker-end="url(#arrow)" fill="transparent"/>
+  <path d="M192.5,60 C192.5,80 200,70 200,90" marker-start="url(#diamond)" marker-end="url(#arrow)"/>
 
-  <g class="custom-element-reaction-queue" transform="translate(70,150)">
+  <g class="custom-element-reaction-queue" transform="translate(119.5,100)">
     <text x="85" y="0" style="text-anchor: middle">custom element reaction queue</text>
     <rect x="0" y="5" width="170" height="29.5" fill="transparent"/>
 


### PR DESCRIPTION
As discussed in https://github.com/w3c/webcomponents/issues/186, there
are certain scenarios where custom element reactions could be enqueued,
but the custom element reactions stack is empty. The most prominent of
these is editing operations.

We solve this issue in two parts:

- First, introduce the backup element queue (similar to the old "base
element queue" concept; see
https://github.com/w3c/webcomponents/issues/457). This takes care of
cases like editing which cannot be solved in any other way.
- Also, we mandate that [CEReactions] be applied to nonstandard APIs
that modify the DOM, including a list of what we've identified so far.

Closes https://github.com/w3c/webcomponents/issues/186.

---

Careful review appreciated. /cc @dominiccooney @kojiishi @rniwa @annevk