### PR TITLE
Editorial: use <iframe>, not <object>, for content-venn.svg

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,5 @@
+iframe { border: 0; }
+
 .bad, .bad *:not(.X\58X) { color: gray; }
 
 .applies .yes, .yesno .yes { background: yellow; }


### PR DESCRIPTION
Helps with #4592.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/8026/dom.html" title="Last updated on Jun 22, 2022, 7:12 PM UTC (8cde724)">/dom.html</a>  ( <a href="https://whatpr.org/html/8026/9af0600...8cde724/dom.html" title="Last updated on Jun 22, 2022, 7:12 PM UTC (8cde724)">diff</a> )