### PR TITLE
Meta: Fix various regressions in html-dfn.js

### DIFF
--- a/html-dfn.js
+++ b/html-dfn.js
@@ -3,117 +3,129 @@
 
 (function() {
 
+var isMultipage = document.documentElement.classList.contains('split');
 var dfnMapDone = false;
 var dfnMap = {};
 var dfnPanel;
-var dfnTimeout;
+
+function isCrossSpecDfn(dfn) {
+  return dfn.firstChild && dfn.firstChild instanceof HTMLAnchorElement;
+}
+
 function dfnLoad(event) {
-  if (event.target && event.target instanceof HTMLAnchorElement) {
+  var current = event.target;
+  var node;
+  var eventInDfnPanel = false;
+  while (current) {
+    if (current.localName === 'dfn') {
+      node = current;
+    }
+    if (dfnPanel && current === dfnPanel) {
+      eventInDfnPanel = true;
+    }
+    current = current.parentElement;
+  }
+  if (!eventInDfnPanel) {
+    dfnClosePanel();
+  }
+  if (!node) {
     return;
   }
-  if (dfnPanel) {
-    dfnPanel.parentNode.removeChild(dfnPanel);
-    dfnPanel = null;
+  if (isCrossSpecDfn(node)) {
+    event.preventDefault();
   }
+  dfnPanel = document.createElement('div');
+  dfnPanel.className = 'dfnPanel';
+  if (node.id || node.parentNode.id) {
+    var permalinkP = document.createElement('p');
+    var permalinkA = document.createElement('a');
+    permalinkA.href = '#' + (node.id || node.parentNode.id);
+    permalinkA.onclick = dfnClosePanel;
+    permalinkA.textContent = '#' + (node.id || node.parentNode.id);
+    permalinkP.appendChild(permalinkA);
+    dfnPanel.appendChild(permalinkP);
+  }
+  if (isCrossSpecDfn(node)) {
+    var realLinkP = document.createElement('p');
+    realLinkP.className = 'spec-link';
+    realLinkP.textContent = 'Spec: ';
+    var realLinkA = document.createElement('a');
+    realLinkA.href = node.firstChild.href;
+    realLinkA.onclick = dfnClosePanel;
+    realLinkA.textContent = node.firstChild.href;
+    realLinkP.appendChild(realLinkA);
+    dfnPanel.appendChild(realLinkP);
+  }
+  var p = document.createElement('p');
+  dfnPanel.appendChild(p);
   if (!dfnMapDone) {
-    document.body.classList.remove('dfnEnabled');
-    dfnPanel = document.createElement('div');
-    dfnPanel.className = 'dfnPanel';
-    dfnPanel.innerHTML = 'Loading cross-references…';
-    dfnMovePanel(null);
+    p.textContent = 'Loading cross-references…';
+    node.appendChild(dfnPanel);
     fetch('/xrefs.json')
       .then(response => response.json())
       .then(data => {
         dfnMap = data;
         dfnMapDone = true;
-        document.body.classList.add('dfnEnabled');
-        dfnPanel.parentNode.removeChild(dfnPanel);
-        dfnPanel = null;
-        dfnShow(event);
+        if (dfnPanel) {
+          dfnShow(p, node);
+        }
+      }).catch(err => {
+        p.textContent = 'Error loading cross-references.';
       });
   } else {
-    dfnShow(event);
+    dfnShow(p, node);
+  }
+  node.appendChild(dfnPanel);
+}
+function dfnShow(p, node) {
+  if (node.id in dfnMap || node.parentNode.id in dfnMap) {
+    p.textContent = 'Referenced in:';
+    var ul = document.createElement('ul');
+    var anchorMap = {};
+    if (node.id in dfnMap) {
+      anchorMap = dfnMap[node.id];
+    }
+    if (node.parentNode.id in dfnMap) {
+      anchorMap = dfnMap[node.parentNode.id];
+    }
+    for (var header in anchorMap) {
+      var li = document.createElement('li');
+      for (var i = 0; i < anchorMap[header].length; i += 1) {
+        var a = document.createElement('a');
+        a.onclick = dfnMovePanel;
+        a.href = anchorMap[header][i];
+        if (!isMultipage) {
+          a.href = a.href.substring(a.href.indexOf('#'));
+        }
+        if (i === 0) {
+          var headerFormatted = header.replace(/</g, '&lt;');
+          headerFormatted = headerFormatted.replace(/ ([^ ]+) (element(?!s)|attribute(?!s)|interface(?!s)|common interface|object)/g, ' <code>$1</code> $2');
+          headerFormatted = headerFormatted.replace(/<code>(Before|After|Other|The|on|an|for|user|User|custom|Custom|built-in|abstract|exotic|global|settings|Browser|Serializable|Transferable|HTML|IDL|document)<\/code>/, '$1');
+          headerFormatted = headerFormatted.replace(/(type=[^\)]+)/g, '<code>$1</code>');
+          headerFormatted = headerFormatted.replace(/(Link type) "([^"]+)"/g, '$1 "<code>$2</code>"');
+          headerFormatted = headerFormatted.replace(/(ImageBitmap|WindowOrWorkerGlobalScope|multipart\/x-mixed-replace|registerProtocolHandler\(\)|registerContentHandler\(\))|storage|/, '<code>$1</code>');
+          a.innerHTML = headerFormatted;
+        } else {
+          li.appendChild(document.createTextNode(' '));
+          a.appendChild(document.createTextNode('(' + (i + 1) + ')'));
+        }
+        li.appendChild(a);
+      }
+      ul.appendChild(li);
+    }
+    dfnPanel.appendChild(ul);
+  } else {
+    p.textContent = 'No references in this specification.';
   }
 }
-function dfnShow(event) {
-  var isMultipage = document.documentElement.classList.contains('split');
-  if (dfnTimeout) {
-    clearTimeout(dfnTimeout);
-    dfnTimeout = null;
+
+function dfnClosePanel(event) {
+  if (dfnPanel) {
+    dfnPanel.remove();
+    dfnPanel = null;
   }
-  if (dfnMapDone) {
-    var node = event.target;
-    while (node && (!node instanceof HTMLElement || !(node.localName == 'dfn' || (node instanceof HTMLHeadingElement && node.hasAttribute('data-dfn-type'))))) {
-      node = node.parentNode;
-    }
-    if (node) {
-      event.preventDefault();
-      var panel = document.createElement('div');
-      panel.className = 'dfnPanel';
-      if (node.id || node.parentNode.id) {
-        var permalinkP = document.createElement('p');
-        var permalinkA = document.createElement('a');
-        permalinkA.href = '#' + (node.id || node.parentNode.id);
-        permalinkA.textContent = '#' + (node.id || node.parentNode.id);
-        permalinkP.appendChild(permalinkA);
-        panel.appendChild(permalinkP);
-      }
-      if (node.firstChild instanceof HTMLAnchorElement) {
-        var realLinkP = document.createElement('p');
-        realLinkP.className = 'spec-link';
-        realLinkP.textContent = 'Spec: ';
-        var realLinkA = document.createElement('a');
-        realLinkA.href = node.firstChild.href;
-        realLinkA.textContent = node.firstChild.href;
-        realLinkP.appendChild(realLinkA);
-        panel.appendChild(realLinkP);
-      }
-      var p = document.createElement('p');
-      panel.appendChild(p);
-      if (node.id in dfnMap || node.parentNode.id in dfnMap) {
-        p.textContent = 'Referenced in:';
-        var ul = document.createElement('ul');
-        var anchorMap = {};
-        if (node.id in dfnMap) {
-          anchorMap = dfnMap[node.id];
-        }
-        if (node.parentNode.id in dfnMap) {
-          anchorMap = dfnMap[node.parentNode.id];
-        }
-        for (var header in anchorMap) {
-          var li = document.createElement('li');
-          for (var i = 0; i < anchorMap[header].length; i += 1) {
-            var a = document.createElement('a');
-            a.onclick = dfnMovePanel;
-            a.href = anchorMap[header][i];
-            if (!isMultipage) {
-              a.href = a.href.substring(a.href.indexOf('#'));
-            }
-            if (i === 0) {
-              var headerFormatted = header.replace(/</g, '&lt;');
-              headerFormatted = headerFormatted.replace(/ ([^ ]+) (element(?!s)|attribute(?!s)|interface(?!s)|common interface|object)/g, ' <code>$1</code> $2');
-              headerFormatted = headerFormatted.replace(/<code>(Before|After|Other|The|on|an|for|user|User|custom|Custom|built-in|abstract|exotic|global|settings|Browser|Serializable|Transferable|HTML|IDL|document)<\/code>/, '$1');
-              headerFormatted = headerFormatted.replace(/(type=[^\)]+)/g, '<code>$1</code>');
-              headerFormatted = headerFormatted.replace(/(Link type) "([^"]+)"/g, '$1 "<code>$2</code>"');
-              headerFormatted = headerFormatted.replace(/(ImageBitmap|WindowOrWorkerGlobalScope|multipart\/x-mixed-replace|registerProtocolHandler\(\)|registerContentHandler\(\))|storage|/, '<code>$1</code>');
-              a.innerHTML = headerFormatted;
-            } else {
-              li.appendChild(document.createTextNode(' '));
-              a.appendChild(document.createTextNode('(' + (i + 1) + ')'));
-            }
-            li.appendChild(a);
-          }
-          ul.appendChild(li);
-        }
-        panel.appendChild(ul);
-      } else {
-        p.textContent = 'No references in this specification.';
-      }
-      node.appendChild(panel);
-      dfnPanel = panel;
-    }
-  } else {
-    dfnTimeout = setTimeout(dfnLoad, 250, event);
+  if (event) {
+    event.stopPropagation();
   }
 }
 
@@ -133,7 +145,7 @@ function dfnMovePanel(event) {
   }
 }
 
-document.body.classList.add('dfnEnabled');
-document.addEventListener('click', dfnLoad, true);
+document.documentElement.classList.add('dfnEnabled');
+document.addEventListener('click', dfnLoad);
 
 })();

--- a/html-dfn.js
+++ b/html-dfn.js
@@ -145,7 +145,7 @@ function dfnMovePanel(event) {
   }
 }
 
-document.documentElement.classList.add('dfnEnabled');
+document.body.classList.add('dfnEnabled');
 document.addEventListener('click', dfnLoad);
 
 })();


### PR DESCRIPTION
* Clicking anywhere but on a link caused cross-references to load.
  Now fixed to only load if a `dfn` is clicked.
* Calling dfnLoad from dfnShow with a timeout is unnecessary with
  the new setup.
* Clicking the permalink didn't close the panel.
* Clicking a cross-spec definition (in the Dependencies section)
  didn't open the panel. It still doesn't show any references. (edit: https://github.com/whatwg/wattsi/issues/47)
* The click handlers were invoked in the wrong order; the onclick
  on the links in the panel should be invoked first so that
  event.stopPropagation() has an effect.
* The permalink was gone for the "No references" case.
* Made the permalink (and spec link, for cross-spec definitions)
  appear immediately without waiting for fetching.
* Show an error message in the panel if the fetch fails.
* Run the script async instead of defer to make the panel available
  as soon as possible. ~~Set the 'dfnEnabled' class on the root
  instead of the body so that the script can run before body exists.
  (This needs a change to standard.css to keep the pointer cursor. edit: https://github.com/whatwg/resources.whatwg.org/issues/58)~~