### PR TITLE
Meta: add a redirect for the clock demo

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,6 +7,7 @@ Redirect 301 /C /multipage/
 Redirect 301 /multipage/entities.json /entities.json
 Redirect 301 /multipage/images/ /images/
 Redirect 301 /multipage/link-fixup.js /link-fixup.js
+Redirect 301 /demos/offline/clock/clock.html /demos/offline/clock/clock2.html
 ErrorDocument 404 /404.html
 
 <Files print.pdf>


### PR DESCRIPTION
There is at least some evidence that there used to exist a demo
offline/clock/clock.html, which has since been moved to
offline/clock/clock2.html. Such a file predates the incorporation of the
demos into this repository in cc0a94cfb006f06de63ee153821a382a4bfafd6b,
but we can add a redirect from the putative old URL just to be safe.

Closes #2620.

---

<del>Tagging "do not merge yet" until we get some clarity from @micbuffa about whether it should redirect to clock1.html or clock2.html (https://github.com/whatwg/html/issues/2620#issuecomment-299014110).</del> <ins>Done, it should be clock2.html</ins> Also, @micbuffa, what name would you like in the acknowledgments?