### PR TITLE
Meta: Make link-fixup.js lightweight

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<script src="/multipage/fragment-links.js"></script>
+<script src="/link-fixup.js" defer></script>
 <title>Broken link</title>
 <style>
  body.loading div.failed, body.failed div.loading, div.failed { display: none; }

--- a/link-fixup.js
+++ b/link-fixup.js
@@ -4,27 +4,31 @@
     return;
   }
 
-  var fragmentLinks = {
-    /* WATTSI_INSERTS_FRAGMENT_LINKS_HERE */
-  };
-
   var fragid = window.location.hash.substr(1);
 
   if (fragid && document.getElementById(fragid)) {
     return;
   }
 
-  // handle section-foo.html links from the old old multipage version,
-  // and broken foo.html from the new version
-  if (!fragid || !(fragid in fragmentLinks)) {
-    var m = window.location.pathname.match(/\/(?:section-)?([\w\-]+)\.html/);
-    if (m) {
-      fragid = m[1];
-    }
-  }
+  var xhr = new XMLHttpRequest();
+  xhr.responseType = 'json';
+  xhr.open('GET', '/multipage/fragment-links.json');
+  xhr.onload = function() {
+    var fragmentLinks = xhr.response;
 
-  var page = fragmentLinks[fragid];
-  if (page) {
-    window.location.replace(page + '.html#' + fragid);
-  }
+    // handle section-foo.html links from the old old multipage version,
+    // and broken foo.html from the new version
+    if (!fragid || !(fragid in fragmentLinks)) {
+      var m = window.location.pathname.match(/\/(?:section-)?([\w\-]+)\.html/);
+      if (m) {
+        fragid = m[1];
+      }
+    }
+
+    var page = fragmentLinks[fragid];
+    if (page) {
+      window.location.replace(page + '.html#' + fragid);
+    }
+  };
+  xhr.send();
 })();


### PR DESCRIPTION
This file was about 2.8MB and was always run on multipage/ but
the common case is to no-op. Instead XHR the fragment-links.json
file only when necessary.

Also fix 404.html to use the correct URL to link-fixup.js and use
`defer`.

Fixes #2026.

---

This depends on https://github.com/whatwg/wattsi/pull/31 and https://github.com/whatwg/html-build/pull/100