### PR TITLE
Meta: Fix bug that loaded xref.json for any click

### DIFF
--- a/html-dfn.js
+++ b/html-dfn.js
@@ -8,7 +8,21 @@ var dfnMap = {};
 var dfnPanel;
 var dfnTimeout;
 function dfnLoad(event) {
-  if (event.target && event.target instanceof HTMLAnchorElement) {
+  var node = event.target;
+  if (node && node instanceof HTMLAnchorElement) {
+    return;
+  }
+  dfncheck:
+  if (node.tagName !== "DFN") {
+    while (node.parentNode) {
+      node = node.parentNode;
+      if (node.tagName === "DFN") {
+        break dfncheck;
+      }
+      if (node.tagName === "BODY") {
+        return;
+      }
+    }
     return;
   }
   if (dfnPanel) {


### PR DESCRIPTION
This change is cleanup for a bug in 3af8da2, which was causing xref.json
to be loaded for any click anywhere in the document other than a
hyperlink. This change corrects the behavior such that xref.json is
loaded only when the click is either on a dfn or descendant of dfn.