### PR TITLE
Meta: add more guidance for how to handle test PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ To preview your changes locally, follow the instructions in the [html-build repo
 
 #### Tests
 
-For normative changes, a corresponding [web-platform-tests](https://github.com/w3c/web-platform-tests) PR is highly appreciated. The author and reviewer can be different from the HTML Standard PR. If testing is not practical, please explain why and if appropriate [file an issue](https://github.com/w3c/web-platform-tests/issues/new) to follow up later.
+For normative changes, a corresponding [web-platform-tests](https://github.com/w3c/web-platform-tests) PR is highly appreciated. The author and reviewer can be different from the HTML Standard PR. If current behavior is unclear, writing tests first can help inform the discussion. Typically, both PRs will be merged at the same time.
+
+If testing is not practical, please explain why and if appropriate [file an issue](https://github.com/w3c/web-platform-tests/issues/new) to follow up later.
 
 #### Formatting
 

--- a/TEAM.md
+++ b/TEAM.md
@@ -6,7 +6,9 @@ This document contains info used by the team maintaining the standard. Mostly bo
 
 Each change needs to result in a single commit on the master branch, with no merge commits. The green squash and merge button is OK to use, but be sure to tidy up the commit message per [guidelines for writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages).
 
-For normative changes, ask for a [web-platform-tests](https://github.com/w3c/web-platform-tests) PR if testing is practical and not overly burdensome. If a follow up issue is filed, add the `html` label.
+For normative changes, ask for a [web-platform-tests](https://github.com/w3c/web-platform-tests) PR if testing is practical and not overly burdensome. Aim to merge both PRs at the same time. If one PR is approved but the other needs more work, add the `do not merge yet` label.
+
+If a follow-up issue is filed, add the `html` label.
 
 ### Fetching and reviewing pull requests from forks
 


### PR DESCRIPTION
Prompted by https://github.com/w3c/web-platform-tests/pull/4034.

Part of #1849.