### PR TITLE
add recommended website to wrap text to 100 characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ In between these clear-cut categories, there is some gray area. Please feel free
 
 Due to the long legacy of the existing text the guidelines below are not always applied. We do require that you apply the guidelines when making changes, though are happy to provide assistance if this proves to be a blocker to you.
 
-Use a column width of 100 characters and add newlines where whitespace is used. (Emacs, set `fill-column` to `100`; in Vim, set `textwidth` to `100`; and in Sublime, set `wrap_width` to `100`. Alternatively, wrap the paragraph(s) with your changes with https://output.jsbin.com/maferi. Make sure that `column length to rewrap` is set to 100.)
+Use a column width of 100 characters and add newlines where whitespace is used. (Emacs, set `fill-column` to `100`; in Vim, set `textwidth` to `100`; and in Sublime, set `wrap_width` to `100`. Alternatively, wrap the paragraph(s) with your changes with https://domenic.github.io/rewrapper/. Make sure that `column length to rewrap` is set to 100.)
 
 Using newlines between "inline" element tag names and their content is forbidden. (This actually alters the content, by adding spaces.) That is,
 ```html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ In between these clear-cut categories, there is some gray area. Please feel free
 
 Due to the long legacy of the existing text the guidelines below are not always applied. We do require that you apply the guidelines when making changes, though are happy to provide assistance if this proves to be a blocker to you.
 
-Use a column width of 100 characters and add newlines where whitespace is used. (Emacs, set `fill-column` to `100`; in Vim, set `textwidth` to `100`; and in Sublime, set `wrap_width` to `100`.)
+Use a column width of 100 characters and add newlines where whitespace is used. (Emacs, set `fill-column` to `100`; in Vim, set `textwidth` to `100`; and in Sublime, set `wrap_width` to `100`. Alternatively, wrap the paragraph(s) with your changes with https://output.jsbin.com/maferi. Make sure that `column length to rewrap` is set to 100.)
 
 Using newlines between "inline" element tag names and their content is forbidden. (This actually alters the content, by adding spaces.) That is,
 ```html


### PR DESCRIPTION
Hi! 

When I raised my [first PR](https://github.com/whatwg/html/pull/5192) to the HTML spec, I didn't know how to wrap my text in VSCode. The contribution guide had instructions for Emacs, Vim, and Sublime. However, developers use many other text editors.

After searching HTML spec issues, I found a similar PR [here](https://github.com/whatwg/html/pull/5153). @domenic asked the author to wrap the text using https://output.jsbin.com/maferi. I used that website to format my own PRs to the HTML spec and found it very useful.

Thus, to assist fellow first-time HTML spec contributors, I'd like to link https://output.jsbin.com/maferi or a similar site in the contributing guidelines. Giving contributors a website as an option to format changes also has the advantage of being editor-agnostic.

**My goal is to make it easier for fellow first-time contributors to format their code.** This helps contributors create better PRs and reduces the time a reviewer might spend asking new contributors to wrap their text and guiding them through the process. Please let me know if there is another site you would prefer I link to in order to achieve this goal.

Thank you!

cc @annevk - thank you for your advice
cc @marcoscaceres 