### PR TITLE
Meta: Persist dfn panel across multipage navigations

### DIFF
--- a/html-dfn.js
+++ b/html-dfn.js
@@ -98,7 +98,7 @@ function dfnCreatePanel(id, path, specURL) {
     var realLinkA = document.createElement('a');
     realLinkA.href = specURL;
     realLinkA.onclick = dfnClosePanel;
-    realLinkA.textContent = node.firstChild.href;
+    realLinkA.textContent = specURL;
     realLinkP.appendChild(realLinkA);
     panel.appendChild(realLinkP);
   }

--- a/html-dfn.js
+++ b/html-dfn.js
@@ -174,6 +174,10 @@ function movePanel(event) {
 }
 
 function restoreOrClosePanelOnNav(event) {
+  // Invoking this function twice is fine since on the second invocation,
+  // if the panel is open, `dfnPanel.dataset.id === id` so nothing happens;
+  // if the panel is closed, it will call `closePanel` which only clean up
+  // sessionStorage (which should already be cleared in that case).
   if (sessionStorage.dfnId) {
     var id = sessionStorage.dfnId;
     var path = sessionStorage.dfnPath;
@@ -192,6 +196,7 @@ document.body.classList.add('dfnEnabled');
 document.addEventListener('click', handleClick);
 if (isMultipage) {
   document.addEventListener('DOMContentLoaded', restoreOrClosePanelOnNav);
+  // Also listen for pageshow to handle history navigation without page-reload.
   window.addEventListener('pageshow', restoreOrClosePanelOnNav);
 }
 

--- a/html-dfn.js
+++ b/html-dfn.js
@@ -12,7 +12,7 @@ function isCrossSpecDfn(dfn) {
   return dfn.firstChild && dfn.firstChild instanceof HTMLAnchorElement;
 }
 
-function dfnHandleClick(event) {
+function handleClick(event) {
   if (event.button !== 0) {
     return;
   }
@@ -29,22 +29,22 @@ function dfnHandleClick(event) {
     current = current.parentElement;
   }
   if (!eventInDfnPanel) {
-    dfnClosePanel();
+    closePanel();
   }
   if (!node) {
     return;
   }
   var id = node.id || node.parentNode.id;
-  var path = "";
+  var path = '';
   if (isMultipage) {
     path = location.pathname;
   }
-  var specURL = "";
+  var specURL = '';
   if (isCrossSpecDfn(node)) {
     specURL = node.firstChild.href;
     event.preventDefault();
   }
-  dfnLoad(id, path, specURL);
+  loadReferences(id, path, specURL);
   node.appendChild(dfnPanel);
   if (isMultipage) {
     sessionStorage.dfnId = id;
@@ -53,12 +53,12 @@ function dfnHandleClick(event) {
   }
 }
 
-function dfnLoad(id, path, specURL) {
+function loadReferences(id, path, specURL) {
   if (dfnPanel) {
     dfnPanel.remove();
     dfnPanel = null;
   }
-  dfnPanel = dfnCreatePanel(id, path, specURL);
+  dfnPanel = createPanel(id, path, specURL);
   var p = document.createElement('p');
   dfnPanel.appendChild(p);
   if (!dfnMapDone) {
@@ -69,24 +69,24 @@ function dfnLoad(id, path, specURL) {
         dfnMap = data;
         dfnMapDone = true;
         if (dfnPanel) {
-          dfnFillInReferences(id);
+          fillInReferences(id);
         }
       }).catch(err => {
         p.textContent = 'Error loading cross-references.';
       });
   } else {
-    dfnFillInReferences(id);
+    fillInReferences(id);
   }
 }
 
-function dfnCreatePanel(id, path, specURL) {
+function createPanel(id, path, specURL) {
   var panel = document.createElement('div');
   panel.className = 'dfnPanel';
   if (id) {
     var permalinkP = document.createElement('p');
     var permalinkA = document.createElement('a');
-    permalinkA.href = path + "#" + id;
-    permalinkA.onclick = dfnClosePanel;
+    permalinkA.href = path + '#' + id;
+    permalinkA.onclick = closePanel;
     permalinkA.textContent = '#' + id;
     permalinkP.appendChild(permalinkA);
     panel.appendChild(permalinkP);
@@ -97,7 +97,7 @@ function dfnCreatePanel(id, path, specURL) {
     realLinkP.textContent = 'Spec: ';
     var realLinkA = document.createElement('a');
     realLinkA.href = specURL;
-    realLinkA.onclick = dfnClosePanel;
+    realLinkA.onclick = closePanel;
     realLinkA.textContent = specURL;
     realLinkP.appendChild(realLinkA);
     panel.appendChild(realLinkP);
@@ -106,7 +106,7 @@ function dfnCreatePanel(id, path, specURL) {
   return panel;
 }
 
-function dfnFillInReferences(id) {
+function fillInReferences(id) {
   var p = dfnPanel.lastChild;
   if (id in dfnMap) {
     p.textContent = 'Referenced in:';
@@ -116,7 +116,7 @@ function dfnFillInReferences(id) {
       var li = document.createElement('li');
       for (var i = 0; i < anchorMap[header].length; i += 1) {
         var a = document.createElement('a');
-        a.onclick = dfnMovePanel;
+        a.onclick = movePanel;
         a.href = anchorMap[header][i];
         if (!isMultipage) {
           a.href = a.href.substring(a.href.indexOf('#'));
@@ -143,7 +143,7 @@ function dfnFillInReferences(id) {
   }
 }
 
-function dfnClosePanel(event) {
+function closePanel(event) {
   if (dfnPanel) {
     dfnPanel.remove();
     dfnPanel = null;
@@ -158,7 +158,7 @@ function dfnClosePanel(event) {
   }
 }
 
-function dfnMovePanel(event) {
+function movePanel(event) {
   if (!dfnPanel) {
     return;
   }
@@ -173,26 +173,26 @@ function dfnMovePanel(event) {
   }
 }
 
-function dfnRestoreOrClosePanelOnNav(event) {
+function restoreOrClosePanelOnNav(event) {
   if (sessionStorage.dfnId) {
     var id = sessionStorage.dfnId;
     var path = sessionStorage.dfnPath;
     var specURL = sessionStorage.dfnSpecURL;
     if (!dfnPanel || (dfnPanel && dfnPanel.dataset.id !== id)) {
-      dfnLoad(id, path, specURL);
-      dfnMovePanel();
+      loadReferences(id, path, specURL);
+      movePanel();
       document.body.insertBefore(dfnPanel, document.body.firstChild);
     }
   } else {
-    dfnClosePanel();
+    closePanel();
   }
 }
 
 document.body.classList.add('dfnEnabled');
-document.addEventListener('click', dfnHandleClick);
+document.addEventListener('click', handleClick);
 if (isMultipage) {
-  document.addEventListener('DOMContentLoaded', dfnRestoreOrClosePanelOnNav);
-  window.addEventListener('pageshow', dfnRestoreOrClosePanelOnNav);
+  document.addEventListener('DOMContentLoaded', restoreOrClosePanelOnNav);
+  window.addEventListener('pageshow', restoreOrClosePanelOnNav);
 }
 
 })();


### PR DESCRIPTION
The intent here is that the dfn panel on multipage should act much
like it does on single-page. Following links in the panel should
let the panel stay open across page navigations. Closing the panel
or clicking on a new dfn, and then traversing through history,
should reflect the latest state.

Also fix subtle bugs that sometimes caused more than one panel to
be created, e.g., if a link in the panel is control-clicked.