### PR TITLE
Meta: make link-fixup.js only look at the path for 404s

### DIFF
--- a/link-fixup.js
+++ b/link-fixup.js
@@ -16,9 +16,9 @@
   xhr.onload = function() {
     var fragmentLinks = xhr.response;
 
-    // handle section-foo.html links from the old old multipage version,
-    // and broken foo.html from the new version
-    if (!fragid || !(fragid in fragmentLinks)) {
+    // Handle section-foo.html links from the old old multipage version,
+    // and broken foo.html from the new version. Only run this for 404s.
+    if ((!fragid || !(fragid in fragmentLinks)) && document.title === '404 Not Found') {
       var m = window.location.pathname.match(/\/(?:section-)?([\w\-]+)\.html/);
       if (m) {
         fragid = m[1];


### PR DESCRIPTION
The Table of Contents link to index.html was redirected to
indices.html#index, and similarly all multipage pages without a
hash was being redirected (sometimes correctly, sometimes not).x