### PR TITLE
Meta: Fix link-fixup.js to support percent-escaped fragid

### DIFF
--- a/link-fixup.js
+++ b/link-fixup.js
@@ -4,7 +4,7 @@
     return;
   }
 
-  var fragid = window.location.hash.substr(1);
+  var fragid = decodeURIComponent(window.location.hash.substr(1));
 
   if (fragid && document.getElementById(fragid)) {
     return;
@@ -27,7 +27,7 @@
 
     var page = fragmentLinks[fragid];
     if (page) {
-      window.location.replace(page + '.html#' + fragid);
+      window.location.replace(page + '.html#' + encodeURIComponent(fragid));
     }
   };
   xhr.send();


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/2552#issuecomment-295360874

---

For `#the-worker's-lifetime`, in Firefox, `location.hash` returns `#the-worker%27s-lifetime` while Opera returns `#the-worker's-lifetime`.

I tested this locally to confirm that it works in Firefox and Opera.