### PR TITLE
Changed Comment in Canvas Example

### DIFF
--- a/demos/canvas/blue-robot/index-idle.html
+++ b/demos/canvas/blue-robot/index-idle.html
@@ -157,7 +157,7 @@
    if (!animating) {
      animating = true;
      paint();
-     // but tick every 150ms, so that we don't slow down when we don't paint
+     // but tick every 100ms, so that we don't slow down when we don't paint
      interval = setInterval(function () {
        var dx = blueRobot.tick();
        landscape.advance(dx);

--- a/demos/canvas/blue-robot/index.html
+++ b/demos/canvas/blue-robot/index.html
@@ -146,7 +146,7 @@
    requestAnimationFrame(paint);
  }
  paint();
- // but tick every 150ms, so that we don't slow down when we don't paint
+ // but tick every 100ms, so that we don't slow down when we don't paint
  setInterval(function () {
    var dx = blueRobot.tick();
    landscape.advance(dx);


### PR DESCRIPTION
Fixes https://github.com/whatwg/html/issues/3825.

It changes the canvas example comment to `100ms`.