### PR TITLE
Restore navigator.plugins and navigator.mimeTypes as PDF-focused

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The HTML Standard is quite complex and people notice minor and larger issues wit
 
 We label [good first issues](https://github.com/whatwg/html/labels/good%20first%20issue) that you could help us fix, to get a taste for how to submit pull requests, how the build process works, and so on.
 
-We'd be happy to mentor you through this process. If you're interested and need help getting started, leave a comment on the issue or bug, or ask around [on IRC](https://whatwg.org/irc). The [FAQ](FAQ.md) may also be helpful.
+We'd be happy to mentor you through this process. If you're interested and need help getting started, leave a comment on the issue or bug, or [ask around](https://whatwg.org/chat). The [FAQ](FAQ.md) may also be helpful.
 
 ## Pull requests
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -82,11 +82,11 @@ Since then, we've realized that much like the [waterfall model](https://en.wikip
 
 ### Is design rationale documented?
 
-Sort of. Often some record of the rationale for a particular design choice can be found within discussions in the GitHub issue tracker, commit logs, or the mailing-list archive or IRC channel archives. Sometimes, there is an explanation in the specification, but doing that everywhere would make the specification huge.
+Sort of. Often some record of the rationale for a particular design choice can be found within discussions in the GitHub issue tracker, commit logs, or the mailing-list archive or [Chat archives](https://whatwg.org/chat#logs). Sometimes, there is an explanation in the specification, but doing that everywhere would make the specification huge.
 
 For a few cases that someone did take the time document, the information can be found at the following locations:
 
-* [Rationale](https://wiki.whatwg.org/wiki/Rationale) — a page that documents some reasons behind decisions in the spec, originally written and maintained by Variable. If anyone wants to help him out, try to grab someone on [IRC](https://wiki.whatwg.org/wiki/IRC); we're always looking for more contributors and this is a good place to start.
+* [Rationale](https://wiki.whatwg.org/wiki/Rationale) — a page that documents some reasons behind decisions in the spec, originally written and maintained by Variable. If anyone wants to help him out, try to find someone via [Chat](https://whatwg.org/chat); we're always looking for more contributors and this is a good place to start.
 * [Why no namespaces](https://wiki.whatwg.org/wiki/Why_no_namespaces)
 * [Why no script implements](https://wiki.whatwg.org/wiki/Why_no_script_implements)
 * [Why not reuse legend](https://wiki.whatwg.org/wiki/Why_not_reuse_legend) or another _mini-header_ element.


### PR DESCRIPTION
This is an attempt at addressing the discussion starting at https://github.com/whatwg/html/issues/6003#issuecomment-805389170.

It ensures browsers only vary on a single boolean, "PDF viewer supported". Then, it:

- Standardizes a new `navigator.pdfSupported` property which exposes that boolean directly.
- Makes the legacy `navigator.plugins` and `navigator.mimeType` interfaces expose a uniform set of `Plugin` and `MimeType` objects, across every browser, in one of two configurations (depending on the PDF viewer supported boolean).

For PDF viewer supported UAs, the resulting structure is:

- 5 `Plugin` objects, named (in order) "PDF Viewer", "Chrome PDF Viewer", "Chromium PDF Viewer", "Microsoft Edge PDF Viewer", "WebKit built-in PDF".
  - `description`: "Portable Document Format" (like Chrome. Safari is the empty string.)
  - `filename`: "internal-pdf-viewer" (like one of Chrome's two possibilities. Safari is the empty string.)
  - All 5 point to both of the following `MimeType` objects via their named/indexed properties.
- 2 `MimeType` objects, for the types "application/pdf" and "text/pdf".
  - `description`: "Portable Document Format" (like both Safari and Chrome)
  - `suffixes`: "pdf" (like both Safari and Chrome)
  - Both point to the 0th "PDF Viewer" `Plugin` object via their `enabledPlugin` getter.
  - `application/x-google-chrome-pdf` is *not* included

----

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/29559
   * I'd also like to write tests based on https://github.com/web-platform-tests/wpt/pull/27129 to see about PDF loading support being synced...
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1164635 , https://bugs.chromium.org/p/chromium/issues/detail?id=1222887
   * Firefox: TODO
   * Safari: TODO

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<details>
<summary>Original change description</summary>
This is an attempt at addressing the discussion starting at https://github.com/whatwg/html/issues/6003#issuecomment-805389170. There is another approach, discussed in https://github.com/whatwg/html/issues/6003#issuecomment-854887958, which might supersede this one.

It also includes `navigator.pdfSupported` as a modern way of doing detection so that web developers have a bit of an easier time, and maybe in five years we can revisit removing `navigator.plugins` and `navigator.mimeTypes`.

This approach (for PDF-supporting UAs) is:

- Such UAs have a *single* `Plugin` with the following properties:
  - `name`: implementation-defined, but must contain the string "PDF".
  - `description`: "Portable Document Format" (like Chrome. Safari is the empty string.)
  - `filename`: "internal-pdf-viewer" (like one of Chrome's two possibilities. Safari is the empty string.)
- Such UAs have *two* `MimeType`s with the following properties:
  - `type`: `application/pdf` for the 0th, and `text/pdf` for the 1st. (Like Safari. Chrome has `application/x-google-chrome-pdf` for the 0th, and `application/pdf` for the 1st.)
  - `description`: "Portable Document Format" (like both Safari and Chrome)
  - `suffixes`: "pdf" (like both Safari and Chrome)
- These objects are related in the following manner: the `Plugin` maps to both `MimeType`s (via named/indexed properties), and each `MimeType` maps to the single `Plugin` (via its `enabledPlugin` getter).

Notable differences in object structure:

- Safari also has a third `MimeType` for `application/postscript`, mapping to the same `Plugin`. Per https://github.com/whatwg/html/issues/6003#issuecomment-806187304 I left that out (although you can see an earlier commit that supported it).

- Chrome has two `MimeType`s and two corresponding `Plugin`s which map to each other. I went with the single-plugin-two-MimeType approach from Safari because it's simpler.

Potential variants:

- We could try to cut out `text/pdf`. It's somewhat harmless but while we're simplifying it might be nice to get rid of...

- This leaves one bit of implementation-defined behavior, the `name` of the plugin. Could we clean that up? See the discussion in https://github.com/whatwg/html/issues/6003#issuecomment-854887958.
</details>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/6738/browsing-the-web.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/browsing-the-web.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/browsing-the-web.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )
<a href="https://whatpr.org/html/6738/common-dom-interfaces.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/common-dom-interfaces.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/common-dom-interfaces.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )
<a href="https://whatpr.org/html/6738/index.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/index.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/index.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )
<a href="https://whatpr.org/html/6738/infrastructure.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/infrastructure.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )
<a href="https://whatpr.org/html/6738/obsolete.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/obsolete.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/obsolete.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )
<a href="https://whatpr.org/html/6738/system-state.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/system-state.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/system-state.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )
<a href="https://whatpr.org/html/6738/window-object.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">/window-object.html</a>  ( <a href="https://whatpr.org/html/6738/5d64c8c...ecf2b88/window-object.html" title="Last updated on Jul 13, 2021, 5:36 PM UTC (ecf2b88)">diff</a> )