### PR TITLE
Dev edition: display the caniuse panels

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -342,6 +342,13 @@ var > var::after {
   background: transparent;
 }
 
+/* Caniuse boxes */
+
+.status {
+  right: auto;
+  left: calc(50% + 586px / 2 - 9em / 2);
+}
+
 /* SPECIFIC ELEMENTS */
 /* Header */
 
@@ -556,6 +563,11 @@ html:not(.index) ol.toc ol {
     left: auto;
     top: auto;
     margin-left: 0.5em;
+  }
+
+ .status {
+    left: auto;
+    right: -8.9em;
   }
 
   /* Search */


### PR DESCRIPTION
Fixes #2794.

Requires a Wattsi pull request to be merged first; that will show up shortly.

Building the spec this way emits a number of warnings about things that are omitted. I am not sure what we should do about them:

```
Warning: Could not find ID parsing-xhtml-documents for annotation that uses URLs:
   https://caniuse.com/#feat=xhtml
Warning: Could not find ID dom-a-rellist for annotation that uses URLs:
   https://caniuse.com/#feat=rellist
Warning: Could not find ID dom-img-naturalwidth for annotation that uses URLs:
   https://caniuse.com/#feat=img-naturalwidth-naturalheight
Warning: Could not find ID navigatorconcurrenthardware for annotation that uses URLs:
   https://caniuse.com/#feat=hardwareconcurrency
Warning: Could not find ID stop-parsing for annotation that uses URLs:
   https://caniuse.com/#feat=domcontentloaded
Warning: Could not find ID dom-document-currentscript for annotation that uses URLs:
   https://caniuse.com/#feat=document-currentscript
Warning: Could not find ID dom-document-head for annotation that uses URLs:
   https://caniuse.com/#feat=documenthead
```

It looks like at least part of the issue may be that subdfns are not generating IDs, which is a bit surprising. Maybe I should try to fix that too.

Also, the styling is only meh.

![screenshot from 2017-07-05 18 54 56](https://user-images.githubusercontent.com/617481/27888434-fe7fea66-61b3-11e7-9879-0bd2817c645e.png)
