### PR TITLE
Meta: align review-draft.sh with copyright year removal

### DIFF
--- a/review-draft.sh
+++ b/review-draft.sh
@@ -36,7 +36,6 @@ REVIEW_DRAFT="review-drafts/$YYYYMM.wattsi"
 # Note that %B in date is locale-specific. Let's hope for English.
 sed -e 's/^  <title w-nodev>HTML Standard<\/title>$/  <title w-nodev>HTML Standard Review Draft '"$(date +'%B %Y')"'<\/title>/' \
     -e 's/^    <h2 w-nohtml w-nosnap id="living-standard" class="no-num no-toc">Review Draft &mdash; Published <span class="pubdate">\[DATE: 01 Jan 1901\]<\/span><\/h2>$/    <h2 w-nohtml w-nosnap id="living-standard" class="no-num no-toc">Review Draft \&mdash; Published '"$(date +'%d %B %Y')"'<\/h2>/' \
-    -e 's/<span class="pubyear">\[DATE: 1901\]<\/span>/'"$(date +'%Y')"'/' \
     < "$INPUT" > "$REVIEW_DRAFT"
 echo "Created Review Draft at $REVIEW_DRAFT"
 header "Please verify that only two lines changed relative to $INPUT:"


### PR DESCRIPTION
I didn't investigate the prior change enough as to why the "three" had to become "two".