### PR TITLE
Add concrete suggestions for datalist display and matching

### DIFF
--- a/images/sample-datalist.svg
+++ b/images/sample-datalist.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 150">
+  <style><![CDATA[
+    text {
+      dominant-baseline: central;
+      font-size: 13px;
+      font-family: sans-serif;
+    }
+
+    .labels > text {
+      text-anchor: end;
+      fill: gray;
+      font-size: 11px;
+    }
+  ]]></style>
+
+  <rect x="5" y="5" width="270" height="20" fill="white" stroke="lightgray"/>
+  <rect x="5" y="25" width="270" height="120" fill="white" stroke="lightgray"/>
+
+  <text x="261" y="15" fill="gray">▼</text>
+
+  <g transform="translate(12,35)">
+    <text x="0" y="0">function</text>
+    <text x="0" y="20">async function</text>
+    <text x="0" y="40">function*</text>
+    <text x="0" y="60">=&gt;</text>
+    <text x="0" y="80">async =&gt;</text>
+    <text x="0" y="100">async function*</text>
+  </g>
+
+  <g transform="translate(270,35)" class="labels">
+    <text x="0" y="0">function</text>
+    <text x="0" y="20">async function</text>
+    <text x="0" y="40">generator function</text>
+    <text x="0" y="60">arrow function</text>
+    <text x="0" y="80">async arrow function</text>
+    <text x="0" y="100">async generator function</text>
+  </g>
+</svg>

--- a/images/sample-email-1.svg
+++ b/images/sample-email-1.svg
@@ -50,17 +50,17 @@
     <rect x="0" y="0" width="290" height="20" fill="white" stroke="lightgray"/>
     <rect x="0" y="20" width="290" height="40" fill="white" stroke="lightgray"/>
 
-    <text x="7" y="10">a<tspan dx="-1.5">|</tspan></text>
+    <text x="7" y="10">s<tspan dx="-1.5">|</tspan></text>
     <text x="276" y="10" fill="gray">▼</text>
 
     <g transform="translate(7,30)">
-      <text x="0" y="0">art@example.net</text>
-      <text x="0" y="20">adamjosh@example.net</text>
+      <text x="0" y="0">spider@parker.example.net</text>
+      <text x="0" y="20">scarlet@avengers.example.net</text>
     </g>
 
     <g transform="translate(285,30)" class="labels">
-      <text x="0" y="0">Arthur Dent</text>
-      <text x="0" y="20">Adam Josh</text>
+      <text x="0" y="0">Spider-Man</text>
+      <text x="0" y="20">Scarlet Witch</text>
     </g>
   </g>
 </svg>

--- a/images/sample-email-2.svg
+++ b/images/sample-email-2.svg
@@ -50,19 +50,19 @@
     <rect x="0" y="0" width="290" height="20" fill="white" stroke="lightgray"/>
     <rect x="0" y="20" width="290" height="80" fill="white" stroke="lightgray"/>
 
-    <text x="7" y="10">bob@example.net, a<tspan dx="-1.5">|</tspan></text>
+    <text x="7" y="10">bob@example.net, s<tspan dx="-1.5">|</tspan></text>
     <text x="276" y="10" fill="gray">▼</text>
 
     <g transform="translate(7,30)">
-      <text x="0" y="0">adamjosh@example.net</text>
-      <text x="0" y="20">art@example.net</text>
+      <text x="0" y="0">spider@parker.example.net</text>
+      <text x="0" y="20">scarlet@avengers.example.net</text>
       <text x="0" y="40">astronomy@science.example.org</text>
       <text x="0" y="60">astrophy@cute.example</text>
     </g>
 
     <g transform="translate(285,30)" class="labels">
-      <text x="0" y="0">Adam Josh</text>
-      <text x="0" y="20">Arthur Dent</text>
+      <text x="0" y="0">Spider-Man</text>
+      <text x="0" y="20">Scarlet Witch</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
As discussed in both #1811 and #1087, users, web developers, and
implementers find the spec's current vague phrasing around datalist UI
confusing. This has led to great implementation divergence, as
documented in the table in #1087. (That table also does not capture the
substring vs. prefix matching divergence.)

This attempts to provide more normative UI guidance and resolve the
issue, essentially taking the union of current display and search
choices. This will require changes from all browsers if they wish to
apply these suggestions.

Fixes #1811; fixes #1087.

/cc @travisleithead @nicksloan @jessi3py for your thoughts. My hope is that we can get general agreement from the people involved (and from the editors) that these UI suggestions are good. If so, we'll merge this, and then file bugs on all the browsers asking them to please conform. I don't expect this to be super-successful, given how little effort browsers are spending on their form controls these days, but it's probably the best we can do.