### PR TITLE
Meta: make Wattsi Syntax link more prominent in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We'd be happy to mentor you through this process. If you're interested and need 
 
 In short, change `source` and submit your patch, with a [good commit message](https://github.com/erlang/otp/wiki/Writing-good-commit-messages). Try to follow the source formatting rules below.
 
-Note that `source` is written in a dialect of HTML, which is eventually compiled into the deployed standard by a tool called [Wattsi](https://github.com/whatwg/wattsi). Documentation for this dialect can be found [in the Wattsi repository](https://github.com/whatwg/wattsi/blob/main/Syntax.md).
+Note that `source` is written in [Wattsi Syntax](https://github.com/whatwg/wattsi/blob/main/Syntax.md), a dialect of HTML, which is eventually compiled into the deployed standard by a tool called [Wattsi](https://github.com/whatwg/wattsi).
 
 Please add your name to the Acknowledgments section (search for `<!-- ACKS`) in your first pull request, even for trivial fixes. The names are sorted lexicographically.
 


### PR DESCRIPTION
Before I made my first editorial PR I was searching the `CONTRIBUTING.md` for information about the syntax used in the `source` file. However I was obviously only skimming the file because I missed the last link in the the following paragraph:

> Note that `source` is written in a dialect of HTML, which is eventually compiled into the deployed standard by a tool called [Wattsi](https://github.com/whatwg/wattsi). Documentation for this dialect can be found [in the Wattsi repository](https://github.com/whatwg/wattsi/blob/main/Syntax.md).

Probably because of the undescriptive link label "in the Wattsi repository". This PR therefore rewords this paragraph to:

> Note that `source` is written in [Wattsi Syntax](https://github.com/whatwg/wattsi/blob/main/Syntax.md), a dialect of HTML, which is eventually compiled into the deployed standard by a tool called [Wattsi](https://github.com/whatwg/wattsi).