### PR TITLE
Meta: fix commit snapshots server config

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,8 +9,12 @@ Redirect 301 /multipage/images/ /images/
 Redirect 301 /multipage/link-fixup.js /link-fixup.js
 ErrorDocument 404 /404.html
 
-<Files print.pdf>
+<Files "print.pdf">
   Header add Content-Disposition "inline; filename=html-standard.pdf"
+</Files>
+
+<Files "commit-snapshots/*">
+  ForceType text/html
 </Files>
 
 # Previously-generated filenames for /multipage/ that do not redirect via script:


### PR DESCRIPTION
This makes URLs like https://html.spec.whatwg.org/commit-snapshots/920c9183a7990968ecac1aeedae22391f3438791 properly display as text/html. This regressed in f7def432160c2fb13203c2a841da9c1932c13b8a when we got rid of the global ForceType.