### PR TITLE
Fix missing closing tags in 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,3 +21,5 @@
  If you found a broken link from another site pointing to the WHATWG site,
  please let that site know of the problem instead. Thanks!</p>
 </div>
+</body>
+</html>


### PR DESCRIPTION
This PR fixes a small HTML validation issue in the 404.html file.

### Changes made:
- Added missing `</body>` and `</html>` closing tags at the end of 404.html

### Why this change is needed:
The 404.html file was missing proper closing tags, which could cause HTML validation errors. While most browsers handle this gracefully, it's best practice to ensure all HTML documents have proper closing tags for validity and consistency.

### Testing:
- Verified the HTML is now valid
- The page continues to function as expected with the loading/failed state transitions