### PR TITLE
Editorial: remove text-shadow from content-venn diagram

### DIFF
--- a/images/content-venn.svg
+++ b/images/content-venn.svg
@@ -6,7 +6,7 @@
   ellipse:hover { stroke-width: 5px; }
   ellipse:not(:hover) + foreignObject { display: none; }
   div { font: 14px sans-serif; }
-  h1 { margin: 0 0 0.25em 0; padding: 0; font: 900 27px sans-serif; text-shadow: 0.15em 0.15em 0.2em gray; }
+  h1 { margin: 0 0 0.25em 0; padding: 0; font: 900 27px sans-serif; }
   ul { margin: 0; padding: 0 0 0 1em; }
   li { display: inline; margin: 0; padding: 0; line-height: 1.5; }
   li:not(:last-child):after { content: ', '; }


### PR DESCRIPTION
The shadow makes it harder to read, and doesn't really match
the style of where it's embedded.