### PR TITLE
Add the `interestfor` attribute

### DIFF
--- a/var-click-highlighting.js
+++ b/var-click-highlighting.js
@@ -1,0 +1,83 @@
+// Derived from https://github.com/speced/bikeshed/blob/3a2640eecd45fd5d8abe5d37b5adaf23cc945b88/bikeshed/stylescript/var-click-highlighting.js with an addition for var-scope.
+/*
+Color-choosing design:
+
+* Colors are ordered by goodness.
+* On clicking a var, give it the earliest color
+    with the lowest usage in the algorithm.
+* On re-clicking, re-use the var's most recent color
+    if that's not currently being used elsewhere.
+*/
+
+const COLOR_COUNT = 7;
+
+document.addEventListener("click", e=>{
+    if(e.target.nodeName == "VAR") {
+        highlightSameAlgoVars(e.target);
+    }
+});
+
+function highlightSameAlgoVars(v) {
+    // Find the algorithm container.
+    let algoContainer = findAlgoContainer(v);
+
+    // Not highlighting document-global vars,
+    // too likely to be unrelated.
+    if(algoContainer == null) return;
+
+    const varName = nameFromVar(v);
+    if(!v.hasAttribute("data-var-color")) {
+        const newColor = chooseHighlightColor(algoContainer, v);
+        for(const el of algoContainer.querySelectorAll("var")) {
+            if(nameFromVar(el) == varName) {
+                el.setAttribute("data-var-color", newColor);
+                el.setAttribute("data-var-last-color", newColor);
+            }
+        }
+    } else {
+        for(const el of algoContainer.querySelectorAll("var")) {
+            if(nameFromVar(el) == varName) {
+                el.removeAttribute("data-var-color");
+            }
+        }
+    }
+}
+function findAlgoContainer(el) {
+    while(el != document.body) {
+        if(el.hasAttribute("data-algorithm") || el.hasAttribute("data-var-scope")) return el;
+        el = el.parentNode;
+    }
+    return null;
+}
+function nameFromVar(el) {
+    return el.textContent.replace(/(\s|\xa0)+/g, " ").trim();
+}
+function colorCountsFromContainer(container) {
+    const namesFromColor = Array.from({length:COLOR_COUNT}, x=>new Set());
+    for(let v of container.querySelectorAll("var[data-var-color]")) {
+        let color = +v.getAttribute("data-var-color");
+        namesFromColor[color].add(nameFromVar(v));
+    }
+
+    return namesFromColor.map(x=>x.size);
+}
+function leastUsedColor(colors) {
+    // Find the earliest color with the lowest count.
+    let minCount = Infinity;
+    let minColor = null;
+    for(var i = 0; i < colors.length; i++) {
+        if(colors[i] < minCount) {
+            minColor = i;
+            minCount = colors[i];
+        }
+    }
+    return minColor;
+}
+function chooseHighlightColor(container, v) {
+    const colorCounts = colorCountsFromContainer(container);
+    if(v.hasAttribute("data-var-last-color")) {
+        let color = +v.getAttribute("data-var-last-color");
+        if(colorCounts[color] == 0) return color;
+    }
+    return leastUsedColor(colorCounts);
+}


### PR DESCRIPTION
The `interestfor` attribute indicates that an element is an interest
invoker and points (via ID) at the element that should be invoked (made
visible, typically) when the user shows interest in the invoker. When
the target is a popover, it is automatically opened and closed as
interest is gained and lost. The delay before interest is gained or lost
can be customized using the `interest-delay-*` CSS properties.

The typical use case for this is hovercards and tooltips.

Keyboards, pointing devices, and touch behavior is normatively defined, and the
user agent should provide a way for the user to express interest regardless of
input modality.

Based on https://open-ui.org/components/interest-invokers.explainer/ and
the implementation in Chromium.

The `:interest-source` and `:interest-target` CSS pseudo-classes are defined here:
https://drafts.csswg.org/selectors/#interest-pseudos

The `interest-delay-*` CSS properties are defined here:
https://drafts.csswg.org/css-ui-4/#interest

***

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chromium ([Intent to Prototype](https://groups.google.com/a/chromium.org/g/blink-dev/c/UO30brSlWhs/m/gfULRkmYAgAJ), [Intent to Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/c/LLgsMjTzmAY/m/o6ymyzauAQAJ), [Intent to Extend Experiment](https://groups.google.com/a/chromium.org/g/blink-dev/c/0aqsckMRjH8/m/PQ4MfNugDQAJ)) 
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/html/semantics/the-button-element/interest-for
   * https://chromium-review.googlesource.com/c/chromium/src/+/6908595
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/326681249
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1984699
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=297786
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): N/A
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: https://github.com/w3c/aria/pull/2617
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/721
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/11006/browsers.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/browsers.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/browsers.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/form-elements.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/form-elements.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/form-elements.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/image-maps.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/image-maps.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/image-maps.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/index.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/index.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/index.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/indices.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/indices.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/indices.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/infrastructure.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/infrastructure.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/interaction.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/interaction.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/interaction.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/popover.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/popover.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/popover.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/semantics-other.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/semantics-other.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/semantics-other.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/text-level-semantics.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/text-level-semantics.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/text-level-semantics.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )
<a href="https://whatpr.org/html/11006/interestfor.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">/interestfor.html</a>  ( <a href="https://whatpr.org/html/11006/a1c1bd1...fa121b6/interestfor.html" title="Last updated on Oct 1, 2025, 11:59 AM UTC (fa121b6)">diff</a> )