### PR TITLE
Meta: move one dev-edition-specific style back

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -130,6 +130,10 @@ h1 dfn, h2 dfn, h3 dfn, h4 dfn, h5 dfn, h6 dfn {
   font-style: normal;
 }
 
+h2 > a.self-link {
+  left: -4em;
+}
+
 /* Links */
 
 a:link {


### PR DESCRIPTION
This was incorrectly moved to the shared style sheet in
df8dfc1b1c72a723285ba126e24577ba74a175d5.