### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.inc linguist-language=HTML
+source text diff=html linguist-language=HTML


### PR DESCRIPTION
* For the `source` file, make git normalize line endings, ensure GitHub
  sees it as being HTML, and use `diff=html` (which affects the formatting
  of the `@@ -k,l +n,m @@ TEXT` “hunk header” shown in `git diff` output).