### PR TITLE
web worker doc example typo, nesting canvas elements

### DIFF
--- a/demos/workers/modules/page.html
+++ b/demos/workers/modules/page.html
@@ -46,8 +46,6 @@
     img.src = url.value;
 
     img.onload = () => {
-
-
       const canvas = document.createElement("canvas");
       canvas.width = img.width;
       canvas.height = img.height;

--- a/demos/workers/modules/page.html
+++ b/demos/workers/modules/page.html
@@ -26,7 +26,7 @@
   </label>
 </p>
 
-<canvas id="output"></canvas>
+<div id="output"></div>
 
 <script type="module">
   const worker = new Worker("worker.js", { type: "module" });
@@ -57,7 +57,7 @@
       imageData = context.getImageData(0, 0, canvas.width, canvas.height);
 
       sendToWorker();
-      output.appendChild(canvas);
+      output.replaceChildren(canvas);
     };
   }
 

--- a/demos/workers/modules/page.html
+++ b/demos/workers/modules/page.html
@@ -46,7 +46,7 @@
     img.src = url.value;
 
     img.onload = () => {
-      output.innerHTML = "";
+
 
       const canvas = document.createElement("canvas");
       canvas.width = img.width;


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->
This code example appends a canvas to the existing canvas#output, which is not valid. So I replace the canvas#output to div#output.

Then I changed output.appendChild(canvas) to output.replaceChildren(canvas).

- [ ] At least two implementers are interested (and none opposed):
   * …canvas#output, - div#output
   * …output.appendChild(canvas) -  output.replaceChildren(canvas).

- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/6404/acknowledgements.html" title="Last updated on Feb 23, 2021, 5:27 PM UTC (2e96a28)">/acknowledgements.html</a>  ( <a href="https://whatpr.org/html/6404/fd40465...2e96a28/acknowledgements.html" title="Last updated on Feb 23, 2021, 5:27 PM UTC (2e96a28)">diff</a> )