### PR TITLE
Meta: Dark mode fixes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -75,7 +75,7 @@ td.eg { border-width: thin; text-align: center; }
 }
 #named-character-references-table > table > tbody > tr > td:first-child + td,
 #named-character-references-table > table > tbody > tr > td:last-child { text-align: center; }
-#named-character-references-table > table > tbody > tr > td:last-child:hover > span { position: absolute; top: auto; left: auto; margin-left: 0.5em; line-height: 1.2; font-size: 5em; border: outset; padding: 0.25em 0.5em; background: white; width: 1.25em; height: auto; text-align: center; }
+#named-character-references-table > table > tbody > tr > td:last-child:hover > span { position: absolute; top: auto; left: auto; margin-left: 0.5em; line-height: 1.2; font-size: 5em; border: outset; padding: 0.25em 0.5em; background: var(--bg, Canvas); width: 1.25em; height: auto; text-align: center; }
 #named-character-references-table > table > tbody > tr#entity-CounterClockwiseContourIntegral > td:first-child { font-size: 0.5em; }
 
 .glyph.control { color: #D50606; }
@@ -119,12 +119,12 @@ td.eg { border-width: thin; text-align: center; }
 }
 
 #module-script-fetching-diagram rect {
-  stroke: black;
+  stroke: var(--text, CanvasText);
   fill: transparent;
 }
 
 #module-script-fetching-diagram path {
-  stroke: black;
+  stroke: var(--text, CanvasText);
 }
 #module-script-fetching-diagram path[marker-end] {
   fill: transparent;


### PR DESCRIPTION
This change fixes dark mode bugs in the module script fetching diagram
and in the named character references table.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/10144/webappapis.html" title="Last updated on Feb 19, 2024, 5:46 AM UTC (4252552)">/webappapis.html</a>  ( <a href="https://whatpr.org/html/10144/39ec692...4252552/webappapis.html" title="Last updated on Feb 19, 2024, 5:46 AM UTC (4252552)">diff</a> )