### PR TITLE
More darkmode coloring. Fixes #10141

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,27 @@
+:root {
+  --bad-example-text: gray;
+
+  --yesno-yes-bg: yellow;
+
+  --img-abstract-bg: #424242;
+  --img-abstract-text: #ffffff;
+}
+@media (prefers-color-scheme:  dark) {
+:root {
+  --bad-example-text: gray;
+
+  --yesno-yes-bg: #004000;
+
+  --img-abstract-bg: #424242;
+  --img-abstract-text: #ffffff;
+}
+}
+
 iframe { border: 0; }
 
-.bad, .bad *:not(.X\58X) { color: gray; }
+.bad, .bad *:not(.X\58X) { color: var(--bad-example-text); }
 
-.applies .yes, .yesno .yes { background: yellow; }
+.applies .yes, .yesno .yes { background: var(--yesno-yes-bg); }
 .yesno .yes, .yesno .no { text-align: center; }
 
 .applies thead th > * { display: block; }
@@ -78,8 +97,6 @@ td.eg { border-width: thin; text-align: center; }
 #named-character-references-table > table > tbody > tr > td:last-child:hover > span { position: absolute; top: auto; left: auto; margin-left: 0.5em; line-height: 1.2; font-size: 5em; border: outset; padding: 0.25em 0.5em; background: var(--bg, Canvas); width: 1.25em; height: auto; text-align: center; }
 #named-character-references-table > table > tbody > tr#entity-CounterClockwiseContourIntegral > td:first-child { font-size: 0.5em; }
 
-.glyph.control { color: #D50606; }
-
 #table-example-1 * { font-family: "Essays1743", serif; line-height: 1.01em; }
 @font-face {
   font-family: 'Essays1743';
@@ -106,8 +123,8 @@ td.eg { border-width: thin; text-align: center; }
   #abstractimg { width: 100%; }
 }
 #abstractimg, #abstractimg text { font: inherit; }
-#abstractimg rect { fill: #424242; }
-#abstractimg text { fill: #ffffff; }
+#abstractimg rect { fill: var(--img-abstract-bg); }
+#abstractimg text { fill: var(--img-abstract-text); }
 #abstractimg .horizontal, #abstractimg .left { word-spacing: 12px; font-size: 18px; text-anchor: middle; }
 #abstractimg .right { font-size: 25px; }
 
@@ -140,12 +157,10 @@ td.eg { border-width: thin; text-align: center; }
 .jake-diagram {
   border-style: hidden none hidden hidden;
   table-layout: fixed;
-  background: white;
-  color: black;
 }
 
 .jake-diagram, .jake-diagram :is(td, th, tr) {
-  border-color: black;
+  border-color: var(--text);
 }
 
 .jake-diagram :where(th.step) {
@@ -171,28 +186,19 @@ td.eg { border-width: thin; text-align: center; }
 }
 
 /* Chosen by clicking around https://colorhunt.co/palettes/pastel */
-.jake-diagram .doc-0 {
-  background: #F0EBE3;
-}
-
-.jake-diagram .doc-1 {
-  background: #EEE4AB;
-}
-
-.jake-diagram .doc-2 {
-  background: #D3CEDF;
-}
-
-.jake-diagram .doc-3 {
-  background: #D6EFED;
-}
-
-.jake-diagram .doc-4 {
-  background: #F4BFBF;
-}
-
-.jake-diagram .doc-5 {
-  background: #DAE5D0;
+.jake-diagram .doc-0 {background: #F0EBE3;}
+.jake-diagram .doc-1 {background: #EEE4AB;}
+.jake-diagram .doc-2 {background: #D3CEDF;}
+.jake-diagram .doc-3 {background: #D6EFED;}
+.jake-diagram .doc-4 {background: #F4BFBF;}
+.jake-diagram .doc-5 {background: #DAE5D0;}
+@media (prefers-color-scheme: dark) {
+.jake-diagram .doc-0 {background: #030637;}
+.jake-diagram .doc-1 {background: #3C0753;}
+.jake-diagram .doc-2 {background: #720455;}
+.jake-diagram .doc-3 {background: #910A67;}
+.jake-diagram .doc-4 {background: #872341;}
+.jake-diagram .doc-5 {background: #B33030;}
 }
 
 /* Dfn panels */

--- a/styles.css
+++ b/styles.css
@@ -8,17 +8,18 @@
   --img-abstract-bg: #424242;
   --img-abstract-text: #ffffff;
 }
+
 @media (prefers-color-scheme:  dark) {
-:root {
-  --bad-example-text: gray;
+  :root {
+    --bad-example-text: gray;
 
-  --yesno-yes-bg: #004000;
+    --yesno-yes-bg: #004000;
 
-  --control-glyph-text: #d50606;
+    --control-glyph-text: #d50606;
 
-  --img-abstract-bg: #424242;
-  --img-abstract-text: #ffffff;
-}
+    --img-abstract-bg: #424242;
+    --img-abstract-text: #ffffff;
+  }
 }
 
 iframe { border: 0; }
@@ -191,19 +192,20 @@ td.eg { border-width: thin; text-align: center; }
 }
 
 /* Chosen by clicking around https://colorhunt.co/palettes/pastel */
-.jake-diagram .doc-0 {background: #F0EBE3;}
-.jake-diagram .doc-1 {background: #EEE4AB;}
-.jake-diagram .doc-2 {background: #D3CEDF;}
-.jake-diagram .doc-3 {background: #D6EFED;}
-.jake-diagram .doc-4 {background: #F4BFBF;}
-.jake-diagram .doc-5 {background: #DAE5D0;}
+.jake-diagram .doc-0 { background: #F0EBE3; }
+.jake-diagram .doc-1 { background: #EEE4AB; }
+.jake-diagram .doc-2 { background: #D3CEDF; }
+.jake-diagram .doc-3 { background: #D6EFED; }
+.jake-diagram .doc-4 { background: #F4BFBF; }
+.jake-diagram .doc-5 { background: #DAE5D0; }
+
 @media (prefers-color-scheme: dark) {
-.jake-diagram .doc-0 {background: #030637;}
-.jake-diagram .doc-1 {background: #3C0753;}
-.jake-diagram .doc-2 {background: #720455;}
-.jake-diagram .doc-3 {background: #910A67;}
-.jake-diagram .doc-4 {background: #872341;}
-.jake-diagram .doc-5 {background: #B33030;}
+  .jake-diagram .doc-0 { background: #030637; }
+  .jake-diagram .doc-1 { background: #3C0753; }
+  .jake-diagram .doc-2 { background: #720455; }
+  .jake-diagram .doc-3 { background: #910A67; }
+  .jake-diagram .doc-4 { background: #872341; }
+  .jake-diagram .doc-5 { background: #B33030; }
 }
 
 /* Dfn panels */

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,8 @@
 
   --yesno-yes-bg: yellow;
 
+  --control-glyph-text: #d50606;
+
   --img-abstract-bg: #424242;
   --img-abstract-text: #ffffff;
 }
@@ -11,6 +13,8 @@
   --bad-example-text: gray;
 
   --yesno-yes-bg: #004000;
+
+  --control-glyph-text: #d50606;
 
   --img-abstract-bg: #424242;
   --img-abstract-text: #ffffff;
@@ -96,6 +100,7 @@ td.eg { border-width: thin; text-align: center; }
 #named-character-references-table > table > tbody > tr > td:last-child { text-align: center; }
 #named-character-references-table > table > tbody > tr > td:last-child:hover > span { position: absolute; top: auto; left: auto; margin-left: 0.5em; line-height: 1.2; font-size: 5em; border: outset; padding: 0.25em 0.5em; background: var(--bg, Canvas); width: 1.25em; height: auto; text-align: center; }
 #named-character-references-table > table > tbody > tr#entity-CounterClockwiseContourIntegral > td:first-child { font-size: 0.5em; }
+#named-character-references-table span.glyph.control { color: var(--control-glyph-text); }
 
 #table-example-1 * { font-family: "Essays1743", serif; line-height: 1.01em; }
 @font-face {


### PR DESCRIPTION
Finishes porting the last few manual colors in `styles.html` to be darkmode-aware. (`dev/styles.html` is already darkmoded)

* Pulled out the "bad example" text color (same in both light and dark, but good for all colors to live together)
* Add darkmode color for the .yesno tables (switched from a lightmode yellow to a darkmode "WHATWG green, but slightly darker", since it's just meant to help draw the eye a little when quickly scanning a large table)
* Removed `.glyph.control` style entirely; it doesn't appear to be used anywhere in the spec.
* Pulled the "abstract img" colors out (again, same in both light and dark)
* Removed the manual bg/text colors from jake diagrams, chose a set of dark cell colors to complement the lightmode pastels.