### PR TITLE
Meta: separate IPR and point to Review Drafts there

### DIFF
--- a/review-draft.sh
+++ b/review-draft.sh
@@ -23,7 +23,7 @@ git checkout -b "review-draft-$(date +'%F')"
 INPUT="source"
 YYYYMM="$(date +'%Y-%m')"
 
-sed -E -i '' 's/<a href="\/review-drafts\/'[0-9]\+'-'[0-9]\+'\/">/<a href="\/review-drafts\/'"$YYYYMM"'">/' "$INPUT"
+sed -E -i '' 's/<a href="\/review-drafts\/'[0-9]\+'-'[0-9]\+'\/">/<a href="\/review-drafts\/'"$YYYYMM"'\/">/' "$INPUT"
 echo "Updated Living Standard to point to the new Review Draft"
 echo ""
 

--- a/review-draft.sh
+++ b/review-draft.sh
@@ -40,5 +40,6 @@ header "Please verify that only three lines changed relative to $INPUT:"
 diff -up "$INPUT" "$REVIEW_DRAFT" || true
 echo ""
 
+git add "$INPUT"
 git add review-drafts/*
 git commit -m "Review Draft Publication: $(date +'%B %G')"

--- a/review-draft.sh
+++ b/review-draft.sh
@@ -21,9 +21,14 @@ git pull
 git checkout -b "review-draft-$(date +'%F')"
 
 INPUT="source"
+YYYYMM="$(date +'%Y-%m')"
+
+sed -E -i '' 's/<a href="\/review-drafts\/'[0-9]\+'-'[0-9]\+'\/">/<a href="\/review-drafts\/'"$YYYYMM"'">/' "$INPUT"
+echo "Updated Living Standard to point to the new Review Draft"
+echo ""
 
 mkdir -p "review-drafts"
-REVIEW_DRAFT="review-drafts/$(date +'%Y-%m').wattsi"
+REVIEW_DRAFT="review-drafts/$YYYYMM.wattsi"
 
 # Note that %B in date is locale-specific. Let's hope for English.
 sed -e 's/^  <title w-nodev>HTML Standard<\/title>$/  <title w-nodev>HTML Standard Review Draft '"$(date +'%B %Y')"'<\/title>/' \


### PR DESCRIPTION
Helps with https://github.com/whatwg/sg/issues/124.

(I suspect we might want to move some of the Review Draft scripts into the whatwg/meta automated publishing infrastructure, but that can be tackled separately.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/5697/acknowledgements.html" title="Last updated on Jul 2, 2020, 6:23 AM UTC (24af14c)">/acknowledgements.html</a>  ( <a href="https://whatpr.org/html/5697/8518025...24af14c/acknowledgements.html" title="Last updated on Jul 2, 2020, 6:23 AM UTC (24af14c)">diff</a> )
<a href="https://whatpr.org/html/5697/index.html" title="Last updated on Jul 2, 2020, 6:23 AM UTC (24af14c)">/index.html</a>  ( <a href="https://whatpr.org/html/5697/8518025...24af14c/index.html" title="Last updated on Jul 2, 2020, 6:23 AM UTC (24af14c)">diff</a> )