### PR TITLE
Meta: Fix link-fixup to work when there's no fragment

### DIFF
--- a/link-fixup.js
+++ b/link-fixup.js
@@ -1,6 +1,6 @@
 (function () {
   'use strict';
-  if (window.location.hash.length < 1) {
+  if (!(/^\/(dev|multipage)\//.test(window.location.pathname))) {
     return;
   }
 


### PR DESCRIPTION
Also do nothing if the path doesn't start with /multipage/ or /dev/.

Helps with #2934.