### PR TITLE
Meta: Give Travis the full path to the java binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
 script:
   - ../html-build/build.sh
-  - java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/html-build/output
+  - /usr/lib/jvm/java-8-oracle/jre/bin/java -jar vnu.jar --skip-non-html /home/travis/build/whatwg/html-build/output
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Travis needs Java8 to run the `vnu.jar` HTML checker. This change causes it to use the full path to the `java` binary, to ensure it always uses the right (Java8) one.