### PR TITLE
Meta: adopt new Ubuntu in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
         path: 'source'


### PR DESCRIPTION
Looks like 22.04 will be the new ubuntu-latest soonish: https://github.com/actions/runner-images.

Align actions/checkout with other WHATWG standards.