### PR TITLE
Fix search results alignment

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -405,7 +405,6 @@ header#head .logo {
 #search ol {
   z-index: 1;
   position: absolute;
-  right: 0;
   width: 25em;
   list-style: none;
   background-color: #eee;


### PR DESCRIPTION
This fixes an issue showing the search results at the end of the screen to the right instead of below the search box.

![image](https://i.imgur.com/NCDJkqs.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/3710/acknowledgements.html" title="Last updated on May 24, 2018, 1:31 AM GMT (4aaf642)">/acknowledgements.html</a>  ( <a href="https://whatpr.org/html/3710/ce8404f...4aaf642/acknowledgements.html" title="Last updated on May 24, 2018, 1:31 AM GMT (4aaf642)">diff</a> )