### PR TITLE
Meta: Make travis run HTML checker on all .html output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: generic
-install: git clone --depth 1 https://github.com/whatwg/html-build.git ../html-build
-script: ../html-build/build.sh
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
+install:
+  - git clone --depth 1 https://github.com/whatwg/html-build.git ../html-build
+  - curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
+script:
+  - ../html-build/build.sh
+  - java -jar vnu.jar /home/travis/build/whatwg/html-build/output/*.html
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
This changes causes the Travis build to run the HTML checker on the `output/index.html` file and on all `output/multipage/*.html` files. The Travis build fails if the checker reports any errors.