### PR TITLE
Meta: move to GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
                    --env "HTML_SOURCE=/whatwg/html" \
                    --mount "type=bind,source=$GITHUB_WORKSPACE/output,destination=/whatwg/output" \
                    --env "HTML_OUTPUT=/whatwg/output" \
-                   whatwg/html-build
+                   ghcr.io/whatwg/html-build
     - name: Deploy
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:


### PR DESCRIPTION
Docker Hub was planning to sunset their free plan: https://www.docker.com/developers/free-team-faq/. Although they have backed down from doing this, it still seems better to centralize our infrastructure dependencies on GitHub.

Wattsi and html-build have been successfully published to the GHCR. This commit moves HTML's continuous integration step to depend on the GHCR version of html-build, instead of the Docker Hub version.