### PR TITLE
Use current global object in static method.

### DIFF
--- a/source
+++ b/source
@@ -126055,8 +126055,8 @@ enum <dfn enum>DOMParserSupportedType</dfn> {
   <ol>
    <li><p>Let <var>compliantHTML</var> be the result of invoking the <span
    data-x="tt-getcompliantstring">get trusted type compliant string</span> algorithm with <code
-   data-x="tt-trustedhtml">TrustedHTML</code>, <span>this</span>'s <span>relevant global
-   object</span>, <var>html</var>, "<code data-x="">Document parseHTMLUnsafe</code>", and "<code
+   data-x="tt-trustedhtml">TrustedHTML</code>, the <span>current global object</span>,
+   <var>html</var>, "<code data-x="">Document parseHTMLUnsafe</code>", and "<code
    data-x="">script</code>".</p></li>
 
    <li>


### PR DESCRIPTION
Document.parseHTMLUnsafe is a static method and doesn't have a `this`. This fixes Document.parseHTMLUnsafe's algorithm to use the `current global object`, rather than `this`' `relevant global object`.

Fix: #11778 

This is an editorial fix, so I'm not entirely sure the checklist below is meaningful. Still:

- [x] At least two implementers are interested (and none opposed):
   * Already implemented in WebKit, Gecko, Blink.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62355
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * n/a. (The tests above couldn't pass if these implementations wouldn't already pick the current global object.)
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: n/a
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/11799/dynamic-markup-insertion.html" title="Last updated on Oct 16, 2025, 12:32 PM UTC (aabc79a)">/dynamic-markup-insertion.html</a>  ( <a href="https://whatpr.org/html/11799/24fcc03...aabc79a/dynamic-markup-insertion.html" title="Last updated on Oct 16, 2025, 12:32 PM UTC (aabc79a)">diff</a> )