### PR TITLE
Extend Canvas TextMetrics for editing and text styling

### DIFF
--- a/source
+++ b/source
@@ -70810,6 +70810,7 @@ interface <dfn interface>TextMetrics</dfn> {
 
 [Exposed=(Window,Worker)]
 interface <dfn interface>TextCluster</dfn> {
+    // opaque object
     readonly attribute double <span data-x="dom-TextCluster-x">x</span>;
     readonly attribute double <span data-x="dom-TextCluster-y">y</span>;
     readonly attribute unsigned long <span data-x="dom-TextCluster-begin">begin</span>;
@@ -74666,10 +74667,9 @@ try {
   <ol>
     <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
 
-    <li><p>Run the <span>text preparation algorithm</span>, passing it the <var>text</var>
-    originally passed to <code data-x="dom-context-2d-measureText">measureText()</code> to obtain
-    the cluster, and an object with the <code>CanvasTextDrawingStyles</code> values as they were
-    when the cluster was measured, with the exception of <code
+    <li><p>Run the <span>text preparation algorithm</span>, passing it the complete text and the
+    <code>CanvasTextDrawingStyles</code> from the opaque <code>TextCluster</code>
+    <var>cluster</var>, with the exception of <code
     data-x="dom-context-2d-textAlign">textAlign</code> and <code
     data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
     data-x="dom-TextCluster-align">align</code> and <code
@@ -74901,8 +74901,14 @@ try {
     <p>Splits the given range of the text into <span
     data-x="grapheme cluster">grapheme clusters</span>, and returns the positional data for each
     cluster. The range includes the character at the <var>start</var> index but stops before the
-    <var>end</var> index. The result is a list of new <code>TextCluster</code> objects with members
-    behaving as described in the following list: <ref>UNICODE</ref></p>
+    <var>end</var> index. The result is a list of new <code>TextCluster</code> objects. These
+    objects are opaque as they encapsulate the complete text that was segmented, along with the
+    <code>CanvasTextDrawingStyles</code> values that were active at the time <code
+    data-x="dom-context-2d-measureText">measureText()</code> was called. Note that <code
+    data-x="dom-context-2d-textAlign">textAlign</code> and
+    <code data-x="dom-context-2d-textBaseline">textBaseline</code> are exceptions, as they are explicitly set attributes and are handled separately. Each
+    <code>TextCluster</code> object has members behaving as described in the following list:
+    <ref>UNICODE</ref></p>
 
     <dl>
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-x">x</code></dfn> attribute</dt>
@@ -74967,11 +74973,6 @@ try {
       that this doesn't change the origin of the coordinate system, just which point is specified
       for each cluster.</p></dd>
     </dl>
-
-    <p class="note">The user agent might internally store in the <code>TextCluster</code> object the
-    complete text, as well as all the <code>CanvasTextDrawingStyles</code> at the time that <code
-    data-x="dom-context-2d-measureText">measureText()</code> was called, as they will be needed to
-    correctly render the clusters as they were measured.</p>
   </dd>
   </dl>
 

--- a/source
+++ b/source
@@ -74667,11 +74667,7 @@ try {
   data-x="dom-context-2d-fillTextCluster">fillTextCluster(<var>cluster</var>, <var>x</var>,
   <var>y</var>, <var>options</var>)</code></dfn> and <dfn method for="CanvasText"><code
   data-x="dom-context-2d-strokeTextCluster">strokeTextCluster(<var>cluster</var>, <var>x</var>,
-  <var>y</var>, <var>options</var>)</code></dfn> methods render a <code>TextCluster</code> object.
-  The cluster is rendered where it would be if the whole text that was passed to <code
-  data-x="dom-context-2d-measureText">measureText()</code> to obtain the cluster was rendered at
-  position (<var>x</var>,<var>y</var>), unless the positioning is modified with the options
-  argument. Specifically, when the method is invoked, the user agent must run these steps:</p>
+  <var>y</var>, <var>options</var>)</code></dfn> methods, when invoked, must run these steps:</p>
 
   <ol>
    <li><p>If any of the arguments are infinite or NaN, then return.</p></li>

--- a/source
+++ b/source
@@ -70687,12 +70687,20 @@ interface mixin <dfn interface>CanvasUserInterface</dfn> {
   undefined <span data-x="dom-context-2d-drawFocusIfNeeded-path-element">drawFocusIfNeeded</span>(<span>Path2D</span> path, <span>Element</span> element);
 };
 
+
+dictionary <dfn dictionary>TextClusterOptions</dfn> {
+  <span>CanvasTextAlign</span> align;
+  <span>CanvasTextBaseline</span> baseline;
+  double x;
+  double y;
+};
+
 interface mixin <dfn interface>CanvasText</dfn> {
   // text (see also the <span>CanvasPathDrawingStyles</span> and <span>CanvasTextDrawingStyles</span> interfaces)
   undefined <span data-x="dom-context-2d-fillText">fillText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
   undefined <span data-x="dom-context-2d-strokeText">strokeText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
+  undefined <span data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options);
   <span>TextMetrics</span> <span data-x="dom-context-2d-measureText">measureText</span>(DOMString text);
-  undefined <span data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<span>TextCluster</span> textCluster, double x, double y, optional <span>TextClusterOptions</span> options);
 };
 
 interface mixin <dfn interface>CanvasDrawImage</dfn> {
@@ -70809,11 +70817,20 @@ interface <dfn interface>TextCluster</dfn> {
     readonly attribute <span>CanvasTextBaseline</span> <span data-x="dom-TextCluster-baseline">baseline</span>;
 };
 
-dictionary <dfn dictionary>TextClusterOptions</dfn> {
-  <span>CanvasTextAlign</span> align;
-  <span>CanvasTextBaseline</span> baseline;
-  double x;
-  double y;
+dictionary <dfn dictionary>ImageDataSettings</dfn> {
+  <span>PredefinedColorSpace</span> <span data-x="dom-PredefinedColorSpace-srgb">colorSpace</span>;
+};
+
+[Exposed=(Window,Worker),
+ <span>Serializable</span>]
+interface <dfn interface>ImageData</dfn> {
+  <span data-x="dom-imagedata">constructor</span>(unsigned long sw, unsigned long sh, optional <span>ImageDataSettings</span> settings = {});
+  <span data-x="dom-imagedata-with-data">constructor</span>(<span data-x="idl-Uint8ClampedArray">Uint8ClampedArray</span> data, unsigned long sw, optional unsigned long sh, optional <span>ImageDataSettings</span> settings = {});
+
+  readonly attribute unsigned long <span data-x="dom-imagedata-width">width</span>;
+  readonly attribute unsigned long <span data-x="dom-imagedata-height">height</span>;
+  readonly attribute <span data-x="idl-Uint8ClampedArray">Uint8ClampedArray</span> <span data-x="dom-imagedata-data">data</span>;
+  readonly attribute <span>PredefinedColorSpace</span> <span data-x="dom-imagedata-colorSpace">colorSpace</span>;
 };
 
 [Exposed=(Window,Worker)]
@@ -74544,6 +74561,15 @@ try {
     provided, the text will be scaled to fit that width if necessary.</p>
    </dd>
 
+   <dt><code data-x=""><var>context</var>.<span subdfn data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<var>cluster</var>, <var>x</var>, <var>y</var> [, <var>options</var> ])</code></dt>
+
+   <dd>
+    <p>Fills the given text cluster as it would be positioned if the text as a whole was rendered at
+    the given position. The align and baseline used to render, as well as the position of the
+    cluster in relation to the anchor point of the while text, can be modified with the options
+    dictionary.</p>
+   </dd>
+
    <dt><code data-x=""><var>metrics</var> = <var>context</var>.<span subdfn data-x="dom-context-2d-measureText">measureText</span>(<var>text</var>)</code></dt>
 
    <dd>
@@ -74569,8 +74595,6 @@ try {
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(<var>start</var>, <var>end</var>)</code></dt>
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(<var>offset</var>)</code></dt>
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(<var>start</var>, <var>end</var> [, <var>options</var> ])</code></dt>
-
-   <dt><code data-x=""><var>context</var>.<span subdfn data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<var>textCluster</var>, <var>x</var>, <var>y</var> [, <var>options</var> ])</code></dt>
   </dl>
 
   <div w-nodev>
@@ -74624,6 +74648,71 @@ try {
     operator</span>.</p>
    </li>
   </ol>
+  </div>
+
+  <div algorithm>
+  <p>The <dfn method for="CanvasText"><code
+  data-x="dom-context-2d-fillTextCluster">fillTextCluster(<var>cluster</var>, <var>x</var>,
+  <var>y</var>, <var>options</var>)</code></dfn> method renders a <code>TextCluster</code> object.
+  The cluster is rendered where it would be if the whole text that was passed to <code
+  data-x="dom-context-2d-measureText">measureText()</code> to obtain the cluster was rendered at
+  position (<var>x</var>,<var>y</var>), unless the positioning is modified with the options
+  argument. Specifically, when the method is invoked, the user agent must run these steps:</p>
+
+  <ol>
+    <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
+
+    <li><p>Run the <span>text preparation algorithm</span>, passing it the <var>text</var>
+    originally passed to <code data-x="dom-context-2d-measureText">measureText()</code> to obtain
+    the cluster, and an object with the <code>CanvasTextDrawingStyles</code> values as they were
+    when the cluster was measured, with the exception of <code
+    data-x="dom-context-2d-textAlign">textAlign</code> and <code
+    data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
+    data-x="dom-TextCluster-align">align</code> and <code
+    data-x="dom-TextCluster-baseline">baseline</code> attributes of <var>cluster</var>. Let
+    <var>glyphs</var> be the result.</p></li>
+
+    <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
+    data-x="code point">code points</span> within the range <code
+    data-x="dom-TextCluster-begin">cluster["begin"]</code> to <code
+    data-x="dom-TextCluster-end">cluster["end"]</code>.</p></li>
+
+    <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
+    <span data-x="'px'">CSS pixels</span> and down by <var>y</var> <span data-x="'px'">CSS
+    pixels</span>.</p></li>
+
+    <li>
+      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
+      data-x="">options["x"]</code> value, move all the shapes in <var>glyphs</var> to the right by
+      <code data-x="">options["x"] &minus; cluster["x"]</code>.</p>
+
+      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
+      data-x="">options["y"]</code> value, move all the shapes in <var>glyphs</var> down by <code
+      data-x="">options["y"] &minus; cluster["y"]</code>.</p>
+    </li>
+
+    <li>
+      <p>Paint the shapes given in <var>glyphs</var>, as transformed by the <span
+      data-x="dom-context-2d-transformation">current transformation matrix</span>, with each <span
+      data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
+      coordinate space unit.</p>
+
+      <p><span>this</span>'s <span
+      data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span> must be applied to the
+      shapes and <span>this</span>'s <span
+      data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored.
+
+      <p>These shapes are painted without affecting the current path, and are subject to <span
+      data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
+      alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
+      operator</span>.</p>
+    </li>
+  </ol>
+
+  <p class="note">By setting <code data-x="">options["x"]</code> and <code
+  data-x="">options["y"]</code> to 0, the cluster will be rendered exactly at the position
+  (<var>x</var>,<var>y</var>) passed to <code
+  data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>.</p>
   </div>
 
   <div algorithm>
@@ -74810,7 +74899,7 @@ try {
         data-x="dom-context-2d-measureText">measureText()</code> was called) in relation to the text
         as a whole.</p>
 
-        <p>The x position specified for each cluster corresponds to the aligment point given by the
+        <p>The x position specified for each cluster corresponds to the alignment point given by the
         <code data-x="dom-TextCluster-align">align</code> attribute of the cluster (e.g. if
         this attribute is set to "<code data-x="">left</code>", the calculated position corresponds
         to the <code data-x="dom-context-2d-textAlign-left">left</code> of each cluster). The
@@ -74827,7 +74916,7 @@ try {
         data-x="dom-context-2d-measureText">measureText()</code> was called) in relation to the text
         as a whole.</p>
 
-        <p>The y position specified for each cluster corresponds to the aligment point given by the
+        <p>The y position specified for each cluster corresponds to the alignment point given by the
         <code data-x="dom-TextCluster-baseline">baseline</code> attribute of the cluster (e.g. if
         this attribute is set to "<code data-x="">top</code>", the calculated position corresponds
         to the <code data-x="dom-context-2d-textBaseline-top">top</code> of each cluster). The
@@ -74849,7 +74938,7 @@ try {
 
       <dd><p>The align for the specific point returned for the cluster. If a
       <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
-      <code data-x="">options.align</code>, this will be the assigned value. Otherwise, it will be
+      <code data-x="">options["align"]</code>, this will be the assigned value. Otherwise, it will be
       set as the <code data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this
       doesn't change the origin of the coordinate system, just which point is specified for each
       cluster.</p></dd>
@@ -74858,7 +74947,7 @@ try {
 
       <dd><p>The baseline for the specific point returned for the cluster. If a
       <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
-      <code data-x="">options.baseline</code>, this will be the assigned value. Otherwise, it will
+      <code data-x="">options["baseline"]</code>, this will be the assigned value. Otherwise, it will
       be set as the <code data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note
       that this doesn't change the origin of the coordinate system, just which point is specified
       for each cluster.</p></dd>
@@ -74880,68 +74969,6 @@ try {
   <p class="note">A future version of the 2D context API might provide a way to render fragments of
   documents, rendered using CSS, straight to the canvas. This would be provided in preference to a
   dedicated way of doing multiline layout.</p>
-
-  <p>The <dfn method for="CanvasText"><code
-  data-x="dom-context-2d-fillTextCluster">fillTextCluster(<var>textCluster</var>, <var>x</var>,
-  <var>y</var>, <var>options</var>)</code></dfn> method renders a <code>TextCluster</code> object.
-  The cluster is rendered where it would be if the whole text that was passed to <code
-  data-x="dom-context-2d-measureText">measureText()</code> to obtain the cluster was rendered at
-  position (<var>x</var>,<var>y</var>), unless the positioning is modified with the options
-  argument. Specifically, when the methods are invoked, the user agent must run these steps:</p>
-
-  <ol>
-    <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
-
-    <li><p>Run the <span>text preparation algorithm</span>, passing it the <var>text</var>
-    originally passed to <code data-x="dom-context-2d-measureText">measureText()</code> to obtain
-    the cluster, and an object with the <code>CanvasTextDrawingStyles</code> values as they were
-    when the cluster was measured, with the exception of <code
-    data-x="dom-context-2d-textAlign">textAlign</code> and <code
-    data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
-    data-x="dom-TextCluster-align">align</code> and <code
-    data-x="dom-TextCluster-baseline">baseline</code> attributes of <var>cluster</var>. Let
-    <var>glyphs</var> be the result.</p></li>
-
-    <li><p>Filter <var>glyphs</var> to include only glyphs that contain <span
-    data-x="code point">code points</span> within the range <code
-    data-x="dom-TextCluster-begin">cluster.begin</code> to <code
-    data-x="dom-TextCluster-end">cluster.end</code>.</p></li>
-
-    <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
-    <span data-x="'px'">CSS pixels</span> and down by <var>y</var> <span data-x="'px'">CSS
-    pixels</span>.</p></li>
-
-    <li>
-      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-      data-x="">options.x</code> value, move all the shapes in <var>glyphs</var> to the right by
-      <code data-x="">options.x-cluster.x</code>.</p>
-
-      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-      data-x="">options.y</code> value, move all the shapes in <var>glyphs</var> down by <code
-      data-x="">options.y-cluster.y</code>.</p>
-    </li>
-
-    <li>
-      <p>Paint the shapes given in <var>glyphs</var>, as transformed by the <span
-      data-x="dom-context-2d-transformation">current transformation matrix</span>, with each <span
-      data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
-      coordinate space unit.</p>
-
-      <p><span>this</span>'s <span
-      data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span> must be applied to the
-      shapes and <span>this</span>'s <span
-      data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored.
-
-      <p>These shapes are painted without affecting the current path, and are subject to <span
-      data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
-      alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
-      operator</span>.</p>
-    </li>
-  </ol>
-
-  <p class="note">By setting <code data-x="">options.x</code> and <code data-x="">options.y</code>
-  to 0, the cluster will be rendered exactly at the position (<var>x</var>,<var>y</var>) passed to
-  <code data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>.</p>
 
   <h6>Drawing paths to the canvas</h6>
 

--- a/source
+++ b/source
@@ -4814,6 +4814,15 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
     </ul>
    </dd>
 
+   <dt>Unicode</dt>
+   <dd>
+    <p>The following terms are defined in <cite>Unicode</cite>: <ref>UNICODE</ref></p>
+
+    <ul class="brief">
+     <li><dfn data-x-href="https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries">grapheme cluster</dfn></li>
+    </ul>
+   </dd>
+
    <dt>Web App Manifest</dt>
 
    <dd>
@@ -70683,6 +70692,7 @@ interface mixin <dfn interface>CanvasText</dfn> {
   undefined <span data-x="dom-context-2d-fillText">fillText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
   undefined <span data-x="dom-context-2d-strokeText">strokeText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
   <span>TextMetrics</span> <span data-x="dom-context-2d-measureText">measureText</span>(DOMString text);
+  undefined <span data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<span>TextCluster</span> textCluster, double x, double y, optional <span>TextClusterOptions</span> options);
 };
 
 interface mixin <dfn interface>CanvasDrawImage</dfn> {
@@ -70782,6 +70792,28 @@ interface <dfn interface>TextMetrics</dfn> {
   readonly attribute double <span data-x="dom-textmetrics-hangingBaseline">hangingBaseline</span>;
   readonly attribute double <span data-x="dom-textmetrics-alphabeticBaseline">alphabeticBaseline</span>;
   readonly attribute double <span data-x="dom-textmetrics-ideographicBaseline">ideographicBaseline</span>;
+
+  sequence&lt;DOMRectReadOnly> <span data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(unsigned long start, unsigned long end);
+  DOMRectReadOnly <span data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(unsigned long start, unsigned long end);
+  unsigned long <span data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(double offset);
+  sequence&lt;<span>TextCluster</span>> <span data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(unsigned long start, unsigned long end, optional <span>TextClusterOptions</span> options);
+};
+
+[Exposed=(Window,Worker)]
+interface <dfn interface>TextCluster</dfn> {
+    readonly attribute double <span data-x="dom-TextCluster-x">x</span>;
+    readonly attribute double <span data-x="dom-TextCluster-y">y</span>;
+    readonly attribute unsigned long <span data-x="dom-TextCluster-begin">begin</span>;
+    readonly attribute unsigned long <span data-x="dom-TextCluster-end">end</span>;
+    readonly attribute <span>CanvasTextAlign</span> <span data-x="dom-TextCluster-align">align</span>;
+    readonly attribute <span>CanvasTextBaseline</span> <span data-x="dom-TextCluster-baseline">baseline</span>;
+};
+
+dictionary <dfn dictionary>TextClusterOptions</dfn> {
+  <span>CanvasTextAlign</span> align;
+  <span>CanvasTextBaseline</span> baseline;
+  double x;
+  double y;
 };
 
 [Exposed=(Window,Worker)]
@@ -74533,6 +74565,12 @@ try {
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-ideographicBaseline">ideographicBaseline</span></code></dt>
 
    <dd><p>Returns the measurement described below.</p></dd>
+   <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(<var>start</var>, <var>end</var>)</code></dt>
+   <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(<var>start</var>, <var>end</var>)</code></dt>
+   <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(<var>offset</var>)</code></dt>
+   <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(<var>start</var>, <var>end</var> [, <var>options</var> ])</code></dt>
+
+   <dt><code data-x=""><var>context</var>.<span subdfn data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<var>textCluster</var>, <var>x</var>, <var>y</var> [, <var>options</var> ])</code></dt>
   </dl>
 
   <div w-nodev>
@@ -74721,6 +74759,116 @@ try {
    positive numbers indicating that the given baseline is below the <span>ideographic-under
    baseline</span>. (Zero if the given baseline is the <span>ideographic-under
    baseline</span>.)</p></dd>
+
+   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method</dt>
+
+   <dd><p>Returns the set of rectangles that the UA would render as selection to select
+   a particular character range, in <span data-x="'px'">CSS pixels</span>. The positions are returned
+   relative to the alignment point given by the <code
+   data-x="dom-context-2d-textAlign">textAlign</code> and <code
+   data-x="dom-context-2d-textBaseline">textBaseline</code> attributes.</p></dd>
+
+   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method</dt>
+
+   <dd>
+    <p>Returns the rectangle equivalent to the box described by <code
+    data-x="dom-textmetrics-actualBoundingBoxLeft">actualBoundingBoxLeft</code>,  <code
+    data-x="dom-textmetrics-actualBoundingBoxRight">actualBoundingBoxRight</code>,  <code
+    data-x="dom-textmetrics-actualBoundingBoxAscent">actualBoundingBoxAscent</code>,  <code
+    data-x="dom-textmetrics-actualBoundingBoxDescent">actualBoundingBoxDescent</code>, for the given
+    range. The positions are returned relative to the alignment point given by the <code
+    data-x="dom-context-2d-textAlign">textAlign</code> and <code
+    data-x="dom-context-2d-textBaseline">textBaseline</code> attributes.</p>
+
+    <p class="note">The bounding box can be (and usually is) different from the selection
+    rectangles, which are based on the advance of the text. A font that is particularly slanted or
+    with accents that go beyond the flow of text will have a different paint bounding box.</p>
+  </dd>
+
+  <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method</dt>
+
+  <dd><p>Returns the string index for the character at the given offset distance from the start
+  position of the text run, relative to the alignment point given by the <code
+  data-x="dom-context-2d-textAlign">textAlign</code> attribute, with offset always increasing left
+  to right (negative offsets are valid). Values to the left or right of the text bounds will return
+  0 or the length of the text, depending on the writing direction.</p></dd>
+
+  <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method</dt>
+
+  <dd>
+    <p>Splits the given range of the text into <span data-x="grapheme cluster">grapheme clusters</span>, and returns the positional data
+    for each cluster, as a list of new <code>TextCluster</code> objects, with members behaving as
+    described in the following list: <ref>UNICODE</ref></p>
+
+    <dl>
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-x">x</code></dfn> attribute</dt>
+
+      <dd>
+        <p>The x coordinate of the cluster, on a coordinate space using <span
+        data-x="'px'">CSS pixels</span>, with its origin at the anchor point defined by the <code
+        data-x="dom-context-2d-textAlign">textAlign</code> attribute (at the time <code
+        data-x="dom-context-2d-measureText">measureText()</code> was called) in relation to the text
+        as a whole.</p>
+
+        <p>The x position specified for each cluster corresponds to the aligment point given by the
+        <code data-x="dom-TextCluster-align">align</code> attribute of the cluster (e.g. if
+        this attribute is set to "<code data-x="">left</code>", the calculated position corresponds
+        to the <code data-x="dom-context-2d-textAlign-left">left</code> of each cluster). The
+        selection criteria for this alignment point is explained in the section for this attribute
+        of the cluster.</p>
+      </dd>
+
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-y">y</code></dfn> attribute</dt>
+
+      <dd>
+        <p>The y coordinate of the cluster, on a coordinate space using <span
+        data-x="'px'">CSS pixels</span>, with its origin at the anchor point defined by the <code
+        data-x="dom-context-2d-textBaseline">textBaseline</code> attribute (at the time <code
+        data-x="dom-context-2d-measureText">measureText()</code> was called) in relation to the text
+        as a whole.</p>
+
+        <p>The y position specified for each cluster corresponds to the aligment point given by the
+        <code data-x="dom-TextCluster-baseline">baseline</code> attribute of the cluster (e.g. if
+        this attribute is set to "<code data-x="">top</code>", the calculated position corresponds
+        to the <code data-x="dom-context-2d-textBaseline-top">top</code> of each cluster). The
+        selection criteria for this alignment point is explained in the section for this attribute
+        of the cluster.</p>
+      </dd>
+
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-begin">begin</code></dfn> attribute</dt>
+
+      <dd><p>The starting index for the range of <span data-x="code point">code points</span> that are
+      rendered as this cluster.</p></dd>
+
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-end">end</code></dfn> attribute</dt>
+
+      <dd><p>The ending index for the range of <span data-x="code point">code points</span> that are
+      rendered as this cluster.</p></dd>
+
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-align">align</code></dfn> attribute</dt>
+
+      <dd><p>The align for the specific point returned for the cluster. If a
+      <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
+      <code data-x="">options.align</code>, this will be the assigned value. Otherwise, it will be
+      set as the <code data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this
+      doesn't change the origin of the coordinate system, just which point is specified for each
+      cluster.</p></dd>
+
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-baseline">baseline</code></dfn> attribute</dt>
+
+      <dd><p>The baseline for the specific point returned for the cluster. If a
+      <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
+      <code data-x="">options.baseline</code>, this will be the assigned value. Otherwise, it will
+      be set as the <code data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note
+      that this doesn't change the origin of the coordinate system, just which point is specified
+      for each cluster.</p></dd>
+    </dl>
+
+    <p class="note">The user agent might internally store in the <code>TextCluster</code> object the
+    complete text, as well as all the <code>CanvasTextDrawingStyles</code> at the time that <code
+    data-x="dom-context-2d-measureText">measureText()</code> was called, as they will be needed to
+    correctly render the clusters as they were measured.</p>
+  </dd>
   </dl>
 
   <p class="note">Glyphs rendered using <code data-x="dom-context-2d-fillText">fillText()</code> and
@@ -74733,7 +74881,67 @@ try {
   documents, rendered using CSS, straight to the canvas. This would be provided in preference to a
   dedicated way of doing multiline layout.</p>
 
+  <p>The <dfn method for="CanvasText"><code
+  data-x="dom-context-2d-fillTextCluster">fillTextCluster(<var>textCluster</var>, <var>x</var>,
+  <var>y</var>, <var>options</var>)</code></dfn> method renders a <code>TextCluster</code> object.
+  The cluster is rendered where it would be if the whole text that was passed to <code
+  data-x="dom-context-2d-measureText">measureText()</code> to obtain the cluster was rendered at
+  position (<var>x</var>,<var>y</var>), unless the positioning is modified with the options
+  argument. Specifically, when the methods are invoked, the user agent must run these steps:</p>
 
+  <ol>
+    <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
+
+    <li><p>Run the <span>text preparation algorithm</span>, passing it the <var>text</var>
+    originally passed to <code data-x="dom-context-2d-measureText">measureText()</code> to obtain
+    the cluster, and an object with the <code>CanvasTextDrawingStyles</code> values as they were
+    when the cluster was measured, with the exception of <code
+    data-x="dom-context-2d-textAlign">textAlign</code> and <code
+    data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
+    data-x="dom-TextCluster-align">align</code> and <code
+    data-x="dom-TextCluster-baseline">baseline</code> attributes of <var>cluster</var>. Let
+    <var>glyphs</var> be the result.</p></li>
+
+    <li><p>Filter <var>glyphs</var> to include only glyphs that contain <span
+    data-x="code point">code points</span> within the range <code
+    data-x="dom-TextCluster-begin">cluster.begin</code> to <code
+    data-x="dom-TextCluster-end">cluster.end</code>.</p></li>
+
+    <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
+    <span data-x="'px'">CSS pixels</span> and down by <var>y</var> <span data-x="'px'">CSS
+    pixels</span>.</p></li>
+
+    <li>
+      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
+      data-x="">options.x</code> value, move all the shapes in <var>glyphs</var> to the right by
+      <code data-x="">options.x-cluster.x</code>.</p>
+
+      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
+      data-x="">options.y</code> value, move all the shapes in <var>glyphs</var> down by <code
+      data-x="">options.y-cluster.y</code>.</p>
+    </li>
+
+    <li>
+      <p>Paint the shapes given in <var>glyphs</var>, as transformed by the <span
+      data-x="dom-context-2d-transformation">current transformation matrix</span>, with each <span
+      data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
+      coordinate space unit.</p>
+
+      <p><span>this</span>'s <span
+      data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span> must be applied to the
+      shapes and <span>this</span>'s <span
+      data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored.
+
+      <p>These shapes are painted without affecting the current path, and are subject to <span
+      data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
+      alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
+      operator</span>.</p>
+    </li>
+  </ol>
+
+  <p class="note">By setting <code data-x="">options.x</code> and <code data-x="">options.y</code>
+  to 0, the cluster will be rendered exactly at the position (<var>x</var>,<var>y</var>) passed to
+  <code data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>.</p>
 
   <h6>Drawing paths to the canvas</h6>
 
@@ -161797,6 +162005,7 @@ INSERT INTERFACES HERE
   Andreas Kling,
   Andrei Popescu,
   Andres Gomez,
+  Andrés Ricardo Pérez Rojas,
   Andres Rios,
   Andreu Botella,
   Andrew Barfield,

--- a/source
+++ b/source
@@ -74662,75 +74662,89 @@ try {
   </ol>
   </div>
 
+  <p>A <dfn>canvas fill-stroke mode</dfn> is an enum that describes whether the rendered text will
+  be filled or stroked:</p>
+
+  <dl>
+   <dt><dfn data-x="canvas-fill-stroke-mode-fill">fill</dfn></dt>
+   <dd><p>The shapes are filled using <span>this</span>'s <span
+   data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span>.</p></dd>
+
+   <dt><dfn data-x="canvas-fill-stroke-mode-stroke">stroke</dfn></dt>
+   <dd><p>The shapes are <span data-x="trace a path">traced</span> using <span>this</span>'s <span
+    data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span>.</p></dd>
+  </dl>
+
   <div algorithm>
   <p>The <dfn method for="CanvasText"><code
   data-x="dom-context-2d-fillTextCluster">fillTextCluster(<var>cluster</var>, <var>x</var>,
-  <var>y</var>, <var>options</var>)</code></dfn> and <dfn method for="CanvasText"><code
+  <var>y</var>, <var>options</var>)</code></dfn> method steps are to call the <span>cluster
+  rendering algorithm</span>, passing it <var>cluster</var>, <var>x</var>, <var>y</var>,
+  <var>options</var>, and the <span data-x="canvas-fill-stroke-mode-fill">fill</span> <span>canvas
+  fill-stroke mode</span> enum.</p>
+
+  <p>The <dfn method for="CanvasText"><code
   data-x="dom-context-2d-strokeTextCluster">strokeTextCluster(<var>cluster</var>, <var>x</var>,
-  <var>y</var>, <var>options</var>)</code></dfn> methods, when invoked, must run these steps:</p>
+  <var>y</var>, <var>options</var>)</code></dfn> method steps are to call the <span>cluster
+  rendering algorithm</span>, passing it <var>cluster</var>, <var>x</var>, <var>y</var>,
+  <var>options</var>, and the <span data-x="canvas-fill-stroke-mode-stroke">stroke</span> <span>canvas
+  fill-stroke mode</span> enum.</p>
+
+  <p>The <dfn>cluster rendering algorithm</dfn> is as follows. It takes as input a
+  <code>TextCluster</code> <var>cluster</var>, a double <var>x</var>, a double <var>y</var>, a
+  <code>TextClusterOptions</code> <var>options</var>, and a <span>canvas fill-stroke mode</span>
+  <var>mode</var>.</p>
 
   <ol>
-   <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
+   <li><p>If the <var>x</var> or the <var>y</var> arguments are infinite or NaN, then return.</p>
+   </li>
 
    <li><p>Run the <span>text preparation algorithm</span>, passing it the complete text and the
    <code>CanvasTextDrawingStyles</code> from the opaque <code>TextCluster</code>
-   <var>cluster</var>, with the exception of <code
-   data-x="dom-context-2d-textAlign">textAlign</code> and <code
-   data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
-   data-x="dom-TextCluster-align">align</code> and <code
-   data-x="dom-TextCluster-baseline">baseline</code> attributes of <var>cluster</var>. Let
-   <var>glyphs</var> be the result.</p></li>
+   <var>cluster</var>. Let <var>glyphs</var> be the result.</p></li>
 
-   <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
-   data-x="code point">code points</span> within the range <code
-   data-x="dom-TextCluster-start">cluster["start"]</code> to <code
-   data-x="dom-TextCluster-end">cluster["end"]</code>.</p></li>
+   <li><p>Filter <var>glyphs</var> to include only the glyphs that correspond to <span
+   data-x="code point">code points</span> within the range <var>cluster</var>["<code
+   data-x="dom-TextCluster-start">start</code>"] to <var>cluster</var>["<code
+   data-x="dom-TextCluster-end">end</code>"].</p></li>
 
    <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
    <span data-x="'px'">CSS pixels</span> and down by <var>y</var> <span data-x="'px'">CSS
    pixels</span>.</p></li>
 
    <li>
-    <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-    data-x="dom-TextClusterOptions-x">options["x"]</code> value, move all the shapes in
-    <var>glyphs</var> to the right by <code data-x=""><span
-    data-x="dom-TextClusterOptions-x">options["x"]</span> &minus; <span
-    data-x="dom-TextCluster-x">cluster["x"]</span></code>.</p>
+    <p>If <var>options</var>["<code data-x="dom-TextClusterOptions-x">x</code>"] <span
+    data-x="map exists">exists</span>, move all the shapes in <var>glyphs</var> to the right by
+    <var>options</var>["<code data-x="dom-TextClusterOptions-x">x</code>"] &minus;
+    <var>cluster</var>["<code data-x="dom-TextCluster-x">x</code>"].</p>
 
-    <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-    data-x="dom-TextClusterOptions-y">options["y"]</code> value, move all the shapes in
-    <var>glyphs</var> down by <code data-x=""><span
-    data-x="dom-TextClusterOptions-y">options["y"]</span> &minus; <span
-    data-x="dom-TextCluster-y">cluster["y"]</span></code>.</p>
+    <p>If <var>options</var>["<code data-x="dom-TextClusterOptions-y">y</code>"] <span
+    data-x="map exists">exists</span>, move all the shapes in <var>glyphs</var> to the right by
+    <var>options</var>["<code data-x="dom-TextClusterOptions-y">y</code>"] &minus;
+    <var>cluster</var>["<code data-x="dom-TextCluster-y">y</code>"].</p>
    </li>
 
-   <li>
-     <p>Paint the shapes given in <var>glyphs</var>, as transformed by the <span
-     data-x="dom-context-2d-transformation">current transformation matrix</span>, with each <span
-     data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
-     coordinate space unit.</p>
+   <li><p>If <var>mode</var> is <span data-x="canvas-fill-stroke-mode-fill">fill</span>, let
+   <var>shapes</var> be the result of applying <span>this</span>'s <span
+   data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span> to the shapes given in
+   <var>glyphs</var>.</p></li>
 
-     <p>For <code data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>,
-     <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span>
-     must be applied to the shapes and <span>this</span>'s <span
-     data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored. For
-     <code data-x="dom-context-2d-strokeTextCluster">strokeTextCluster()</code>, the reverse holds:
-     <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke
-     style</span> must be applied to the result of <span data-x="trace a path">tracing</span> the
-     shapes using the object implementing the <code>CanvasText</code> interface for the line
-     styles, and <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill
-     style</span> must be ignored.</p>
+   <li><p>Otherwise, if <var>mode</var> is <span
+   data-x="canvas-fill-stroke-mode-stroke">stroke</span>, let <var>shapes</var> be the result of
+   applying <span>this</span>'s <span
+   data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> to the result of <span
+   data-x="trace a path">tracing</span> the shapes given in <var>glyphs</var> using the object
+   implementing the <code>CanvasText</code> interface for the line styles.</p></li>
 
-     <p>These shapes are painted without affecting the current path, and are subject to <span
-     data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
-     alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
-     operator</span>.</p>
-   </li>
+   <li><p>Paint <var>shapes</var> without affecting the current path, and subject to <span
+   data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
+   alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
+   operator</span>.</p></li>
   </ol>
 
-  <p class="note">By setting <code data-x="">options["x"]</code> and <code
-  data-x="">options["y"]</code> to 0, the cluster will be rendered exactly at the position
-  (<var>x</var>,<var>y</var>) passed to <code
+  <p class="note">By setting <var>options</var>["<code data-x="dom-TextClusterOptions-x">x</code>"]
+  and <var>options</var>["<code data-x="dom-TextClusterOptions-y">y</code>"] to 0, the cluster will
+  be rendered exactly at the position (<var>x</var>,<var>y</var>) passed to <code
   data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code> and <code
   data-x="dom-context-2d-strokeTextCluster">strokeTextCluster()</code>.</p>
   </div>
@@ -74909,7 +74923,7 @@ try {
      <span>text preparation algorithm</span> when <code
      data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
 
-     <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
+     <li><p>Filter <var>glyphs</var> to include only the glyphs that correspond to <span
      data-x="code point">code points</span> within the range that includes the <var>start</var>
      index but stops before the <var>end</var> index.</p></li>
 
@@ -74996,19 +75010,17 @@ try {
 
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-align">align</code></dfn> attribute</dt>
 
-      <dd><p>The align for the specific point returned for the cluster. If a
-      <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
-      <code data-x="dom-TextClusterOptions-align">options["align"]</code>, this will be the assigned
-      value. Otherwise, it will be set as the <code
+      <dd><p>The align for the specific point returned for the cluster. Let it be
+      <var>options</var>["<code data-x="dom-TextClusterOptions-align">align</code>"] if it <span
+      data-x="map exists">exists</span>; otherwise, the <code
       data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this doesn't change
       the origin of the coordinate system, just which point is specified for each cluster.</p></dd>
 
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-baseline">baseline</code></dfn> attribute</dt>
 
-      <dd><p>The baseline for the specific point returned for the cluster. If a
-      <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
-      <code data-x="dom-TextClusterOptions-baseline">options["baseline"]</code>, this will be the
-      assigned value. Otherwise, it will be set as the <code
+      <dd><p>The baseline for the specific point returned for the cluster. Let it be
+      <var>options</var>["<code data-x="dom-TextClusterOptions-baseline">baseline</code>"] if it
+      <span data-x="map exists">exists</span>; otherwise, the <code
       data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note that this doesn't
       change the origin of the coordinate system, just which point is specified for each cluster.
       </p></dd>

--- a/source
+++ b/source
@@ -4293,6 +4293,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
          <dfn data-x="DOMPointInit-x" data-x-href="https://drafts.csswg.org/geometry/#dom-dompointinit-x">x</dfn> and
          <dfn data-x="DOMPointInit-y" data-x-href="https://drafts.csswg.org/geometry/#dom-dompointinit-y">y</dfn> members</li>
       <li><dfn data-x-href="https://drafts.csswg.org/geometry/#matrix-multiply">Matrix multiplication</dfn></li>
+      <li><dfn data-x-href="https://www.w3.org/TR/geometry-1/#DOMRect">DOMRectReadOnly and DOMRect</dfn></li>
     </ul>
 
     <p>The following terms are defined in the <cite>CSS Scoping</cite>: <ref>CSSSCOPING</ref></p>
@@ -70802,8 +70803,8 @@ interface <dfn interface>TextMetrics</dfn> {
   readonly attribute double <span data-x="dom-textmetrics-alphabeticBaseline">alphabeticBaseline</span>;
   readonly attribute double <span data-x="dom-textmetrics-ideographicBaseline">ideographicBaseline</span>;
 
-  sequence&lt;DOMRectReadOnly> <span data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(unsigned long start, unsigned long end);
-  DOMRectReadOnly <span data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(unsigned long start, unsigned long end);
+  sequence&lt;<span data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</span>> <span data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(unsigned long start, unsigned long end);
+  <span data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</span> <span data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(unsigned long start, unsigned long end);
   unsigned long <span data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(double offset);
   sequence&lt;<span>TextCluster</span>> <span data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(unsigned long start, unsigned long end, optional <span>TextClusterOptions</span> options);
 };
@@ -74594,10 +74595,27 @@ try {
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-ideographicBaseline">ideographicBaseline</span></code></dt>
 
    <dd><p>Returns the measurement described below.</p></dd>
+
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(<var>start</var>, <var>end</var>)</code></dt>
+
+   <dd><p>Returns a list of <code data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</code> objects corresponding to the selection
+   rectangles for the given range in the string.</p></dd>
+
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(<var>start</var>, <var>end</var>)</code></dt>
+
+   <dd><p>Returns a <code data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</code> that corresponds to the bounding rectangle for the
+   given range in the string.</p></dd>
+
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(<var>offset</var>)</code></dt>
+
+   <dd><p>Returns the index for the character at the given offset from the start of the text.</p></dd>
+
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(<var>start</var>, <var>end</var> [, <var>options</var> ])</code></dt>
+
+   <dd><p>Returns a list of <code>TextCluster</code> objects, with positional data for each one.
+   They correspond to splitting the text into the minimal rendering units possible. The options
+   dictionary enables selecting a specific point to be returned for each cluster be specifying align
+   and baseline values.</p></dd>
   </dl>
 
   <div w-nodev>

--- a/source
+++ b/source
@@ -70700,6 +70700,7 @@ interface mixin <dfn interface>CanvasText</dfn> {
   undefined <span data-x="dom-context-2d-fillText">fillText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
   undefined <span data-x="dom-context-2d-strokeText">strokeText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
   undefined <span data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options);
+  undefined <span data-x="dom-context-2d-strokeTextCluster">strokeTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options);
   <span>TextMetrics</span> <span data-x="dom-context-2d-measureText">measureText</span>(DOMString text);
 };
 
@@ -74562,12 +74563,13 @@ try {
    </dd>
 
    <dt><code data-x=""><var>context</var>.<span subdfn data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<var>cluster</var>, <var>x</var>, <var>y</var> [, <var>options</var> ])</code></dt>
+   <dt><code data-x=""><var>context</var>.<span subdfn data-x="dom-context-2d-strokeTextCluster">strokeTextCluster</span>(<var>cluster</var>, <var>x</var>, <var>y</var> [, <var>options</var> ])</code></dt>
 
    <dd>
-    <p>Fills the given text cluster as it would be positioned if the text as a whole was rendered at
-    the given position. The align and baseline used to render, as well as the position of the
-    cluster in relation to the anchor point of the while text, can be modified with the options
-    dictionary.</p>
+    <p>Fills or strokes (respectively) the given text cluster as it would be positioned if the text
+    as a whole was rendered at the given position. The align and baseline used to render, as well as
+    the position of the cluster in relation to the anchor point of the while text, can be modified
+    with the options dictionary.</p>
    </dd>
 
    <dt><code data-x=""><var>metrics</var> = <var>context</var>.<span subdfn data-x="dom-context-2d-measureText">measureText</span>(<var>text</var>)</code></dt>
@@ -74653,7 +74655,9 @@ try {
   <div algorithm>
   <p>The <dfn method for="CanvasText"><code
   data-x="dom-context-2d-fillTextCluster">fillTextCluster(<var>cluster</var>, <var>x</var>,
-  <var>y</var>, <var>options</var>)</code></dfn> method renders a <code>TextCluster</code> object.
+  <var>y</var>, <var>options</var>)</code></dfn> and <dfn method for="CanvasText"><code
+  data-x="dom-context-2d-strokeTextCluster">strokeTextCluster(<var>cluster</var>, <var>x</var>,
+  <var>y</var>, <var>options</var>)</code></dfn> methods render a <code>TextCluster</code> object.
   The cluster is rendered where it would be if the whole text that was passed to <code
   data-x="dom-context-2d-measureText">measureText()</code> to obtain the cluster was rendered at
   position (<var>x</var>,<var>y</var>), unless the positioning is modified with the options
@@ -74697,10 +74701,16 @@ try {
       data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
       coordinate space unit.</p>
 
-      <p><span>this</span>'s <span
-      data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span> must be applied to the
-      shapes and <span>this</span>'s <span
-      data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored.
+      <p>For <code data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>,
+      <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span>
+      must be applied to the shapes and <span>this</span>'s <span
+      data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored. For
+      <code data-x="dom-context-2d-strokeTextCluster">strokeTextCluster()</code>, the reverse holds:
+      <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke
+      style</span> must be applied to the result of <span data-x="trace a path">tracing</span> the
+      shapes using the object implementing the <code>CanvasText</code> interface for the line
+      styles, and <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill
+      style</span> must be ignored.</p>
 
       <p>These shapes are painted without affecting the current path, and are subject to <span
       data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
@@ -74712,7 +74722,8 @@ try {
   <p class="note">By setting <code data-x="">options["x"]</code> and <code
   data-x="">options["y"]</code> to 0, the cluster will be rendered exactly at the position
   (<var>x</var>,<var>y</var>) passed to <code
-  data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>.</p>
+  data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code> and <code
+  data-x="dom-context-2d-strokeTextCluster">strokeTextCluster()</code>.</p>
   </div>
 
   <div algorithm>

--- a/source
+++ b/source
@@ -74936,13 +74936,24 @@ try {
     with accents that go beyond the flow of text will have a different paint bounding box.</p>
    </dd>
 
-   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method</dt>
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method steps are:</dt>
 
-   <dd><p>Returns the string index for the character at the given offset distance from the start
-   position of the text run, relative to the alignment point given by the <code
-   data-x="dom-context-2d-textAlign">textAlign</code> attribute, with offset always increasing left
-   to right (negative offsets are valid). Values to the left or right of the text bounds will return
-   0 or the length of the text, depending on the writing direction.</p></dd>
+   <dd>
+    <ol>
+     <li><p>Let <var>glyphs</var> be the result of the
+     <span>text preparation algorithm</span> when <code
+     data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
+
+     <li><p>Let <var>index</var> be the character offset with the <var>x</var> position closest to
+     <var>offset</var> in <var>glyphs</var>.</p></li>
+
+     <li><p>Return <var>index</var>.</p></li>
+
+     <p class="note">Note that negative values for <var>offset</var> are valid. Values to the left
+     or right of the text bounds will return 0 or the length of the text, depending on the writing
+     direction.</p>
+    </ol>
+   </dd>
 
    <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method steps are:</dt>
 

--- a/source
+++ b/source
@@ -4815,15 +4815,6 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
     </ul>
    </dd>
 
-   <dt>Unicode</dt>
-   <dd>
-    <p>The following terms are defined in <cite>Unicode</cite>: <ref>UNICODE</ref></p>
-
-    <ul class="brief">
-     <li><dfn data-x-href="https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries">grapheme cluster</dfn></li>
-    </ul>
-   </dd>
-
    <dt>Web App Manifest</dt>
 
    <dd>
@@ -74916,17 +74907,21 @@ try {
    <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method</dt>
 
    <dd>
-    <p>Splits the given range of the text into <span
-    data-x="grapheme cluster">grapheme clusters</span>, and returns the positional data for each
-    cluster. The range includes the character at the <var>start</var> index but stops before the
-    <var>end</var> index. The result is a list of new <code>TextCluster</code> objects. These
-    objects are opaque as they encapsulate the complete text that was segmented, along with the
+    <p>Splits the given range of the text into clusters and returns the positional data for each
+    cluster. The range includes the character at the <var>start</var> index  but stops before the
+    <var>end</var> index. Each cluster represents a minimal group of characters such that their
+    corresponding glyphs cannot be broken down any further, and each character in the range is part
+    of only one cluster. If a cluster is only partially contained by the given character range, it
+    should still be included in the returned list.</p>
+
+    <p>The result is a list of new <code>TextCluster</code> objects. These objects are opaque as
+    they encapsulate the complete text that was segmented, along with the
     <code>CanvasTextDrawingStyles</code> values that were active at the time <code
     data-x="dom-context-2d-measureText">measureText()</code> was called. Note that <code
-    data-x="dom-context-2d-textAlign">textAlign</code> and
-    <code data-x="dom-context-2d-textBaseline">textBaseline</code> are exceptions, as they are explicitly set attributes and are handled separately. Each
-    <code>TextCluster</code> object has members behaving as described in the following list:
-    <ref>UNICODE</ref></p>
+    data-x="dom-context-2d-textAlign">textAlign</code> and <code
+    data-x="dom-context-2d-textBaseline">textBaseline</code> are exceptions, as they are explicitly
+    set attributes and are handled separately. Each <code>TextCluster</code> object has members
+    behaving as described in the following list:</p>
 
     <dl>
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-x">x</code></dfn> attribute</dt>

--- a/source
+++ b/source
@@ -70812,22 +70812,6 @@ interface <dfn interface>TextCluster</dfn> {
     readonly attribute <span>CanvasTextBaseline</span> <span data-x="dom-TextCluster-baseline">baseline</span>;
 };
 
-dictionary <dfn dictionary>ImageDataSettings</dfn> {
-  <span>PredefinedColorSpace</span> <span data-x="dom-PredefinedColorSpace-srgb">colorSpace</span>;
-};
-
-[Exposed=(Window,Worker),
- <span>Serializable</span>]
-interface <dfn interface>ImageData</dfn> {
-  <span data-x="dom-imagedata">constructor</span>(unsigned long sw, unsigned long sh, optional <span>ImageDataSettings</span> settings = {});
-  <span data-x="dom-imagedata-with-data">constructor</span>(<span data-x="idl-Uint8ClampedArray">Uint8ClampedArray</span> data, unsigned long sw, optional unsigned long sh, optional <span>ImageDataSettings</span> settings = {});
-
-  readonly attribute unsigned long <span data-x="dom-imagedata-width">width</span>;
-  readonly attribute unsigned long <span data-x="dom-imagedata-height">height</span>;
-  readonly attribute <span data-x="idl-Uint8ClampedArray">Uint8ClampedArray</span> <span data-x="dom-imagedata-data">data</span>;
-  readonly attribute <span>PredefinedColorSpace</span> <span data-x="dom-imagedata-colorSpace">colorSpace</span>;
-};
-
 [Exposed=(Window,Worker)]
 interface <dfn interface>Path2D</dfn> {
   <span data-x="dom-Path2D">constructor</span>(optional (<span>Path2D</span> or DOMString) path);
@@ -74885,9 +74869,9 @@ try {
    baseline</span>. (Zero if the given baseline is the <span>ideographic-under
    baseline</span>.)</p></dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method steps are:</dt>
+   <dt var-scope>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method steps are:</dt>
 
-   <dd>
+   <dd var-scope>
     <ol>
      <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
      greater or equal than the number of <span data-x="code point">code points</span> in the
@@ -74911,9 +74895,9 @@ try {
     </ol>
   </dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method steps are:</dt>
+   <dt var-scope>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method steps are:</dt>
 
-   <dd>
+   <dd var-scope>
     <ol>
      <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
      greater or equal than the number of <span data-x="code point">code points</span> in the
@@ -74938,9 +74922,9 @@ try {
     with accents that go beyond the flow of text will have a different paint bounding box.</p>
    </dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method steps are:</dt>
+   <dt var-scope>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method steps are:</dt>
 
-   <dd>
+   <dd var-scope>
     <ol>
      <li><p>Let <var>glyphs</var> be the result of the
      <span>text preparation algorithm</span> when <code
@@ -74957,9 +74941,9 @@ try {
     direction.</p>
    </dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters-complete">getTextClusters(<var>options</var>)</code></dfn> method steps are:</dt>
+   <dt var-scope>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters-complete">getTextClusters(<var>options</var>)</code></dfn> method steps are:</dt>
 
-   <dd>
+   <dd var-scope>
    <ol>
     <li><p>Let <var>start</var> be 0.</p></li>
 
@@ -74970,9 +74954,9 @@ try {
    </ol>
    </dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method steps are:</dt>
+   <dt var-scope>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method steps are:</dt>
 
-   <dd>
+   <dd var-scope>
     <ol>
      <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
      greater or equal than the number of <span data-x="code point">code points</span> in the

--- a/source
+++ b/source
@@ -4293,7 +4293,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
          <dfn data-x="DOMPointInit-x" data-x-href="https://drafts.csswg.org/geometry/#dom-dompointinit-x">x</dfn> and
          <dfn data-x="DOMPointInit-y" data-x-href="https://drafts.csswg.org/geometry/#dom-dompointinit-y">y</dfn> members</li>
       <li><dfn data-x-href="https://drafts.csswg.org/geometry/#matrix-multiply">Matrix multiplication</dfn></li>
-      <li><dfn data-x-href="https://www.w3.org/TR/geometry-1/#domrectreadonly">DOMRectReadOnly</dfn></li>
+      <li><dfn data-x-href="https://drafts.csswg.org/geometry/#domrectreadonly"><code>DOMRectReadOnly</code></dfn></li>
     </ul>
 
     <p>The following terms are defined in the <cite>CSS Scoping</cite>: <ref>CSSSCOPING</ref></p>
@@ -70681,18 +70681,18 @@ interface mixin <dfn interface>CanvasUserInterface</dfn> {
 
 
 dictionary <dfn dictionary>TextClusterOptions</dfn> {
-  <span>CanvasTextAlign</span> align;
-  <span>CanvasTextBaseline</span> baseline;
-  double x;
-  double y;
+  <span>CanvasTextAlign</span> <dfn dict-member for="TextClusterOptions" data-x="dom-TextClusterOptions-align">align</dfn>;
+  <span>CanvasTextBaseline</span> <dfn dict-member for="TextClusterOptions" data-x="dom-TextClusterOptions-baseline">baseline</dfn>;
+  double <dfn dict-member for="TextClusterOptions" data-x="dom-TextClusterOptions-x">x</dfn>;
+  double <dfn dict-member for="TextClusterOptions" data-x="dom-TextClusterOptions-y">y</dfn>;
 };
 
 interface mixin <dfn interface>CanvasText</dfn> {
   // text (see also the <span>CanvasPathDrawingStyles</span> and <span>CanvasTextDrawingStyles</span> interfaces)
   undefined <span data-x="dom-context-2d-fillText">fillText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
   undefined <span data-x="dom-context-2d-strokeText">strokeText</span>(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
-  undefined <span data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options);
-  undefined <span data-x="dom-context-2d-strokeTextCluster">strokeTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options);
+  undefined <span data-x="dom-context-2d-fillTextCluster">fillTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options = {});
+  undefined <span data-x="dom-context-2d-strokeTextCluster">strokeTextCluster</span>(<span>TextCluster</span> cluster, double x, double y, optional <span>TextClusterOptions</span> options = {});
   <span>TextMetrics</span> <span data-x="dom-context-2d-measureText">measureText</span>(DOMString text);
 };
 
@@ -74692,12 +74692,16 @@ try {
 
    <li>
     <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-    data-x="">options["x"]</code> value, move all the shapes in <var>glyphs</var> to the right by
-    <code data-x="">options["x"] &minus; cluster["x"]</code>.</p>
+    data-x="dom-TextClusterOptions-x">options["x"]</code> value, move all the shapes in
+    <var>glyphs</var> to the right by <code data-x=""><span
+    data-x="dom-TextClusterOptions-x">options["x"]</span> &minus; <span
+    data-x="dom-TextCluster-x">cluster["x"]</span></code>.</p>
 
     <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-    data-x="">options["y"]</code> value, move all the shapes in <var>glyphs</var> down by <code
-    data-x="">options["y"] &minus; cluster["y"]</code>.</p>
+    data-x="dom-TextClusterOptions-y">options["y"]</code> value, move all the shapes in
+    <var>glyphs</var> down by <code data-x=""><span
+    data-x="dom-TextClusterOptions-y">options["y"]</span> &minus; <span
+    data-x="dom-TextCluster-y">cluster["y"]</span></code>.</p>
    </li>
 
    <li>
@@ -74865,7 +74869,7 @@ try {
    baseline</span>. (Zero if the given baseline is the <span>ideographic-under
    baseline</span>.)</p></dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method, when invoked, must run these steps:</dt>
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method steps are:</dt>
 
    <dd>
     <ol>
@@ -74891,7 +74895,7 @@ try {
     </ol>
   </dd>
 
-   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method, when invoked, must run these steps:</dt>
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method steps are:</dt>
 
    <dd>
     <ol>
@@ -74994,19 +74998,20 @@ try {
 
       <dd><p>The align for the specific point returned for the cluster. If a
       <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
-      <code data-x="">options["align"]</code>, this will be the assigned value. Otherwise, it will be
-      set as the <code data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this
-      doesn't change the origin of the coordinate system, just which point is specified for each
-      cluster.</p></dd>
+      <code data-x="dom-TextClusterOptions-align">options["align"]</code>, this will be the assigned
+      value. Otherwise, it will be set as the <code
+      data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this doesn't change
+      the origin of the coordinate system, just which point is specified for each cluster.</p></dd>
 
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-baseline">baseline</code></dfn> attribute</dt>
 
       <dd><p>The baseline for the specific point returned for the cluster. If a
       <code>TextClusterOptions</code> options dictionary is passed, and it has a value for
-      <code data-x="">options["baseline"]</code>, this will be the assigned value. Otherwise, it will
-      be set as the <code data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note
-      that this doesn't change the origin of the coordinate system, just which point is specified
-      for each cluster.</p></dd>
+      <code data-x="dom-TextClusterOptions-baseline">options["baseline"]</code>, this will be the
+      assigned value. Otherwise, it will be set as the <code
+      data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note that this doesn't
+      change the origin of the coordinate system, just which point is specified for each cluster.
+      </p></dd>
     </dl>
    </dd>
   </dl>
@@ -75020,6 +75025,8 @@ try {
   <p class="note">A future version of the 2D context API might provide a way to render fragments of
   documents, rendered using CSS, straight to the canvas. This would be provided in preference to a
   dedicated way of doing multiline layout.</p>
+
+
 
   <h6>Drawing paths to the canvas</h6>
 

--- a/source
+++ b/source
@@ -4293,7 +4293,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
          <dfn data-x="DOMPointInit-x" data-x-href="https://drafts.csswg.org/geometry/#dom-dompointinit-x">x</dfn> and
          <dfn data-x="DOMPointInit-y" data-x-href="https://drafts.csswg.org/geometry/#dom-dompointinit-y">y</dfn> members</li>
       <li><dfn data-x-href="https://drafts.csswg.org/geometry/#matrix-multiply">Matrix multiplication</dfn></li>
-      <li><dfn data-x-href="https://www.w3.org/TR/geometry-1/#DOMRect">DOMRectReadOnly and DOMRect</dfn></li>
+      <li><dfn data-x-href="https://www.w3.org/TR/geometry-1/#domrectreadonly">DOMRectReadOnly</dfn></li>
     </ul>
 
     <p>The following terms are defined in the <cite>CSS Scoping</cite>: <ref>CSSSCOPING</ref></p>
@@ -70794,8 +70794,8 @@ interface <dfn interface>TextMetrics</dfn> {
   readonly attribute double <span data-x="dom-textmetrics-alphabeticBaseline">alphabeticBaseline</span>;
   readonly attribute double <span data-x="dom-textmetrics-ideographicBaseline">ideographicBaseline</span>;
 
-  sequence&lt;<span data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</span>> <span data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(unsigned long start, unsigned long end);
-  <span data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</span> <span data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(unsigned long start, unsigned long end);
+  sequence&lt;<span>DOMRectReadOnly</span>> <span data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(unsigned long start, unsigned long end);
+  <span>DOMRectReadOnly</span> <span data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(unsigned long start, unsigned long end);
   unsigned long <span data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(double offset);
   sequence&lt;<span>TextCluster</span>> <span data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(unsigned long start, unsigned long end, optional <span>TextClusterOptions</span> options);
 };
@@ -74589,12 +74589,12 @@ try {
 
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(<var>start</var>, <var>end</var>)</code></dt>
 
-   <dd><p>Returns a list of <code data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</code> objects corresponding to the selection
+   <dd><p>Returns a list of <code>DOMRectReadOnly</code> objects corresponding to the selection
    rectangles for the given range in the string.</p></dd>
 
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(<var>start</var>, <var>end</var>)</code></dt>
 
-   <dd><p>Returns a <code data-x="DOMRectReadOnly and DOMRect">DOMRectReadOnly</code> that corresponds to the bounding rectangle for the
+   <dd><p>Returns a <code>DOMRectReadOnly</code> that corresponds to the bounding rectangle for the
    given range in the string.</p></dd>
 
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(<var>offset</var>)</code></dt>
@@ -74674,58 +74674,58 @@ try {
   argument. Specifically, when the method is invoked, the user agent must run these steps:</p>
 
   <ol>
-    <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
+   <li><p>If any of the arguments are infinite or NaN, then return.</p></li>
 
-    <li><p>Run the <span>text preparation algorithm</span>, passing it the complete text and the
-    <code>CanvasTextDrawingStyles</code> from the opaque <code>TextCluster</code>
-    <var>cluster</var>, with the exception of <code
-    data-x="dom-context-2d-textAlign">textAlign</code> and <code
-    data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
-    data-x="dom-TextCluster-align">align</code> and <code
-    data-x="dom-TextCluster-baseline">baseline</code> attributes of <var>cluster</var>. Let
-    <var>glyphs</var> be the result.</p></li>
+   <li><p>Run the <span>text preparation algorithm</span>, passing it the complete text and the
+   <code>CanvasTextDrawingStyles</code> from the opaque <code>TextCluster</code>
+   <var>cluster</var>, with the exception of <code
+   data-x="dom-context-2d-textAlign">textAlign</code> and <code
+   data-x="dom-context-2d-textBaseline">textBaseline</code>, which are taken from the <code
+   data-x="dom-TextCluster-align">align</code> and <code
+   data-x="dom-TextCluster-baseline">baseline</code> attributes of <var>cluster</var>. Let
+   <var>glyphs</var> be the result.</p></li>
 
-    <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
-    data-x="code point">code points</span> within the range <code
-    data-x="dom-TextCluster-begin">cluster["begin"]</code> to <code
-    data-x="dom-TextCluster-end">cluster["end"]</code>.</p></li>
+   <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
+   data-x="code point">code points</span> within the range <code
+   data-x="dom-TextCluster-begin">cluster["begin"]</code> to <code
+   data-x="dom-TextCluster-end">cluster["end"]</code>.</p></li>
 
-    <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
-    <span data-x="'px'">CSS pixels</span> and down by <var>y</var> <span data-x="'px'">CSS
-    pixels</span>.</p></li>
+   <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
+   <span data-x="'px'">CSS pixels</span> and down by <var>y</var> <span data-x="'px'">CSS
+   pixels</span>.</p></li>
 
-    <li>
-      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-      data-x="">options["x"]</code> value, move all the shapes in <var>glyphs</var> to the right by
-      <code data-x="">options["x"] &minus; cluster["x"]</code>.</p>
+   <li>
+    <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
+    data-x="">options["x"]</code> value, move all the shapes in <var>glyphs</var> to the right by
+    <code data-x="">options["x"] &minus; cluster["x"]</code>.</p>
 
-      <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
-      data-x="">options["y"]</code> value, move all the shapes in <var>glyphs</var> down by <code
-      data-x="">options["y"] &minus; cluster["y"]</code>.</p>
-    </li>
+    <p>If a <code>TextClusterOptions</code> options dictionary is passed and it has an <code
+    data-x="">options["y"]</code> value, move all the shapes in <var>glyphs</var> down by <code
+    data-x="">options["y"] &minus; cluster["y"]</code>.</p>
+   </li>
 
-    <li>
-      <p>Paint the shapes given in <var>glyphs</var>, as transformed by the <span
-      data-x="dom-context-2d-transformation">current transformation matrix</span>, with each <span
-      data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
-      coordinate space unit.</p>
+   <li>
+     <p>Paint the shapes given in <var>glyphs</var>, as transformed by the <span
+     data-x="dom-context-2d-transformation">current transformation matrix</span>, with each <span
+     data-x="'px'">CSS pixel</span> in the coordinate space of <var>glyphs</var> mapped to one
+     coordinate space unit.</p>
 
-      <p>For <code data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>,
-      <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span>
-      must be applied to the shapes and <span>this</span>'s <span
-      data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored. For
-      <code data-x="dom-context-2d-strokeTextCluster">strokeTextCluster()</code>, the reverse holds:
-      <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke
-      style</span> must be applied to the result of <span data-x="trace a path">tracing</span> the
-      shapes using the object implementing the <code>CanvasText</code> interface for the line
-      styles, and <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill
-      style</span> must be ignored.</p>
+     <p>For <code data-x="dom-context-2d-fillTextCluster">fillTextCluster()</code>,
+     <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill style</span>
+     must be applied to the shapes and <span>this</span>'s <span
+     data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke style</span> must be ignored. For
+     <code data-x="dom-context-2d-strokeTextCluster">strokeTextCluster()</code>, the reverse holds:
+     <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-stroke-style">stroke
+     style</span> must be applied to the result of <span data-x="trace a path">tracing</span> the
+     shapes using the object implementing the <code>CanvasText</code> interface for the line
+     styles, and <span>this</span>'s <span data-x="concept-CanvasFillStrokeStyles-fill-style">fill
+     style</span> must be ignored.</p>
 
-      <p>These shapes are painted without affecting the current path, and are subject to <span
-      data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
-      alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
-      operator</span>.</p>
-    </li>
+     <p>These shapes are painted without affecting the current path, and are subject to <span
+     data-x="shadows">shadow effects</span>, <span data-x="concept-canvas-global-alpha">global
+     alpha</span>, the <span>clipping region</span>, and the <span>current compositing and blending
+     operator</span>.</p>
+   </li>
   </ol>
 
   <p class="note">By setting <code data-x="">options["x"]</code> and <code

--- a/source
+++ b/source
@@ -74865,27 +74865,53 @@ try {
    baseline</span>. (Zero if the given baseline is the <span>ideographic-under
    baseline</span>.)</p></dd>
 
-   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method</dt>
-
-   <dd><p>Returns the set of rectangles, in <span data-x="'px'">CSS pixels</span>, that the user
-   agent would render as a selection to select the characters within the specified range. The
-   range includes the character at the <var>start</var> index but stops before the <var>end</var>
-   index. The positions are returned relative to the alignment point given by the
-   <code data-x="dom-context-2d-textAlign">textAlign</code> and <code
-   data-x="dom-context-2d-textBaseline">textBaseline</code> attributes.</p></dd>
-
-   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method</dt>
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method, when invoked, must run these steps:</dt>
 
    <dd>
-    <p>Returns the rectangle equivalent to the box described by <code
-    data-x="dom-textmetrics-actualBoundingBoxLeft">actualBoundingBoxLeft</code>,  <code
-    data-x="dom-textmetrics-actualBoundingBoxRight">actualBoundingBoxRight</code>,  <code
-    data-x="dom-textmetrics-actualBoundingBoxAscent">actualBoundingBoxAscent</code>,  <code
-    data-x="dom-textmetrics-actualBoundingBoxDescent">actualBoundingBoxDescent</code>, for the given
-    range. The range includes the character at the <var>start</var> index but stops before the
-    <var>end</var> index. The positions are returned relative to the alignment point given by the
-    <code data-x="dom-context-2d-textAlign">textAlign</code> and <code
-    data-x="dom-context-2d-textBaseline">textBaseline</code> attributes.</p>
+    <ol>
+     <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
+     greater or equal than the number of <span data-x="code point">code points</span> in the
+     measured text, or <var>end</var> is greater than the number of <span
+     data-x="code point">code points</span> in the measured text, then throw an
+     <span>"<code>IndexSizeError</code>"</span> <code>DOMException</code>.</p></li>
+
+     <li><p>Let <var>element</var> be <span>inline box</span> returned by the
+     <span>text preparation algorithm</span> when <code
+     data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
+
+     <li><p>Let <var>rects</var> be a list of <code>DOMRectReadOnly</code> objects.</p></li>
+
+     <li><p>Fill <var>rects</var> with the selection rectangles the user agent would render if the
+     <span data-x="concept-textarea/input-selection">selection</span> was set to a range in
+     <var>element</var>, with the first included <span>code point</span> at the <var>start</var>th
+     position (in logical order) and the last included code point at the <var>(end-1)</var>th
+     position.</p></li>
+
+     <li><p>Return <var>rects</var>.</p></li>
+    </ol>
+  </dd>
+
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method, when invoked, must run these steps:</dt>
+
+   <dd>
+    <ol>
+     <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
+     greater or equal than the number of <span data-x="code point">code points</span> in the
+     measured text, or <var>end</var> is greater than the number of <span
+     data-x="code point">code points</span> in the measured text, then throw an
+     <span>"<code>IndexSizeError</code>"</span> <code>DOMException</code>.</p></li>
+
+     <li><p>Let <var>glyphs</var> be the result of the
+     <span>text preparation algorithm</span> when <code
+     data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
+
+     <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
+     data-x="code point">code points</span> within the range that includes the <var>start</var>
+     index but stops before the <var>end</var> index.</p></li>
+
+     <li><p>Return a <code>DOMRectReadOnly</code> representing the bounding box of
+     <var>glyphs</var>.</p></li>
+    </ol>
 
     <p class="note">The bounding box can be (and usually is) different from the selection
     rectangles, which are based on the advance of the text. A font that is particularly slanted or

--- a/source
+++ b/source
@@ -74885,19 +74885,19 @@ try {
     <p class="note">The bounding box can be (and usually is) different from the selection
     rectangles, which are based on the advance of the text. A font that is particularly slanted or
     with accents that go beyond the flow of text will have a different paint bounding box.</p>
-  </dd>
+   </dd>
 
-  <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method</dt>
+   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset(<var>offset</var>)</code></dfn> method</dt>
 
-  <dd><p>Returns the string index for the character at the given offset distance from the start
-  position of the text run, relative to the alignment point given by the <code
-  data-x="dom-context-2d-textAlign">textAlign</code> attribute, with offset always increasing left
-  to right (negative offsets are valid). Values to the left or right of the text bounds will return
-  0 or the length of the text, depending on the writing direction.</p></dd>
+   <dd><p>Returns the string index for the character at the given offset distance from the start
+   position of the text run, relative to the alignment point given by the <code
+   data-x="dom-context-2d-textAlign">textAlign</code> attribute, with offset always increasing left
+   to right (negative offsets are valid). Values to the left or right of the text bounds will return
+   0 or the length of the text, depending on the writing direction.</p></dd>
 
-  <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method</dt>
+   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method</dt>
 
-  <dd>
+   <dd>
     <p>Splits the given range of the text into <span
     data-x="grapheme cluster">grapheme clusters</span>, and returns the positional data for each
     cluster. The range includes the character at the <var>start</var> index but stops before the
@@ -74973,7 +74973,7 @@ try {
       that this doesn't change the origin of the coordinate system, just which point is specified
       for each cluster.</p></dd>
     </dl>
-  </dd>
+   </dd>
   </dl>
 
   <p class="note">Glyphs rendered using <code data-x="dom-context-2d-fillText">fillText()</code> and

--- a/source
+++ b/source
@@ -74950,11 +74950,11 @@ try {
      <var>offset</var> in <var>glyphs</var>.</p></li>
 
      <li><p>Return <var>index</var>.</p></li>
-
-     <p class="note">Note that negative values for <var>offset</var> are valid. Values to the left
-     or right of the text bounds will return 0 or the length of the text, depending on the writing
-     direction.</p>
     </ol>
+
+    <p class="note">Negative values for <var>offset</var> are valid. Values to the left
+    or right of the text bounds will return 0 or the length of the text, depending on the writing
+    direction.</p>
    </dd>
 
    <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters-complete">getTextClusters(<var>options</var>)</code></dfn> method steps are:</dt>

--- a/source
+++ b/source
@@ -74944,29 +74944,43 @@ try {
    to right (negative offsets are valid). Values to the left or right of the text bounds will return
    0 or the length of the text, depending on the writing direction.</p></dd>
 
-   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method</dt>
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method steps are:</dt>
 
    <dd>
-    <p>Splits the given range of the text into clusters and returns the positional data for each
-    cluster. The range includes the character at the <var>start</var> index  but stops before the
-    <var>end</var> index. Each cluster represents a minimal group of characters such that their
-    corresponding glyphs cannot be broken down any further, and each character in the range is part
-    of only one cluster. If a cluster is only partially contained by the given character range, it
-    should still be included in the returned list.</p>
+    <ol>
+     <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
+     greater or equal than the number of <span data-x="code point">code points</span> in the
+     measured text, or <var>end</var> is greater than the number of <span
+     data-x="code point">code points</span> in the measured text, then throw an
+     <span>"<code>IndexSizeError</code>"</span> <code>DOMException</code>.</p></li>
 
-    <p>The result is a list of new <code>TextCluster</code> objects. These objects are opaque as
-    they encapsulate the complete text that was segmented, along with the
-    <code>CanvasTextDrawingStyles</code> values that were active at the time <code
-    data-x="dom-context-2d-measureText">measureText()</code> was called. Note that <code
-    data-x="dom-context-2d-textAlign">textAlign</code> and <code
-    data-x="dom-context-2d-textBaseline">textBaseline</code> are exceptions, as they are explicitly
-    set attributes and are handled separately. Each <code>TextCluster</code> object has members
-    behaving as described in the following list:</p>
+     <li><p>Let <var>glyphs</var> be the result of the
+     <span>text preparation algorithm</span> when <code
+     data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
 
-    <dl>
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-x">x</code></dfn> attribute</dt>
+     <li><p>Filter <var>glyphs</var> to include only the glyphs that correspond to <span
+     data-x="code point">code points</span> within the range that includes the <var>start</var>
+     index but stops before the <var>end</var> index.</p></li>
 
-      <dd>
+     <li>
+      <p>Split the given range of the text into clusters. Each cluster represents a minimal group
+      of characters such that their corresponding glyphs cannot be broken down any further, and each
+      character in the range is part of only one cluster. If a cluster is only partially contained by
+      the given character range, it should still be included.</p>
+
+      <p>Return these clusters as a list of new <code>TextCluster</code> objects. These objects are
+      opaque as they encapsulate the complete text that was segmented, along with the
+      <code>CanvasTextDrawingStyles</code> values that were active at the time <code
+      data-x="dom-context-2d-measureText">measureText()</code> was called. Note that <code
+      data-x="dom-context-2d-textAlign">textAlign</code> and <code
+      data-x="dom-context-2d-textBaseline">textBaseline</code> are exceptions, as they are
+      explicitly set attributes and are handled separately. Each <code>TextCluster</code> object has
+      members behaving as described in the following list:</p>
+
+      <dl>
+       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-x">x</code></dfn> attribute</dt>
+
+       <dd>
         <p>The x coordinate of the cluster, on a coordinate space using <span
         data-x="'px'">CSS pixels</span>, with its origin at the anchor point defined by the <code
         data-x="dom-context-2d-textAlign">textAlign</code> attribute (at the time <code
@@ -74979,11 +74993,11 @@ try {
         to the <code data-x="dom-context-2d-textAlign-left">left</code> of each cluster). The
         selection criteria for this alignment point is explained in the section for this attribute
         of the cluster.</p>
-      </dd>
+       </dd>
 
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-y">y</code></dfn> attribute</dt>
+       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-y">y</code></dfn> attribute</dt>
 
-      <dd>
+       <dd>
         <p>The y coordinate of the cluster, on a coordinate space using <span
         data-x="'px'">CSS pixels</span>, with its origin at the anchor point defined by the <code
         data-x="dom-context-2d-textBaseline">textBaseline</code> attribute (at the time <code
@@ -74996,35 +75010,37 @@ try {
         to the <code data-x="dom-context-2d-textBaseline-top">top</code> of each cluster). The
         selection criteria for this alignment point is explained in the section for this attribute
         of the cluster.</p>
-      </dd>
+       </dd>
 
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-start">start</code></dfn> attribute</dt>
+       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-start">start</code></dfn> attribute</dt>
 
-      <dd><p>The starting index for the range of <span data-x="code point">code points</span> that are
-      rendered as this cluster.</p></dd>
+       <dd><p>The starting index for the range of <span data-x="code point">code points</span> that are
+       rendered as this cluster.</p></dd>
 
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-end">end</code></dfn> attribute</dt>
+       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-end">end</code></dfn> attribute</dt>
 
-      <dd><p>The index immediately after the last included index for the range of <span
-      data-x="code point">code points</span> that are rendered as this cluster.</p></dd>
+       <dd><p>The index immediately after the last included index for the range of <span
+       data-x="code point">code points</span> that are rendered as this cluster.</p></dd>
 
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-align">align</code></dfn> attribute</dt>
+       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-align">align</code></dfn> attribute</dt>
 
-      <dd><p>The align for the specific point returned for the cluster. Let it be
-      <var>options</var>["<code data-x="dom-TextClusterOptions-align">align</code>"] if it <span
-      data-x="map exists">exists</span>; otherwise, the <code
-      data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this doesn't change
-      the origin of the coordinate system, just which point is specified for each cluster.</p></dd>
+       <dd><p>The align for the specific point returned for the cluster. Let it be
+       <var>options</var>["<code data-x="dom-TextClusterOptions-align">align</code>"] if it <span
+       data-x="map exists">exists</span>; otherwise, the <code
+       data-x="dom-context-2d-textAlign">textAlign</code> attribute. Note that this doesn't change
+       the origin of the coordinate system, just which point is specified for each cluster.</p></dd>
 
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-baseline">baseline</code></dfn> attribute</dt>
+       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-baseline">baseline</code></dfn> attribute</dt>
 
-      <dd><p>The baseline for the specific point returned for the cluster. Let it be
-      <var>options</var>["<code data-x="dom-TextClusterOptions-baseline">baseline</code>"] if it
-      <span data-x="map exists">exists</span>; otherwise, the <code
-      data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note that this doesn't
-      change the origin of the coordinate system, just which point is specified for each cluster.
-      </p></dd>
-    </dl>
+       <dd><p>The baseline for the specific point returned for the cluster. Let it be
+       <var>options</var>["<code data-x="dom-TextClusterOptions-baseline">baseline</code>"] if it
+       <span data-x="map exists">exists</span>; otherwise, the <code
+       data-x="dom-context-2d-textBaseline">textBaseline</code> attribute. Note that this doesn't
+       change the origin of the coordinate system, just which point is specified for each cluster.
+       </p></dd>
+      </dl>
+     </li>
+    </ol>
    </dd>
   </dl>
 

--- a/source
+++ b/source
@@ -70805,7 +70805,7 @@ interface <dfn interface>TextCluster</dfn> {
     // opaque object
     readonly attribute double <span data-x="dom-TextCluster-x">x</span>;
     readonly attribute double <span data-x="dom-TextCluster-y">y</span>;
-    readonly attribute unsigned long <span data-x="dom-TextCluster-begin">begin</span>;
+    readonly attribute unsigned long <span data-x="dom-TextCluster-start">start</span>;
     readonly attribute unsigned long <span data-x="dom-TextCluster-end">end</span>;
     readonly attribute <span>CanvasTextAlign</span> <span data-x="dom-TextCluster-align">align</span>;
     readonly attribute <span>CanvasTextBaseline</span> <span data-x="dom-TextCluster-baseline">baseline</span>;
@@ -74683,7 +74683,7 @@ try {
 
    <li><p>Filter <var>glyphs</var> to include only the glyphs that contain <span
    data-x="code point">code points</span> within the range <code
-   data-x="dom-TextCluster-begin">cluster["begin"]</code> to <code
+   data-x="dom-TextCluster-start">cluster["start"]</code> to <code
    data-x="dom-TextCluster-end">cluster["end"]</code>.</p></li>
 
    <li><p>Move all the shapes in <var>glyphs</var> to the right by <var>x</var>
@@ -74954,7 +74954,7 @@ try {
         of the cluster.</p>
       </dd>
 
-      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-begin">begin</code></dfn> attribute</dt>
+      <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-start">start</code></dfn> attribute</dt>
 
       <dd><p>The starting index for the range of <span data-x="code point">code points</span> that are
       rendered as this cluster.</p></dd>

--- a/source
+++ b/source
@@ -74584,7 +74584,7 @@ try {
 
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(<var>offset</var>)</code></dt>
 
-   <dd><p>Returns the index for the character at the given offset from the start of the text.</p></dd>
+   <dd><p>Returns the index for the <span>code unit</span> at the given offset from the start of the text.</p></dd>
 
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters-complete">getTextClusters</span>([ <var>options</var> ])</code></dt>
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(<var>start</var>, <var>end</var> [, <var>options</var> ])</code></dt>
@@ -74690,7 +74690,7 @@ try {
    <var>cluster</var>. Let <var>glyphs</var> be the result.</p></li>
 
    <li><p>Filter <var>glyphs</var> to include only the glyphs that correspond to <span
-   data-x="code point">code points</span> within the range <var>cluster</var>["<code
+   data-x="code unit">code units</span> within the range <var>cluster</var>["<code
    data-x="dom-TextCluster-start">start</code>"] to <var>cluster</var>["<code
    data-x="dom-TextCluster-end">end</code>"].</p></li>
 
@@ -74874,9 +74874,9 @@ try {
    <dd var-scope>
     <ol>
      <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
-     greater or equal than the number of <span data-x="code point">code points</span> in the
+     greater or equal than the number of <span data-x="code unit">code units</span> in the
      measured text, or <var>end</var> is greater than the number of <span
-     data-x="code point">code points</span> in the measured text, then throw an
+     data-x="code unit">code units</span> in the measured text, then throw an
      <span>"<code>IndexSizeError</code>"</span> <code>DOMException</code>.</p></li>
 
      <li><p>Let <var>element</var> be <span>inline box</span> returned by the
@@ -74887,8 +74887,8 @@ try {
 
      <li><p>Fill <var>rects</var> with the selection rectangles the user agent would render if the
      <span data-x="concept-textarea/input-selection">selection</span> was set to a range in
-     <var>element</var>, with the first included <span>code point</span> at the <var>start</var>th
-     position (in logical order) and the last included code point at the <var>(end-1)</var>th
+     <var>element</var>, with the first included <span>code unit</span> at the <var>start</var>th
+     position (in logical order) and the last included <span>code unit</span> at the <var>(end-1)</var>th
      position.</p></li>
 
      <li><p>Return <var>rects</var>.</p></li>
@@ -74900,9 +74900,9 @@ try {
    <dd var-scope>
     <ol>
      <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
-     greater or equal than the number of <span data-x="code point">code points</span> in the
+     greater or equal than the number of <span data-x="code unit">code units</span> in the
      measured text, or <var>end</var> is greater than the number of <span
-     data-x="code point">code points</span> in the measured text, then throw an
+     data-x="code unit">code units</span> in the measured text, then throw an
      <span>"<code>IndexSizeError</code>"</span> <code>DOMException</code>.</p></li>
 
      <li><p>Let <var>glyphs</var> be the result of the
@@ -74910,7 +74910,7 @@ try {
      data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
 
      <li><p>Filter <var>glyphs</var> to include only the glyphs that correspond to <span
-     data-x="code point">code points</span> within the range that includes the <var>start</var>
+     data-x="code unit">code units</span> within the range that includes the <var>start</var>
      index but stops before the <var>end</var> index.</p></li>
 
      <li><p>Return a <code>DOMRectReadOnly</code> representing the bounding box of
@@ -74930,7 +74930,7 @@ try {
      <span>text preparation algorithm</span> when <code
      data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
 
-     <li><p>Let <var>index</var> be the character offset with the <var>x</var> position closest to
+     <li><p>Let <var>index</var> be the <span>code unit</span> offset with the <var>x</var> position closest to
      <var>offset</var> in <var>glyphs</var>.</p></li>
 
      <li><p>Return <var>index</var>.</p></li>
@@ -74947,7 +74947,7 @@ try {
    <ol>
     <li><p>Let <var>start</var> be 0.</p></li>
 
-    <li><p>Let <var>end</var> be the number of <span data-x="code point">code points</span> in the
+    <li><p>Let <var>end</var> be the number of <span data-x="code unit">code units</span> in the
     measured text.</p></li>
 
     <li><p>Return <code data-x="dom-textmetrics-getTextClusters">getTextClusters(start, end, options)</code>.</p></li>
@@ -74959,9 +74959,9 @@ try {
    <dd var-scope>
     <ol>
      <li><p>If either <var>start</var> or <var>end</var> are less than 0, <var>start</var> is
-     greater or equal than the number of <span data-x="code point">code points</span> in the
+     greater or equal than the number of <span data-x="code unit">code units</span> in the
      measured text, or <var>end</var> is greater than the number of <span
-     data-x="code point">code points</span> in the measured text, then throw an
+     data-x="code unit">code units</span> in the measured text, then throw an
      <span>"<code>IndexSizeError</code>"</span> <code>DOMException</code>.</p></li>
 
      <li><p>Let <var>glyphs</var> be the result of the
@@ -74969,7 +74969,7 @@ try {
      data-x="dom-context-2d-measureText">measureText()</code> was called.</p></li>
 
      <li><p>Filter <var>glyphs</var> to include only the glyphs that correspond to <span
-     data-x="code point">code points</span> within the range that includes the <var>start</var>
+     data-x="code unit">code units</span> within the range that includes the <var>start</var>
      index but stops before the <var>end</var> index.</p></li>
 
      <li>
@@ -75024,13 +75024,13 @@ try {
 
        <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-start">start</code></dfn> attribute</dt>
 
-       <dd><p>The starting index for the range of <span data-x="code point">code points</span> that are
+       <dd><p>The starting index for the range of <span data-x="code unit">code units</span> that are
        rendered as this cluster.</p></dd>
 
        <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-end">end</code></dfn> attribute</dt>
 
        <dd><p>The index immediately after the last included index for the range of <span
-       data-x="code point">code points</span> that are rendered as this cluster.</p></dd>
+       data-x="code unit">code units</span> that are rendered as this cluster.</p></dd>
 
        <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-align">align</code></dfn> attribute</dt>
 

--- a/source
+++ b/source
@@ -74851,10 +74851,11 @@ try {
 
    <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getSelectionRects">getSelectionRects(<var>start</var>, <var>end</var>)</code></dfn> method</dt>
 
-   <dd><p>Returns the set of rectangles that the UA would render as selection to select
-   a particular character range, in <span data-x="'px'">CSS pixels</span>. The positions are returned
-   relative to the alignment point given by the <code
-   data-x="dom-context-2d-textAlign">textAlign</code> and <code
+   <dd><p>Returns the set of rectangles, in <span data-x="'px'">CSS pixels</span>, that the user
+   agent would render as a selection to select the characters within the specified range. The
+   range includes the character at the <var>start</var> index but stops before the <var>end</var>
+   index. The positions are returned relative to the alignment point given by the
+   <code data-x="dom-context-2d-textAlign">textAlign</code> and <code
    data-x="dom-context-2d-textBaseline">textBaseline</code> attributes.</p></dd>
 
    <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox(<var>start</var>, <var>end</var>)</code></dfn> method</dt>
@@ -74865,8 +74866,9 @@ try {
     data-x="dom-textmetrics-actualBoundingBoxRight">actualBoundingBoxRight</code>,  <code
     data-x="dom-textmetrics-actualBoundingBoxAscent">actualBoundingBoxAscent</code>,  <code
     data-x="dom-textmetrics-actualBoundingBoxDescent">actualBoundingBoxDescent</code>, for the given
-    range. The positions are returned relative to the alignment point given by the <code
-    data-x="dom-context-2d-textAlign">textAlign</code> and <code
+    range. The range includes the character at the <var>start</var> index but stops before the
+    <var>end</var> index. The positions are returned relative to the alignment point given by the
+    <code data-x="dom-context-2d-textAlign">textAlign</code> and <code
     data-x="dom-context-2d-textBaseline">textBaseline</code> attributes.</p>
 
     <p class="note">The bounding box can be (and usually is) different from the selection
@@ -74885,9 +74887,11 @@ try {
   <dt><dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method</dt>
 
   <dd>
-    <p>Splits the given range of the text into <span data-x="grapheme cluster">grapheme clusters</span>, and returns the positional data
-    for each cluster, as a list of new <code>TextCluster</code> objects, with members behaving as
-    described in the following list: <ref>UNICODE</ref></p>
+    <p>Splits the given range of the text into <span
+    data-x="grapheme cluster">grapheme clusters</span>, and returns the positional data for each
+    cluster. The range includes the character at the <var>start</var> index but stops before the
+    <var>end</var> index. The result is a list of new <code>TextCluster</code> objects with members
+    behaving as described in the following list: <ref>UNICODE</ref></p>
 
     <dl>
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-x">x</code></dfn> attribute</dt>
@@ -74931,8 +74935,8 @@ try {
 
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-end">end</code></dfn> attribute</dt>
 
-      <dd><p>The ending index for the range of <span data-x="code point">code points</span> that are
-      rendered as this cluster.</p></dd>
+      <dd><p>The index immediately after the last included index for the range of <span
+      data-x="code point">code points</span> that are rendered as this cluster.</p></dd>
 
       <dt><dfn attribute for="TextCluster"><code data-x="dom-TextCluster-align">align</code></dfn> attribute</dt>
 

--- a/source
+++ b/source
@@ -70797,7 +70797,8 @@ interface <dfn interface>TextMetrics</dfn> {
   sequence&lt;<span>DOMRectReadOnly</span>> <span data-x="dom-textmetrics-getSelectionRects">getSelectionRects</span>(unsigned long start, unsigned long end);
   <span>DOMRectReadOnly</span> <span data-x="dom-textmetrics-getActualBoundingBox">getActualBoundingBox</span>(unsigned long start, unsigned long end);
   unsigned long <span data-x="dom-textmetrics-getIndexFromOffset">getIndexFromOffset</span>(double offset);
-  sequence&lt;<span>TextCluster</span>> <span data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(unsigned long start, unsigned long end, optional <span>TextClusterOptions</span> options);
+  sequence&lt;<span>TextCluster</span>> <span data-x="dom-textmetrics-getTextClusters-complete">getTextClusters</span>(optional <span>TextClusterOptions</span> options = {});
+  sequence&lt;<span>TextCluster</span>> <span data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(unsigned long start, unsigned long end, optional <span>TextClusterOptions</span> options = {});
 };
 
 [Exposed=(Window,Worker)]
@@ -74601,9 +74602,10 @@ try {
 
    <dd><p>Returns the index for the character at the given offset from the start of the text.</p></dd>
 
+   <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters-complete">getTextClusters</span>([ <var>options</var> ])</code></dt>
    <dt><code data-x=""><var>metrics</var>.<span subdfn data-x="dom-textmetrics-getTextClusters">getTextClusters</span>(<var>start</var>, <var>end</var> [, <var>options</var> ])</code></dt>
 
-   <dd><p>Returns a list of <code>TextCluster</code> objects, with positional data for each one.
+   <dd><p>Return a list of <code>TextCluster</code> objects, with positional data for each one.
    They correspond to splitting the text into the minimal rendering units possible. The options
    dictionary enables selecting a specific point to be returned for each cluster be specifying align
    and baseline values.</p></dd>
@@ -74953,6 +74955,19 @@ try {
      or right of the text bounds will return 0 or the length of the text, depending on the writing
      direction.</p>
     </ol>
+   </dd>
+
+   <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters-complete">getTextClusters(<var>options</var>)</code></dfn> method steps are:</dt>
+
+   <dd>
+   <ol>
+    <li><p>Let <var>start</var> be 0.</p></li>
+
+    <li><p>Let <var>end</var> be the number of <span data-x="code point">code points</span> in the
+    measured text.</p></li>
+
+    <li><p>Return <code data-x="dom-textmetrics-getTextClusters">getTextClusters(start, end, options)</code>.</p></li>
+   </ol>
    </dd>
 
    <dt>The <dfn method for="TextMetrics"><code data-x="dom-textmetrics-getTextClusters">getTextClusters(<var>start</var>, <var>end</var>, <var>options</var>)</code></dfn> method steps are:</dt>


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

This change adds the following functionalities to TextMetrics objects:
- Get the set of rectangles that the user agent would render as the selection background when a particular character range of the measured text is selected.
- Get the rectangle corresponding to the actual bounding box for a character range of the measured text. This is the equivalent to TextMetrics.actualBoundingBox restricted to the given range.
- Get the string index for the character at a given offset distance from the start position of the measured text.
- Split a character range of the measured text into grapheme clusters. That is, for the given range, it returns the minimal logical units of text, each of which can be rendered, along with their corresponding positional data. 

Additionally, a new method is added to the Canvas 2D rendering context to render these clusters. When rendering, all relevant CanvasTextDrawingStyles are used as they were when the text was measured.

See the discussion in the issue: https://github.com/whatwg/html/issues/10677

- [ ] At least two implementers are interested (and none opposed):
   * Chromium:  The new methods have been implemented (https://issues.chromium.org/u/1/issues/341213359)
   * Gecko: Position has been requested (https://github.com/mozilla/standards-positions/issues/1144)
   * WebKit: Position has been requested, and some portions have already started landing (https://github.com/WebKit/standards-positions/issues/436)
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/tree/master/html/canvas/element/text
   * https://github.com/web-platform-tests/wpt/tree/master/html/canvas/offscreen/text
   * Relevant tests: `2d.text.measure.selection-rects*`, `2d.text.measure.getActualBoundingBox*`, `2d.text.measure.index-from-offset*`, and `2d.text.measure.text-clusters*`.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/341213359
   * Gecko: …
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=284464
- [ ] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs:
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/11000/acknowledgements.html" title="Last updated on Aug 28, 2026, 3:06 PM UTC (a78cc29)">/acknowledgements.html</a>  ( <a href="https://whatpr.org/html/11000/508a037...a78cc29/acknowledgements.html" title="Last updated on Aug 28, 2026, 3:06 PM UTC (a78cc29)">diff</a> )
<a href="https://whatpr.org/html/11000/canvas.html" title="Last updated on Aug 28, 2026, 3:06 PM UTC (a78cc29)">/canvas.html</a>  ( <a href="https://whatpr.org/html/11000/508a037...a78cc29/canvas.html" title="Last updated on Aug 28, 2026, 3:06 PM UTC (a78cc29)">diff</a> )
<a href="https://whatpr.org/html/11000/infrastructure.html" title="Last updated on Aug 28, 2026, 3:06 PM UTC (a78cc29)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/11000/508a037...a78cc29/infrastructure.html" title="Last updated on Aug 28, 2026, 3:06 PM UTC (a78cc29)">diff</a> )