### PR TITLE
Unwrap the heading for the meta element section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,18 @@ Due to the long legacy of the existing text the guidelines below are not always 
 
 Use a column width of 100 characters and add newlines where whitespace is used. (Emacs, set `fill-column` to `100`; in Vim, set `textwidth` to `100`; and in Sublime, set `wrap_width` to `100`. Alternatively, wrap the paragraph(s) with your changes with https://domenic.github.io/rewrapper/. Make sure that `column length to rewrap` is set to 100.)
 
+However, be careful not to wrap headings for element names across multiple lines. That is:
+
+```html
+  <h4 element data-lt="meta" id="the-meta-element">The <dfn id="meta"><code>meta</code></dfn> element</h4>
+```
+is fine, even though it's longer than 100 characters; but the following:
+```html
+  <h4 element data-lt="meta" id="the-meta-element">The <dfn id="meta"><code>meta</code></dfn>
+  element</h4>
+```
+is not fine. (The reason it's not is: to build the published spec, we have a script that injects the **Tag omission in text/html** subsection into each output element section, and that doesn't expect those headings to break across multiple lines.)
+
 Using newlines between "inline" element tag names and their content is forbidden. (This actually alters the content, by adding spaces.) That is,
 ```html
    <dd><span>Parse error</span>. Create a new DOCTYPE token. Set its <i data-x="force-quirks


### PR DESCRIPTION
This patch unwraps the heading for the `meta` element section from <100 characters back to >100 characters.

Otherwise, without this change, the `.pre-process-tag-omission.pl` script we use for generating the **Tag omission in text/html** subsections for every element section doesn’t work as expected for the `meta` element section.

The reason is, that script is written to read in the source line-by-line and so doesn’t expect any headings to break across multiple lines.

This patch also includes a change adding an admonition to `CONTRIBUTING.md` about not wrapping element-section headings.

---

This patch is an alternative to https://github.com/whatwg/html-build/pull/250. I’d personally prefer we make this change to the source rather than that change to the script — because the `meta` element is actually the only element-section heading we currently have which is longer than breaks across lines. So it seems easier to just unwrap it back to a single line, rather than further touching that script (which is obviously fragile, and touching it risks introduced other regressions).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/5930/index.html" title="Last updated on Sep 20, 2020, 3:33 AM UTC (bee8505)">/index.html</a>  ( <a href="https://whatpr.org/html/5930/f7a3dcc...bee8505/index.html" title="Last updated on Sep 20, 2020, 3:33 AM UTC (bee8505)">diff</a> )
<a href="https://whatpr.org/html/5930/semantics.html" title="Last updated on Sep 20, 2020, 3:33 AM UTC (bee8505)">/semantics.html</a>  ( <a href="https://whatpr.org/html/5930/f7a3dcc...bee8505/semantics.html" title="Last updated on Sep 20, 2020, 3:33 AM UTC (bee8505)">diff</a> )