### PR TITLE
Dev edition: add introduction, plus various tweaks

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -74,7 +74,7 @@ h1 {
   font-size: 300%;
 }
 
-h2:not(#dev-edition-h2) {
+h2:not(#dev-edition-h2):not(#about-dev-edition) {
   font-size: 160%;
   text-transform: uppercase;
   letter-spacing: 0.2em;
@@ -385,7 +385,6 @@ header#head h2 {
 header#head .logo {
   position: absolute;
   left: -120px;
-  top: -20px;
 }
 
 /* Search bar */
@@ -506,6 +505,13 @@ html:not(.index) ol.toc ol {
   margin: 0;
 }
 
+/* About */
+
+#about-dev-edition {
+  margin: 1.5em 0 1em 0;
+  font-size: 34px;
+}
+
 /* RESPONSIVE STYLES */
 
 @media screen and (max-width: 767px) {
@@ -577,7 +583,7 @@ ul.domTree, ul.domTree ul {
 }
 
 ul.domTree li {
-  padding: 0; 
+  padding: 0;
   margin: 0;
   list-style: none;
   position: relative;


### PR DESCRIPTION
* Adds an "About this specification" introduction, like the previous
  version had. Closes #2780.
* Fixes the header logo positioning; the recent introduction of the
  search box in cfb8b9e63541b035170c186b6957086ad9599de1 made the title
  spill onto multiple lines, causing the logo to no longer be centered.
* Changes the <title> to "HTML Standard, Developer's Edition" to
  distinguish it better from the full standard. whatwg/wattsi#50 remains
  open for making the <title> more useful in general.
* Adds the full standard's favicon to the developer's edition too.
* Removes the useless Google fonts download, as we ended up deciding to
  serve Droid Serif ourselves.