### PR TITLE
Meta: Add <meta charset=utf-8> to all demos/ files

### DIFF
--- a/demos/canvas/blue-robot/index-idle.html
+++ b/demos/canvas/blue-robot/index-idle.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<title>Blue Robot Demo</title>
 <meta charset="utf-8">
+<title>Blue Robot Demo</title>
 <style>
   html { overflow: hidden; min-height: 200px; min-width: 380px; }
   body { height: 200px; position: relative; margin: 8px; }

--- a/demos/canvas/blue-robot/index-idle.html
+++ b/demos/canvas/blue-robot/index-idle.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Blue Robot Demo</title>
+<meta charset="utf-8">
 <style>
   html { overflow: hidden; min-height: 200px; min-width: 380px; }
   body { height: 200px; position: relative; margin: 8px; }

--- a/demos/canvas/blue-robot/index.html
+++ b/demos/canvas/blue-robot/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<title>Blue Robot Demo</title>
 <meta charset="utf-8">
+<title>Blue Robot Demo</title>
 <style>
   html { overflow: hidden; min-height: 200px; min-width: 380px; }
   body { height: 200px; position: relative; margin: 8px; }

--- a/demos/canvas/blue-robot/index.html
+++ b/demos/canvas/blue-robot/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Blue Robot Demo</title>
+<meta charset="utf-8">
 <style>
   html { overflow: hidden; min-height: 200px; min-width: 380px; }
   body { height: 200px; position: relative; margin: 8px; }

--- a/demos/offline/clock/clock1.html
+++ b/demos/offline/clock/clock1.html
@@ -2,8 +2,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Clock</title>
   <meta charset="utf-8">
+  <title>Clock</title>
   <script src="clock.js"></script>
   <link rel="stylesheet" href="clock.css">
  </head>

--- a/demos/offline/clock/clock1.html
+++ b/demos/offline/clock/clock1.html
@@ -3,6 +3,7 @@
 <html>
  <head>
   <title>Clock</title>
+  <meta charset="utf-8">
   <script src="clock.js"></script>
   <link rel="stylesheet" href="clock.css">
  </head>

--- a/demos/offline/clock/clock2.html
+++ b/demos/offline/clock/clock2.html
@@ -2,8 +2,8 @@
 <!DOCTYPE HTML>
 <html manifest="clock.appcache">
  <head>
-  <title>Clock</title>
   <meta charset="utf-8">
+  <title>Clock</title>
   <script src="clock.js"></script>
   <link rel="stylesheet" href="clock.css">
  </head>

--- a/demos/offline/clock/clock2.html
+++ b/demos/offline/clock/clock2.html
@@ -3,6 +3,7 @@
 <html manifest="clock.appcache">
  <head>
   <title>Clock</title>
+  <meta charset="utf-8">
   <script src="clock.js"></script>
   <link rel="stylesheet" href="clock.css">
  </head>

--- a/demos/workers/crypto/page.html
+++ b/demos/workers/crypto/page.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Worker example: Crypto library</title>
+  <meta charset="utf-8">
   <script>
    var cryptoLib = new Worker('libcrypto-v1.js'); // or could use 'libcrypto-v2.js'
    function getKeys() {

--- a/demos/workers/crypto/page.html
+++ b/demos/workers/crypto/page.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Worker example: Crypto library</title>
   <meta charset="utf-8">
+  <title>Worker example: Crypto library</title>
   <script>
    var cryptoLib = new Worker('libcrypto-v1.js'); // or could use 'libcrypto-v2.js'
    function getKeys() {

--- a/demos/workers/multicore/page.html
+++ b/demos/workers/multicore/page.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Worker example: Multicore computation</title>
   <meta charset="utf-8">
+  <title>Worker example: Multicore computation</title>
  </head>
  <body>
   <p>Result: <output id="result"></output></p>

--- a/demos/workers/multicore/page.html
+++ b/demos/workers/multicore/page.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Worker example: Multicore computation</title>
+  <meta charset="utf-8">
  </head>
  <body>
   <p>Result: <output id="result"></output></p>

--- a/demos/workers/multiviewer/page.html
+++ b/demos/workers/multiviewer/page.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Workers example: Multiviewer</title>
+  <meta charset="utf-8">
   <script>
    function openViewer() {
      window.open('viewer.html');

--- a/demos/workers/multiviewer/page.html
+++ b/demos/workers/multiviewer/page.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Workers example: Multiviewer</title>
   <meta charset="utf-8">
+  <title>Workers example: Multiviewer</title>
   <script>
    function openViewer() {
      window.open('viewer.html');

--- a/demos/workers/multiviewer/viewer.html
+++ b/demos/workers/multiviewer/viewer.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Workers example: Multiviewer viewer</title>
   <meta charset="utf-8">
+  <title>Workers example: Multiviewer viewer</title>
   <script>
    var worker = new SharedWorker('worker.js', 'core');
 

--- a/demos/workers/multiviewer/viewer.html
+++ b/demos/workers/multiviewer/viewer.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Workers example: Multiviewer viewer</title>
+  <meta charset="utf-8">
   <script>
    var worker = new SharedWorker('worker.js', 'core');
 

--- a/demos/workers/primes/page.html
+++ b/demos/workers/primes/page.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Worker example: One-core computation</title>
   <meta charset="utf-8">
+  <title>Worker example: One-core computation</title>
  </head>
  <body>
   <p>The highest prime number discovered so far is: <output id="result"></output></p>

--- a/demos/workers/primes/page.html
+++ b/demos/workers/primes/page.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Worker example: One-core computation</title>
+  <meta charset="utf-8">
  </head>
  <body>
   <p>The highest prime number discovered so far is: <output id="result"></output></p>

--- a/demos/workers/shared/001/test.html
+++ b/demos/workers/shared/001/test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<title>Shared workers: demo 1</title>
 <meta charset="utf-8">
+<title>Shared workers: demo 1</title>
 <pre id="log">Log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/001/test.html
+++ b/demos/workers/shared/001/test.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Shared workers: demo 1</title>
+<meta charset="utf-8">
 <pre id="log">Log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/002/test.html
+++ b/demos/workers/shared/002/test.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Shared workers: demo 2</title>
+<meta charset="utf-8">
 <pre id="log">Log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/002/test.html
+++ b/demos/workers/shared/002/test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<title>Shared workers: demo 2</title>
 <meta charset="utf-8">
+<title>Shared workers: demo 2</title>
 <pre id="log">Log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/003/inner.html
+++ b/demos/workers/shared/003/inner.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Shared workers: demo 3 inner frame</title>
+<meta charset="utf-8">
 <pre id=log>Inner log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/003/inner.html
+++ b/demos/workers/shared/003/inner.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<title>Shared workers: demo 3 inner frame</title>
 <meta charset="utf-8">
+<title>Shared workers: demo 3 inner frame</title>
 <pre id=log>Inner log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/003/test.html
+++ b/demos/workers/shared/003/test.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Shared workers: demo 3</title>
+<meta charset="utf-8">
 <pre id="log">Log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/shared/003/test.html
+++ b/demos/workers/shared/003/test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
-<title>Shared workers: demo 3</title>
 <meta charset="utf-8">
+<title>Shared workers: demo 3</title>
 <pre id="log">Log:</pre>
 <script>
   var worker = new SharedWorker('test.js');

--- a/demos/workers/stocks/page.html
+++ b/demos/workers/stocks/page.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
  <head>
-  <title>Worker example: Stock ticker</title>
   <meta charset="utf-8">
+  <title>Worker example: Stock ticker</title>
   <script>
    // TICKER
    var symbol = 'GOOG'; // default symbol to watch

--- a/demos/workers/stocks/page.html
+++ b/demos/workers/stocks/page.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Worker example: Stock ticker</title>
+  <meta charset="utf-8">
   <script>
    // TICKER
    var symbol = 'GOOG'; // default symbol to watch


### PR DESCRIPTION
This ensures that the HTML documents in the `demos/` subdirectory follow the best practice of always including `<meta charset="utf-8">`.