### PR TITLE
Increase colour contrast

### DIFF
--- a/dev/styles.css
+++ b/dev/styles.css
@@ -277,7 +277,7 @@ var > var::after {
 
 .note {
   padding: 3px;
-  background-color: #eee;
+  background-color: #f7f7f7;
 }
 
 .note pre {
@@ -302,7 +302,7 @@ var > var::after {
 
 .css::before {
   content: "CSS:";
-  color: #888888;
+  color: #757575;
   font-size: 1em;
   display: block;
   background: transparent;
@@ -438,7 +438,7 @@ ol.toc li {
 }
 
 ol.toc .secno {
-  color: #888888;
+  color: #757575;
 }
 
 html.index ol.toc li {


### PR DESCRIPTION
This improves the spec page following [WCAG](https://www.w3.org/WAI/WCAG21/quickref) [1.4.3 Color Contrast](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1#contrast-minimum), increasing colour contrast of: 

* gray on white (changing foreground from #888888 to #757575, improving the ratio from `3.54 : 1` to `4.6 : 1`)
* note box (changing background from #eee to #f7f7f7, improving the ratio between link colour and background from `4.19 : 1` to `4.54 : 1`)

With this change, both would have a contrast of more than `4.5 : 1`, as per WCAG.

<img width="1207" alt="two screenshots of blobs of text with gray background, the right one uses lighter gray than the left one" src="https://user-images.githubusercontent.com/178782/158190907-16a3eb8f-daf7-4571-b8a7-b881e2b15e51.png">

<img width="955" alt="two screenshots of numbered lists, the one on the right has slightly darker gray numbers than the one on the left" src="https://user-images.githubusercontent.com/178782/158190993-34ac8979-f1b2-4f2c-abd5-5947b595bfd4.png">


(this PR only updates the stylesheet, not the actual specification)