### PR TITLE
Change link for typographic conventions to HTTPS

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -269,7 +269,7 @@ var > var::after {
 
 /*
   Typographic conventions
-  (http://developers.whatwg.org/introduction.html#typographic-conventions)
+  (https://developers.whatwg.org/introduction.html#typographic-conventions)
 */
 .note, .example, .XXX, .warning, pre {
   max-width: 580px;


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.


- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
-->

Editorial change only, updating <http://developers.whatwg.org/introduction.html#typographic-conventions> to directly use HTTPS.