### PR TITLE
Add proposal for maxcount attribute

### DIFF
--- a/maxcount-attribute.md
+++ b/maxcount-attribute.md
@@ -1,0 +1,3 @@
+# Proposed maxcount attribute
+The `maxcount` attribute is a non-negative integer attribute that limits the number of values that may be selected when the `multiple` attribute is present. 
+User agents must prevent users from selecting more than maxcount files or entering more than maxcount email addresses.


### PR DESCRIPTION
This PR proposes a new `maxcount` attribute for <input> elements with the `multiple` attribute.

The `maxcount` attribute limits the number of files or email addresses a user can select/enter. User agents should prevent additional selections if the number exceeds maxcount.

Related to issue #11994.
