### PR TITLE
Fix typo FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -334,7 +334,7 @@ Short of that, there are actually quite a number of ways for people to invent th
 * Authors can use the microdata feature (the `item=""` and `itemprop=""` attributes) to embed nested name-value pairs of data to be shared with other applications and sites.
 * Authors can propose new elements and attributes and, if the wider community and user-agent vendors agree that they are worth the effort, they can be added to the language.
 
-### HTML should group `<dt>`s and `<dd>`s together in `<di>`s!
+### HTML should group `<dt>`s and `<dd>`s together in `<div>`s!
 
 HTML allows `<div>` as a grouping element in `<dl>`. See [the `<dl>` specification](https://html.spec.whatwg.org/multipage/#the-dl-element) and [issue #1937](https://github.com/whatwg/html/issues/1937) wherein this was added.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.


- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

-->

I saw a typo in `FAQ.md` file and have corrected it. `<di>` -> `<div>`
I created it as a pull request, but you can delete it if you don't need the pull request for the typo correction. : )