### PR TITLE
Fix and tweak module worker example

### DIFF
--- a/demos/workers/modules/page.html
+++ b/demos/workers/modules/page.html
@@ -2,24 +2,30 @@
 <meta charset="utf-8">
 <title>Worker example: image decoding</title>
 
-<label>
-  Type an image URL to decode
-  <input type="url" id="image-url" list="image-list">
-  <datalist id="image-list">
-    <option value="https://html.spec.whatwg.org/images/drawImage.png">
-    <option value="https://html.spec.whatwg.org/images/robots.jpeg">
-    <option value="https://html.spec.whatwg.org/images/arcTo2.png">
-  </datalist>
-</label>
+<p>
+  <label>
+    Type an image URL to decode
+    <input type="url" id="image-url" list="image-list">
+    <datalist id="image-list">
+      <option value="https://html.spec.whatwg.org/images/drawImage.png">
+      <option value="https://html.spec.whatwg.org/images/robots.jpeg">
+      <option value="https://html.spec.whatwg.org/images/arcTo2.png">
+    </datalist>
+  </label>
+</p>
 
-<label>
-  Choose a filter to apply
-  <select id="filter">
-    <option value="none">none</option>
-    <option value="grayscale">grayscale</option>
-    <option value="brighten">brighten by 20%</option>
-  </select>
-</label>
+<p>
+  <label>
+    Choose a filter to apply
+    <select id="filter">
+      <option value="none">none</option>
+      <option value="grayscale">grayscale</option>
+      <option value="brighten">brighten by 20%</option>
+    </select>
+  </label>
+</p>
+
+<canvas id="output"></canvas>
 
 <script type="module">
   const worker = new Worker("worker.js", { type: "module" });


### PR DESCRIPTION
Adds missing `<canvas>` element, and wraps the `<label>`s with `<p>`s. Closes #2908.

@Hermannovich, what name would you prefer in the acknowledgments?