### PR TITLE
Meta: remove year from copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft).
+Copyright © WHATWG (Apple, Google, Mozilla, Microsoft).
 This work is licensed under a Creative Commons Attribution 4.0 International License:
 
 Attribution 4.0 International


### PR DESCRIPTION
Helps with https://github.com/whatwg/sg/issues/102.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/5668/acknowledgements.html" title="Last updated on Jun 25, 2020, 10:45 AM UTC (27b0b66)">/acknowledgements.html</a>  ( <a href="https://whatpr.org/html/5668/b4fbe04...27b0b66/acknowledgements.html" title="Last updated on Jun 25, 2020, 10:45 AM UTC (27b0b66)">diff</a> )