### PR TITLE
Meta: add a pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-Thank you for contributing to the HTML Standard, please describe the change you are making and complete the checklist below if your change is not editorial.
+<!--
+Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
+-->
 
 - [ ] At least two implementers are interested (and none opposed):
-   * &hellip;
+   * …
+   * …
 - [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
-   * &hellip;
+   * …
 - [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
-   * Chrome: &hellip;
-   * Firefox: &hellip;
-   * Safari: &hellip;
+   * Chrome: …
+   * Firefox: …
+   * Safari: …
 
 (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+Thank you for contributing to the HTML Standard, please describe the change you are making and complete the checklist below if your change is not editorial.
+
+- [ ] At least two implementers are interested (and none opposed):
+   * &hellip;
+- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
+   * &hellip;
+- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
+   * Chrome: &hellip;
+   * Firefox: &hellip;
+   * Safari: &hellip;
+
+(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


### PR DESCRIPTION
The idea here is to centralize important information for reviewers and onlookers in OP and relay expectations to those making the change.

Given the high volume of new external contributors HTML gets this is particularly important here, but if successful we could generalize this across the WHATWG.