### PR TITLE
Meta: Make checker correctly recurse output dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
 script:
   - ../html-build/build.sh
-  - java -jar vnu.jar /home/travis/build/whatwg/html-build/output/*.html
+  - java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/html-build/output
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
This change make Travis run the HTML checker vnu.jar with the right option and pathname arg needed to make it recurse through the output dir and only check HTML files.