### PR TITLE
Introduce the new menu elements

### DIFF
--- a/source
+++ b/source
@@ -13652,11 +13652,11 @@ https://software.hixie.ch/utilities/js/live-dom-viewer/?%3C%21DOCTYPE%20HTML%3E%
    <li>elements with the <code data-x="attr-tabindex">tabindex</code> attribute specified</li>
   </ul>
 
-  <!-- TODO(dbaron): This is getting pretty complicated!  It might simplify things to introduce a
-  variant of "transparent" content models, where a content model can be transparent with
-  exceptions.  -->
-
   <h6><code>menubar</code> element inner content elements</h6>
+
+  <p class="XXX">TODO(dbaron): This is getting pretty complicated!  It might simplify things to
+  introduce a variant of "transparent" content models, where a content model can be transparent with
+  exceptions.</p>
 
   <p><dfn><code>menubar</code> element inner content elements</dfn> are the elements which are
   allowed as descendants of <code>menubar</code> elements.</p>
@@ -13741,8 +13741,8 @@ https://software.hixie.ch/utilities/js/live-dom-viewer/?%3C%21DOCTYPE%20HTML%3E%
    <li><span>phrasing content</span> that is not in the following exclusion list</li>
   </ul>
 
-  <!-- TODO(dbaron): Does this properly exclude interactive content from descendants, or only from
-  children? -->
+  <p class="XXX">TODO(dbaron): Does this properly exclude interactive content from descendants, or
+  only from children?</p>
 
   <p>The following are excluded from <span><code>menuitem</code> element inner content
   elements</span>:</p>
@@ -58717,8 +58717,6 @@ out of 233&#x2009;257&#x2009;824 bytes available&lt;/meter>&lt;/p></code></pre>
    <dd>Otherwise: Optionally, a <code>legend</code> element, followed by <span>flow content</span>.</dd>
    <dt><span data-x="concept-element-attributes">Content attributes</span>:</dt>
    <dd><span>Global attributes</span></dd>
-   <!-- TODO(domfarolino): If we end up going with fieldset for the menu elements proposal, then
-   make the disabled attribute apply to menuitem elements -->
    <dd><code data-x="attr-fieldset-disabled">disabled</code></dd>
    <dd><code data-x="attr-fieldset-checkable">checkable</code></dd>
    <dd><code data-x="attr-fae-form">form</code></dd>
@@ -58758,6 +58756,8 @@ interface <dfn interface>HTMLFieldSetElement</dfn> : <span>HTMLElement</span> {
   content) grouped together, optionally with a caption. The caption is given by the first
   <code>legend</code> element that is a child of the <code>fieldset</code> element, if any. The
   remainder of the descendants form the group.</p>
+
+  <p class="XXX">TODO(domfarolino): Make the disabled attribute apply to menuitem elements.</p>
 
   <div algorithm>
   <p>The <dfn element-attr for="fieldset"><code
@@ -65982,9 +65982,11 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    left and right arrow keys.</p>
   </div>
 
-  <!-- TODO (dbaron): Set this to true sometimes! -->
   <p>Each <code>menubar</code> or <code>menulist</code> element has a <dfn>contains invalid menu
   content</dfn> boolean, initially false.</p>
+
+  <p class="XXX">TODO (dbaron): Set <span>contains invalid menu content</span> to true
+  sometimes!</p>
 
   <p>Depending on user agent decisions about matching platform behavior, <code>menuitem</code>
   elements may activate on <code data-x="event-mouseup">mouseup</code> even when the <code
@@ -66054,8 +66056,9 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    <li>
     <p>While <var>nextList</var> is not null:</p>
 
-    <!-- TODO(dbaron): Chromium code uses (I think) a loop over "topmost popover ancestor" here
-    instead.  Should this? -->
+    <p class="XXX">TODO(dbaron): Chromium code uses (I think) a loop over "topmost popover ancestor"
+    here instead.  I think this probably should do so as well.</p>
+
     <ol>
      <li><p>Let <var>list</var> be <var>nextList</var>.</p></li>
 
@@ -66137,7 +66140,8 @@ interface <dfn interface>HTMLMenuListElement</dfn> : <span>HTMLElement</span> {
   <span>popover state</span> is not <span data-x="popover-state-no-popover">No Popover</span> by
   default, even when the <code data-x="attr-popover">popover</code> attribute is not present.</p>
 
-  <!-- TODO(dbaron): Is this a reasonable way to define a flag for two elements? -->
+  <p class="XXX">TODO(dbaron): Is this a reasonable way to define a flag for two elements?</p>
+
   <p>Each <code>menulist</code> element has a <span>contains invalid menu content</span> boolean
   (defined under the <code>menubar</code> element).</p>
 
@@ -66473,8 +66477,8 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   that <span data-x="menuitem-invoked-submenu">invoke a submenu</span> — to let the user interact
   with the item without immediately dismissing it.</p>
 
-  <!-- TODO(dbaron): Should the <var>fireEvents</var> flag exist or should we fire events
-  for IDL setters too? -->
+  <p class="XXX">TODO(dbaron): Should the <var>fireEvents</var> flag exist or should we fire events
+  for IDL setters too?</p>
 
   <ol>
    <li><p>If <var>element</var>'s <span data-x="menuitem-checkable-state">checkable state</span> is
@@ -66502,9 +66506,11 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     generally be unchecked by a user gesture.</p>
    </li>
 
-   <!-- TODO(dbaron): This should fire "checked" events too! -->
-   <!-- TODO(dbaron): This and the reset algorithm should allow other elements between the
-   menuitems and the fieldset. -->
+   <li><p class="XXX">TODO(dbaron): This should fire "checked" events too!</p></li>
+
+   <li><p class="XXX">TODO(dbaron): This and the reset algorithm should allow other elements between
+   the menuitems and the fieldset.</p></li>
+
    <li><p>If <var>element</var>'s <span data-x="concept-menuitem-checkedness">checkedness</span> is
    true and <var>element</var>'s <span data-x="menuitem-checkable-state">checkable state</span> is
    <span data-x="attr-fieldset-checkable-state-single">Single</span>, then <span>reset
@@ -66642,13 +66648,16 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     </dl>
    </li>
 
-   <!-- TODO(dbaron): Link to writing modes better. -->
-   <li><p>If <var>physicalDirection</var> is none, then let <var>logicalDirection</var> be none,
-   otherwise let <var>logicalDirection</var> be the one of "block-start", "block-end",
-   "inline-start", or "inline-end" that maps to <var>physicalDirection</var> given
-   <var>direction</var> and <var>writingMode</var> in the
-   <a href="https://drafts.csswg.org/css-writing-modes/#logical-to-physical">Abstract-to-Physical
-   Mappings</a>.</p></li>
+   <li>
+    <p>If <var>physicalDirection</var> is none, then let <var>logicalDirection</var> be none,
+    otherwise let <var>logicalDirection</var> be the one of "block-start", "block-end",
+    "inline-start", or "inline-end" that maps to <var>physicalDirection</var> given
+    <var>direction</var> and <var>writingMode</var> in the <a
+    href="https://drafts.csswg.org/css-writing-modes/#logical-to-physical">Abstract-to-Physical
+    Mappings</a>.</p>
+
+    <p class="XXX">TODO(dbaron): Link to writing modes better.</p>
+   </li>
 
    <li><p>Let <var>menuContainer</var> be <var>item</var>'s <span>menu container</span>.</p></li>
 
@@ -66813,11 +66822,11 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
      <dd>Run the <span>focusing steps</span> for the <span>first focusable menuitem</span> of
      <var>menuContainer</var>, if it is not null.</dd>
 
-     <!-- TODO(dbaron): Should this instead patch the sequential focus navigation rules?  Also, it's
-     possible that this no longer needs to run after now that this is based on the DOM tree, since
-     we might ignore invoker relationships now.  (Though perhaps we should still consider them.) -->
      <dt>If <var>key</var> is "Tab"</dt>
      <dd>
+      <p class="XXX">TODO(dbaron): Should this instead patch the sequential focus navigation
+      rules?</p>
+
       <p>If the user agent normally handles the "Tab" key by running the <span>move focus
       sequentially</span> algorithm, it should afterwards run the following steps:</p>
 
@@ -66831,6 +66840,10 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
        <li><p><span data-x="hide popover algorithm">Hide a popover</span> given
        <var>outermostMenulist</var>, false, true, false, and <var>trigger</var>.</p></li>
       </ol>
+
+      <p class="note">Note that this steps need to run after <span>move focus sequentially</span>
+      because correctly moving focus depends on invoker relationships that disappear when closing
+      the menus (particularly if a <code>menulist</code>'s invoker was a <code>button</code>).</p>
      </dd>
 
      <dt>Otherwise</dt>
@@ -86413,8 +86426,8 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
 
   <h4><dfn>Sequential focus navigation</dfn></h4>
 
-  <!-- TODO(dbaron): Figure out how to make only one <code>menuitem</code> per
-  <span>outermost containing menulist</span> be in the sequential focus navigation order. -->
+  <p class="XXX">TODO(dbaron): Figure out how to make only one <code>menuitem</code> per
+  <span>outermost containing menulist</span> be in the sequential focus navigation order.</p>
 
   <p>Each <code>Document</code> has a <dfn>sequential focus navigation order</dfn>, which orders
   some or all of the <span data-x="focusable area">focusable areas</span> in the
@@ -86858,9 +86871,10 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
   page is loaded, allowing the user to just start typing without having to manually focus the main
   element.</p>
 
-  <!-- TODO(domfarolino) (before merge): Should we also change this to reference the generic
-  <span>popover state</span> instead of the popover attribute specifically? I don't think we need
-  to, since we don't support form elements inside menulists. -->
+  <p class="XXX">TODO(domfarolino) (before merge): Should we also change this to reference the
+  generic <span>popover state</span> instead of the popover attribute specifically? I don't think we
+  need to, since we don't support form elements inside menulists.</p>
+
   <p>When the <code data-x="attr-fe-autofocus">autofocus</code> attribute is specified on an element
   inside <code>dialog</code> elements or <span>HTML elements</span> whose <code
   data-x="attr-popover">popover</code> attribute is set, then it will be focused when the dialog or
@@ -86877,10 +86891,13 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
    <li><p>If <var>element</var> is a <code>dialog</code> element, then return
    <var>element</var>.</p></li>
 
-   <!-- TODO(domfarolino): See the above question. -->
-   <li><p>If <var>element</var>'s <code data-x="attr-popover">popover</code> attribute is not in the
-   <span data-x="attr-popover-none-state">No Popover</span> state, then return
-   <var>element</var>.</p></li>
+   <li>
+    <p class="XXX">TODO(domfarolino): See the above question.</p>
+
+    <p>If <var>element</var>'s <code data-x="attr-popover">popover</code> attribute is not in the
+    <span data-x="attr-popover-none-state">No Popover</span> state, then return
+    <var>element</var>.</p>
+   </li>
 
    <li><p>Let <var>ancestor</var> be <var>element</var>.</p></li>
 
@@ -86893,10 +86910,13 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
      <li><p>If <var>ancestor</var> is a <code>dialog</code> element, then return
      <var>ancestor</var>.</p></li>
 
-     <!-- TODO(domfarolino): See the above question. -->
-     <li><p>If <var>ancestor</var>'s <code data-x="attr-popover">popover</code> attribute is not in
-     the <span data-x="attr-popover-none-state">No Popover</span> state, then return
-     <var>ancestor</var>.</p></li>
+     <li>
+      <p class="XXX">TODO(domfarolino): See the above question.</p>
+
+      <p>If <var>ancestor</var>'s <code data-x="attr-popover">popover</code> attribute is not in the
+      <span data-x="attr-popover-none-state">No Popover</span> state, then return
+      <var>ancestor</var>.</p>
+     </li>
     </ol>
    </li>
 
@@ -91568,12 +91588,15 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
    <li><p>If <var>localName</var> is not <code data-x="attr-popover">popover</code>, then
    return.</p></li>
 
-   <!-- TODO(domfarolino): Should this step apply to menulist elements? Do we respect the popover
-   attribute and its value mutations on that element? -->
-   <li><p>If <var>element</var>'s <span>popover visibility state</span> is in the <span
-   data-x="popover-showing-state">showing state</span> and <var>oldValue</var> and <var>value</var>
-   are in different <span data-x="attr-popover">states</span>, then run the <span>hide popover
-   algorithm</span> given <var>element</var>, true, true, false, and null.</p></li>
+   <li>
+    <p class="XXX">TODO(domfarolino): Should this step apply to menulist elements? Do we respect the
+    popover attribute and its value mutations on that element?</p>
+
+    <p>If <var>element</var>'s <span>popover visibility state</span> is in the <span
+    data-x="popover-showing-state">showing state</span> and <var>oldValue</var> and <var>value</var>
+    are in different <span data-x="attr-popover">states</span>, then run the <span>hide popover
+    algorithm</span> given <var>element</var>, true, true, false, and null.</p>
+   </li>
   </ol>
   </div>
 
@@ -92578,9 +92601,10 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
 
   <h4>The popover target attributes</h4>
 
-  <!-- TODO(domfarolino): Should we expand these attributes to menuitem elements? And should we
+  <p class="XXX">TODO(domfarolino): Should we expand these attributes to menuitem elements? And should we
   expand their targeting behavior to include targeting menulist elements, which are popovers by
-  default but don't use the explicit popover attribute? See the various TODOs below. -->
+  default but don't use the explicit popover attribute? See the various TODOs below.</p>
+
   <p><span data-x="concept-button">Buttons</span> may have the following content attributes:</p>
 
   <ul>
@@ -92591,8 +92615,9 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
    data-x="attr-popovertargetaction">popovertargetaction</code></dfn></p></li>
   </ul>
 
-  <!-- TODO(domfarolino): If we decide to expand the popovertarget attribute targeting behavior to
-  include targeting menulist elements, then we'll have to loosen this paragraph. -->
+  <p class="XXX">TODO(domfarolino): If we decide to expand the popovertarget attribute targeting behavior to
+  include targeting menulist elements, then we'll have to loosen this paragraph.</p>
+
   <p>If specified, the <code data-x="attr-popovertarget">popovertarget</code> attribute value must
   be the <span data-x="concept-ID">ID</span> of an element with a <code
   data-x="attr-popover">popover</code> attribute in the same <span>tree</span> as the <span
@@ -92732,11 +92757,15 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
 
    <li><p>If <var>popoverElement</var> is null, then return null.</p></li>
 
-   <!-- TODO(domfarolino): See the above TODO: if we decide to expand the popovertarget's targeting
-   ability to target menulist elements, then we'll need to loosen this condition below, to include
-   menulist elements which are popovers by default, even without the explicit popover attribute. -->
-   <li><p>If <var>popoverElement</var>'s <code data-x="attr-popover">popover</code> attribute is in
-   the <span data-x="attr-popover-none-state">No Popover</span> state, then return null.</p></li>
+   <li>
+    <p class="XXX">TODO(domfarolino): See the above TODO: if we decide to expand the popovertarget's
+    targeting ability to target menulist elements, then we'll need to loosen this condition below,
+    to include menulist elements which are popovers by default, even without the explicit popover
+    attribute.</p>
+
+    <p>If <var>popoverElement</var>'s <code data-x="attr-popover">popover</code> attribute is in the
+    <span data-x="attr-popover-none-state">No Popover</span> state, then return null.</p>
+   </li>
 
    <li><p>Return <var>popoverElement</var>.</p></li>
   </ol>
@@ -92943,7 +92972,9 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
   steps</dfn> and <dfn>command steps</dfn> defined for the element's <span
   data-x="concept-element-local-name">local name</span>.</p>
 
-  <!-- TODO(domfarolino DOMFAROLINO): Probably add shared activation behavior algorithm here? -->
+  <p class="XXX">TODO(domfarolino DOMFAROLINO): Probably add shared activation behavior algorithm
+  here?</p>
+
   <div algorithm>
   <p>Both <code>menuitem</code> elements and <code>button</code> elements are the only command
   invoker elements. As such, much of their <span>activation behavior</span> is shared. The parts
@@ -149645,7 +149676,9 @@ menubar, menulist {
   }
 }</code></pre>
 
-  <!-- TODO(domfarolino): Probably expand this to include menulists anchored at a button. -->
+  <p class="XXX">TODO(domfarolino): Probably expand this to include menulists anchored at a
+  button.</p>
+
   <p>The following styles are <span>expected</span> to apply to <code>menulist</code> elements whose
   <span>implicit anchor element</span> is a <code>menuitem</code> element whose <span>cached
   ancestor <code>menulist</code> element</span> is not null.</p>
@@ -152062,6 +152095,9 @@ interface <dfn interface>External</dfn> {
 
   <!-- NON-NORMATIVE SECTION -->
 
+  <p class="XXX">TODO(domfarolino): Add table rows for menubar, menulist, menuitem, submenu
+  elements.</p>
+
   <table>
    <caption>List of elements</caption>
    <thead>
@@ -152997,8 +153033,6 @@ interface <dfn interface>External</dfn> {
      <td><span data-x="global attributes">globals</span></td>
      <td><code>HTMLMenuElement</code></td>
     </tr>
-
-    <!-- TODO(domfarolino): Add table rows for menubar, menulist, menuitem elements. -->
 
     <tr>
      <th><code>meta</code></th>
@@ -154217,10 +154251,10 @@ interface <dfn interface>External</dfn> {
       <span>interactive content</span>, or elements with <code
       data-x="attr-tabindex">tabindex</code>
 
-    <!-- TODO(dbaron): Add menubar/menulist/menuitem inner content elements -->
 
   </table>
 
+  <p class="XXX">TODO(dbaron): Add menubar/menulist/menuitem inner content elements</p>
 
   <h3 class="no-num">Attributes</h3>
 

--- a/source
+++ b/source
@@ -66024,26 +66024,82 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    contains exactly one item whose <span data-x="concept-event-path-invocation-target">invocation
    target</span> is <var>menuContainer</var>.</p></li>
 
-   <li><p>For each <var>item</var> in <var>event</var>'s
-   <span data-x="concept-event-path">path</span>:</p>
-   <ol>
-    <li><p>Let <var>target</var> be <var>item</var>'s <span
-    data-x="concept-event-path-invocation-target">invocation target</span>.</p></li>
+   <li>
+    <p>For each <var>item</var> in <var>event</var>'s <span
+    data-x="concept-event-path">path</span>:</p>
 
-    <li><p>If <var>target</var> is a <code>menuitem</code> element, return
-    <var>target</var>.</p></li>
+    <ol>
+     <li><p>Let <var>target</var> be <var>item</var>'s <span
+     data-x="concept-event-path-invocation-target">invocation target</span>.</p></li>
 
-    <li><p>If <var>target</var> is <var>menuContainer</var>, return null.</p></li>
-   </ol>
+     <li><p>If <var>target</var> is a <code>menuitem</code> element, return
+     <var>target</var>.</p></li>
+
+     <li><p>If <var>target</var> is <var>menuContainer</var>, return null.</p></li>
+    </ol>
    </li>
 
   </ol>
   </div>
 
-  <!-- TODO: rectify this definition with "child of a submenu" tests used elsewhere -->
-  <p>The <dfn>furthest ancestor menu container</dfn> of an element is the <span>inclusive
-  ancestor</span> of that element that is a <code>menulist</code> or <code>menubar</code> and is
-  furthest from the element (that is, highest in the tree).</p>
+  <div algorithm>
+  <p>To found the <dfn>outermost containing menulist</dfn> of a <code>menuitem</code> element
+  <var>item</var>, take the following steps:</p>
+  <ol>
+   <li><p>Let <var>list</var> be null.</p></li>
+
+   <li><p>Let <var>nextList</var> be <var>item</var>'s <span>cached ancestor <code>menulist</code>
+   element</span>.</p></li>
+
+   <li>
+    <p>While <var>nextList</var> is not null:</p>
+
+    <!-- TODO: Chromium code uses (I think) a loop over "topmost popover ancestor" here instead.
+    Should this? -->
+    <ol>
+     <li><p>Let <var>list</var> be <var>nextList</var>.</p></li>
+
+     <li><p>Let <var>nextItem</var> be <var>list</var>'s <span>popover trigger</span>.</p></li>
+
+     <li><p>If <var>nextItem</var> is not a <code>menuitem</code> element, then
+     <span>break</span>.</p></li>
+
+     <li><p>Let <var>nextList</var> be <var>nextItem</var>'s <span>cached ancestor
+     <code>menubar</code> element</span>.</p></li>
+    </ol>
+   </li>
+
+   <li><p>Return <var>list</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>To find the <dfn>outermost menu container</dfn> of a <code>menuitem</code> element
+  <var>item</var>, take the following steps:</p>
+
+  <ol>
+   <li><p>Let <var>container</var> be <var>item</var>'s <span>cached ancestor <code>menubar</code>
+   element</span>.</p></li>
+
+   <li><p>If <var>container</var> is not null, return <var>container</var>.</p></li>
+
+   <li><p>Let <var>outerList</var> be <var>item</var>'s <span>outermost containing
+   menulist</span>.</p></li>
+
+   <li><p>Let <var>barItem</var> be <var>outerList</var>'s <span>popover trigger</span>.</p></li>
+
+   <li><p>If <var>barItem</var> is not a <code>menuitem</code> element, then
+   return <var>outerList</var>.</p></li>
+
+   <li><p>Let <var>bar</var> be <var>barItem</var>'s <span>cached ancestor <code>menubar</code>
+   element</span>.</p></li>
+
+   <li><p>If <var>bar</var> is null, return <var>outerList</var>.</p></li>
+
+   <li><p>Return <var>bar</var>.</p></li>
+  </ol>
+  </div>
+
 
   <h4>The <dfn element><code>menulist</code></dfn> element</h4>
 
@@ -66345,6 +66401,20 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
+  <p>An element <var>container</var>'s <dfn>first focusable menuitem</dfn> is the first
+  <code>menuitem</code> descendant of <var>container</var> in <span>tree order</span> whose
+  <span>menu container</span> is <var>container</var> and that is not <code
+  data-x="attr-menuitem-disabled">disabled</code>.</p>
+  </div>
+
+  <div algorithm>
+  <p>An element <var>container</var>'s <dfn>last focusable menuitem</dfn> is the last
+  <code>menuitem</code> descendant of <var>container</var> in <span>tree order</span> whose
+  <span>menu container</span> is <var>container</var> and that is not <code
+  data-x="attr-menuitem-disabled">disabled</code>.</p>
+  </div>
+
+  <div algorithm>
   <p>A <code>menuitem</code> element <var>item</var>'s <dfn>next focusable menuitem</dfn> is the
   result of the following steps:</p>
 
@@ -66356,10 +66426,8 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <var>item</var>, whose <span>menu container</span> is <var>container</var>, and is not <code
    data-x="attr-menuitem-disabled">disabled</code>.</p></li>
 
-   <li><p>If <var>next</var> is null, let <var>next</var> be the first <code>menuitem</code>
-   descendant of <var>container</var> in <span>tree order</span> whose <span>menu container</span>
-   is <var>container</var> and that is not <code
-   data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+   <li><p>If <var>next</var> is null, let <var>next</var> be
+   <var>container</var>'s <span>first focusable menuitem</span>.</p></li>
 
    <li><p>Return <var>next</var>.</p></li>
   </ol>
@@ -66378,10 +66446,8 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    container</span> is <var>container</var>, and is not <code
    data-x="attr-menuitem-disabled">disabled</code>.</p></li>
 
-   <li><p>If <var>previous</var> is null, let <var>previous</var> be the last <code>menuitem</code>
-   descendant of <var>container</var> in <span>tree order</span> whose <span>menu container</span>
-   is <var>container</var> and that is not <code
-   data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+   <li><p>If <var>previous</var> is null, let <var>previous</var> be <var>container</var>'s
+   <span>last focusable menuitem</span>.</p></li>
 
    <li><p>Return <var>previous</var>.</p></li>
   </ol>
@@ -66492,9 +66558,9 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     </ol>
    </li>
 
-   <li><p class="XXX">TODO(domfarolino): Invoke steps to "close the
-   outermost containing menulist" when appropriate, before running the shared steps
-   below.</p></li>
+   <li><p class="XXX">TODO(domfarolino): Invoke steps to close the <span>outermost containing
+   menulist</span> when appropriate (sometimes we don't do this for checkable items?), before
+   running the shared steps below.</p></li>
 
    <li><p>Run the <span>shared command invoker activation steps</span> given <var>element</var> and
    <var>event</var>.</p></li>
@@ -66502,7 +66568,7 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
-  <p>When a <code>menuitem</code> element's <span>furthest ancestor menu container</span>'s
+  <p>When a <code>menuitem</code> element's <span>outermost menu container</span>'s
   <span>contains invalid menu content</span> flag is false, the <code>menuitem</code> element
   <var>item</var> should handle a <code data-x="event-keydown">keydown</code> event <var>event</var>
   as follows:</p>
@@ -66523,11 +66589,11 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <li><p>If <var>key</var> is not "Tab" and <var>isShift</var> is true, return.</p></li>
 
    <li><p>Let <var>direction</var> be the <span>computed value</span> of the
-   <span>'direction'</span> property on <var>item</var>'s <span>furthest ancestor menu
+   <span>'direction'</span> property on <var>item</var>'s <span>outermost menu
    container</span>.</p></li>
 
    <li><p>Let <var>writingMode</var> be the <span>computed value</span> of the
-   <span>'writing-mode'</span> property on <var>item</var>'s <span>furthest ancestor menu
+   <span>'writing-mode'</span> property on <var>item</var>'s <span>outermost menu
    container</span>.</p></li>
 
    <li><p>Let <var>physicalDirection</var> be the following:</p>
@@ -66566,10 +66632,12 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <li><p>Then:</p>
     <dl class="switch">
      <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is false</dt>
-     <dd>Move focus to the <span>previous focusable menuitem</span> of <var>item</var>.</dd>
+     <dd>Run the <span>focusing steps</span> for the <span>previous focusable menuitem</span> of
+     <var>item</var>.</dd>
 
      <dt>If <var>logicalDirection</var> is "block-end" and <var>inMenubar</var> is false</dt>
-     <dd>Move focus to the <span>next focusable menuitem</span> of <var>item</var>.</dd>
+     <dd>Run the <span>focusing steps</span> for the <span>next focusable menuitem</span> of
+     <var>item</var>.</dd>
 
      <dt>If <var>logicalDirection</var> is "inline-start" and <var>inMenubar</var> is false</dt>
      <dd>
@@ -66599,24 +66667,57 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
 
        <li><p>If <var>nextFocus</var> is null, return.</p></li>
 
-       <li><p>TODO</p></li>
+       <li><p><span data-x="hide popover algorithm">Hide a popover</span> given
+       <var>menuContainer</var>, false, true, false, and <var>itemTrigger</var>.</p></li>
+
+       <li><p>Run the <span>focusing steps</span> for <var>nextFocus</var>.</p></li>
       </ol>
      </dd>
 
      <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is false and
      <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is null</dt>
-     <dd>TODO</dd>
+     <dd>
+      <p>Execute the following steps:</p>
+
+      <ol>
+       <li><p>Let <var>outermostMenulist</var> be <var>item</var>'s <span>outermost containing
+       menulist</span>.</p></li>
+
+       <li><p>Let <var>itemTrigger</var> be <var>outermostMenulist</var>'s <span>popover
+       trigger</span>.</p></li>
+
+       <li><p>If <var>itemTrigger</var> is not a <code>menuitem</code>, return.</p></li>
+
+       <li><p>Let <var>nextFocus</var> be <var>itemTrigger</var>'s <span>next focusable
+       menuitem</span> if it is not equal to <var>itemTrigger</var>, otherwise null.</p></li>
+
+       <li><p>If <var>nextFocus</var> is null, return.</p></li>
+
+       <li><p><span data-x="hide popover algorithm">Hide a popover</span> given
+       <var>outermostMenulist</var>, false, true, false, and <var>itemTrigger</var>.</p></li>
+
+       <li><p>Run the <span>focusing steps</span> for <var>nextFocus</var>.</p></li>
+      </ol>
+     </dd>
 
      <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is false and
      <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is not
      null</dt>
-     <dd>TODO</dd>
+     <dd>
+      <p>Execute the following steps:</p>
 
-     <dt>If <var>key</var> is "Home" and <var>inMenubar</var> is false</dt>
-     <dd>TODO</dd>
+      <ol>
+       <li><p>Let <var>submenu</var> be
+       <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span>.</p></li>
 
-     <dt>If <var>key</var> is "End" and <var>inMenubar</var> is false</dt>
-     <dd>TODO</dd>
+       <li><p>If <var>submenu</var>'s <span>popover visibility state</span> is <span
+       data-x="popover-hidden-state">hidden</span>, then <span data-x="show popover">show a
+       popover</span> given <var>submenu</var>, false, and <var>item</var>.</p></li>
+
+       <li><p>Run the <span>focusing steps</span> for <var>submenu</var>'s <span>first focusable
+       menuitem</span>, if it is not null.</p></li>
+      </ol>
+     </dd>
 
      <dt>If <var>key</var> is "PageUp" and <var>inMenubar</var> is false</dt>
      <dd>TODO</dd>
@@ -66624,23 +66725,59 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
      <dt>If <var>key</var> is "PageDown" and <var>inMenubar</var> is false</dt>
      <dd>TODO</dd>
 
-     <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is true</dt>
-     <dd>TODO</dd>
+     <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is true and
+     <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is not
+     null</dt>
+     <dd>
+      <p>Execute the following steps:</p>
 
-     <dt>If <var>logicalDirection</var> is "block-end" and <var>inMenubar</var> is true</dt>
-     <dd>TODO</dd>
+      <ol>
+       <li><p>Let <var>submenu</var> be
+       <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span>.</p></li>
+
+       <li><p>If <var>submenu</var>'s <span>popover visibility state</span> is <span
+       data-x="popover-hidden-state">hidden</span>, then <span data-x="show popover">show a
+       popover</span> given <var>submenu</var>, false, and <var>item</var>.</p></li>
+
+       <li><p>Run the <span>focusing steps</span> for <var>submenu</var>'s <span>first focusable
+       menuitem</span>, if it is not null.</p></li>
+      </ol>
+     </dd>
+
+     <dt>If <var>logicalDirection</var> is "block-end" and <var>inMenubar</var> is true and
+     <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is not
+     null</dt>
+     <dd>
+      <p>Execute the following steps:</p>
+
+      <ol>
+       <li><p>Let <var>submenu</var> be
+       <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span>.</p></li>
+
+       <li><p>If <var>submenu</var>'s <span>popover visibility state</span> is <span
+       data-x="popover-hidden-state">hidden</span>, then <span data-x="show popover">show a
+       popover</span> given <var>submenu</var>, false, and <var>item</var>.</p></li>
+
+       <li><p>Run the <span>focusing steps</span> for <var>submenu</var>'s <span>last focusable
+       menuitem</span>, if it is not null.</p></li>
+      </ol>
+     </dd>
 
      <dt>If <var>logicalDirection</var> is "inline-start" and <var>inMenubar</var> is true</dt>
-     <dd>TODO</dd>
+     <dd>Run the <span>focusing steps</span> for the <span>previous focusable menuitem</span> of
+     <var>item</var>.</dd>
 
      <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is true</dt>
-     <dd>TODO</dd>
+     <dd>Run the <span>focusing steps</span> for the <span>next focusable menuitem</span> of
+     <var>item</var>.</dd>
 
-     <dt>If <var>key</var> is "Home" and <var>inMenubar</var> is true</dt>
-     <dd>TODO</dd>
+     <dt>If <var>key</var> is "Home"</dt>
+     <dd>Run the <span>focusing steps</span> for the <span>first focusable menuitem</span> of
+     <var>menuContainer</var>, if it is not null.</dd>
 
-     <dt>If <var>key</var> is "End" and <var>inMenubar</var> is true</dt>
-     <dd>TODO</dd>
+     <dt>If <var>key</var> is "End"</dt>
+     <dd>Run the <span>focusing steps</span> for the <span>first focusable menuitem</span> of
+     <var>menuContainer</var>, if it is not null.</dd>
 
      <dt>If <var>key</var> is "Tab"</dt>
      <dd>TODO</dd>

--- a/source
+++ b/source
@@ -65982,7 +65982,7 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    left and right arrow keys.</p>
   </div>
 
-  <!-- TODO: Set this to true sometimes! -->
+  <!-- TODO (dbaron): Set this to true sometimes! -->
   <p>Each <code>menubar</code> or <code>menulist</code> element has a <dfn>contains invalid menu
   content</dfn> boolean, initially false.</p>
 
@@ -66054,8 +66054,8 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    <li>
     <p>While <var>nextList</var> is not null:</p>
 
-    <!-- TODO: Chromium code uses (I think) a loop over "topmost popover ancestor" here instead.
-    Should this? -->
+    <!-- TODO(dbaron): Chromium code uses (I think) a loop over "topmost popover ancestor" here
+    instead.  Should this? -->
     <ol>
      <li><p>Let <var>list</var> be <var>nextList</var>.</p></li>
 
@@ -66137,7 +66137,7 @@ interface <dfn interface>HTMLMenuListElement</dfn> : <span>HTMLElement</span> {
   <span>popover state</span> is not <span data-x="popover-state-no-popover">No Popover</span> by
   default, even when the <code data-x="attr-popover">popover</code> attribute is not present.</p>
 
-  <!-- TODO: Is this a reasonable way to define a flag for two elements? -->
+  <!-- TODO(dbaron): Is this a reasonable way to define a flag for two elements? -->
   <p>Each <code>menulist</code> element has a <span>contains invalid menu content</span> boolean
   (defined under the <code>menubar</code> element).</p>
 
@@ -66616,7 +66616,7 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     </dl>
    </li>
 
-   <!-- TODO: Link to writing modes better. -->
+   <!-- TODO(dbaron): Link to writing modes better. -->
    <li><p>If <var>physicalDirection</var> is none, then let <var>logicalDirection</var> be none,
    otherwise let <var>logicalDirection</var> be the one of "block-start", "block-end",
    "inline-start", or "inline-end" that maps to <var>physicalDirection</var> given
@@ -66787,10 +66787,9 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
      <dd>Run the <span>focusing steps</span> for the <span>first focusable menuitem</span> of
      <var>menuContainer</var>, if it is not null.</dd>
 
-     <!-- TODO: Should this instead patch the sequential focus navigation rules?  Also, what should
-     happen before versus after closing?  Do we really need to find the next focusable element
-     before doing the closing, and does that correctly skip over the other menuitems in the menu
-     tree? -->
+     <!-- TODO(dbaron): Should this instead patch the sequential focus navigation rules?  Also, it's
+     possible that this no longer needs to run after now that this is based on the DOM tree, since
+     we might ignore invoker relationships now.  (Though perhaps we should still consider them.) -->
      <dt>If <var>key</var> is "Tab"</dt>
      <dd>
       <p>If the user agent normally handles the "Tab" key by running the <span>move focus
@@ -86387,6 +86386,9 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
 
 
   <h4><dfn>Sequential focus navigation</dfn></h4>
+
+  <!-- TODO(dbaron): Figure out how to make only one <code>menuitem</code> per
+  <span>outermost containing menulist</span> be in the sequential focus navigation order. -->
 
   <p>Each <code>Document</code> has a <dfn>sequential focus navigation order</dfn>, which orders
   some or all of the <span data-x="focusable area">focusable areas</span> in the

--- a/source
+++ b/source
@@ -80110,6 +80110,11 @@ Demos:
 
      <li><p><code>input</code> elements that <span data-x="input-support-picker">support a
      picker</span> and whose pickers are open</p></li>
+
+     <li><p><code>menuitem</code> elements that have an <span
+     data-x="menuitem-invoked-submenu">invoked submenu</span>, that invoked submenu's <span>popover
+     visibility state</span> is <span data-x="popover-showing-state">showing</span>, and the invoked
+     submenu's <span>popover trigger</span> is the <code>menuitem</code> element</p></li>
     </ul>
    </dd>
   </dl>

--- a/source
+++ b/source
@@ -65980,6 +65980,10 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    left and right arrow keys.</p>
   </div>
 
+  <!-- TODO: Set this to true sometimes! -->
+  <p>Each <code>menubar</code> or <code>menulist</code> element has a <dfn>contains invalid menu
+  content</dfn> boolean, initially false.</p>
+
   <p>Depending on user agent decisions about matching platform behavior, <code>menuitem</code>
   elements may activate on <code data-x="event-mouseup">mouseup</code> even when the <code
   data-x="event-mousedown">mousedown</code> (and thus the <code data-x="event-click">click</code>)
@@ -66034,6 +66038,11 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
   </ol>
   </div>
 
+  <!-- TODO: rectify this definition with "child of a submenu" tests used elsewhere -->
+  <p>The <dfn>furthest ancestor menu container</dfn> of an element is the <span>inclusive
+  ancestor</span> of that element that is a <code>menulist</code> or <code>menubar</code> and is
+  furthest from the element (that is, highest in the tree).</p>
+
   <h4>The <dfn element><code>menulist</code></dfn> element</h4>
 
   <dl class="element">
@@ -66070,12 +66079,16 @@ interface <dfn interface>HTMLMenuListElement</dfn> : <span>HTMLElement</span> {
   <span>popover state</span> is not <span data-x="popover-state-no-popover">No Popover</span> by
   default, even when the <code data-x="attr-popover">popover</code> attribute is not present.</p>
 
+  <!-- TODO: Is this a reasonable way to define a flag for two elements? -->
+  <p>Each <code>menulist</code> element has a <span>contains invalid menu content</span> boolean
+  (defined under the <code>menubar</code> element).</p>
+
   <p>Depending on user agent decisions about matching platform behavior, <code>menuitem</code>
   elements may activate on <code data-x="event-mouseup">mouseup</code> even when the <code
   data-x="event-mousedown">mousedown</code> (and thus the <code data-x="event-click">click</code>)
   event did not got to the <code>menuitem</code> (for example, because a drag gesture that begins
   on one <code>menuitem</code> and ends on another activates the <code>menuitem</code>).  If a user
-  agent has this behavior, then <code>menulist</code> elements whose parent is a
+  agent has this behavior, then <code>menulist</code> elements whose parent is not a
   <code>submenu</code> element must also implement <span>activation behavior</span> (given a <code
   data-x="event-click">click</code> event) that will <span>fire click on a menuitem if
   needed</span> given that event and the <code>menulist</code> element.</p>
@@ -66426,6 +66439,134 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   </ol>
   </div>
 
+  <div algorithm>
+  <p>When a <code>menuitem</code> element's <span>furthest ancestor menu container</span>'s
+  <span>contains invalid menu content</span> flag is false, the <code>menuitem</code> element
+  <var>item</var> should handle a <code data-x="event-keydown">keydown</code> event <var>event</var>
+  as follows:</p>
+
+  <ol>
+   <li><p>If <code data-x="">event.getModifierState("Alt")</code>,
+   <code data-x="">event.getModifierState("AltGraph")</code>,
+   <code data-x="">event.getModifierState("Control")</code>,
+   <code data-x="">event.getModifierState("Fn")</code>,
+   <code data-x="">event.getModifierState("Meta")</code>, or
+   <code data-x="">event.getModifierState("Symbol")</code> is true, then return.</p></li>
+
+   <li><p>Let <var>isShift</var> be
+   <code data-x="">event.getModifierState("Shift")</code>.</p></li>
+
+   <li><p>Let <var>key</var> be <code data-x="">event.key</code>.</p></li>
+
+   <li><p>If <var>key</var> is not "Tab" and <var>isShift</var> is true, return.</p></li>
+
+   <li><p>Let <var>direction</var> be the <span>computed value</span> of the
+   <span>'direction'</span> property on <var>item</var>'s <span>furthest ancestor menu
+   container</span>.</p></li>
+
+   <li><p>Let <var>writingMode</var> be the <span>computed value</span> of the
+   <span>'writing-mode'</span> property on <var>item</var>'s <span>furthest ancestor menu
+   container</span>.</p></li>
+
+   <li><p>Let <var>physicalDirection</var> be the following:</p>
+
+    <dl class="switch">
+     <dt>If <var>key</var> is "ArrowRight"
+     <dd>right
+
+     <dt>If <var>key</var> is "ArrowUp"
+     <dd>top
+
+     <dt>If <var>key</var> is "ArrowDown"
+     <dd>bottom
+
+     <dt>If <var>key</var> is "ArrowLeft"
+     <dd>left
+
+     <dt>Otherwise
+     <dd>none
+    </dl>
+   </li>
+
+   <!-- TODO: Link to writing modes better. -->
+   <li><p>If <var>physicalDirection</var> is none, then let <var>logicalDirection</var> be none,
+   otherwise let <var>logicalDirection</var> be the one of "block-start", "block-end",
+   "inline-start", or "inline-end" that maps to <var>physicalDirection</var> given
+   <var>direction</var> and <var>writingMode</var> in the
+   <a href="https://drafts.csswg.org/css-writing-modes/#logical-to-physical">Abstract-to-Physical
+   Mappings</a>.</p></li>
+
+   <li><p>Let <var>menuContainer</var> be the <span>cached ancestor <code>menulist</code>
+   element</span> of <var>item</var> if it is not null, otherwise the <span>cached ancestor
+   <code>menubar</code> element</span> of <var>item</var>.</p></li>
+
+   <li><p>Let <var>inMenubar</var> be true if <var>menuContainer</var> is a <code>menubar</code>,
+   otherwise false.</p></li>
+
+   <li><p>Then:</p>
+    <dl class="switch">
+     <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is false</dt>
+     <dd>Move focus to the previous <code>menuitem</code> in <var>menuContainer</var> whose
+     <span>cached ancestor <code>menulist</code> element</span> is <var>menuContainer</var>, cycling
+     to the end if there is no such previous item.</dd>
+
+     <dt>If <var>logicalDirection</var> is "block-end" and <var>inMenubar</var> is false</dt>
+     <dd>Move focus to the next <code>menuitem</code> in <var>menuContainer</var> whose <span>cached
+     ancestor <code>menulist</code> element</span> is <var>menuContainer</var>, cycling to the start
+     if there is no such next item.</dd>
+
+     <dt>If <var>logicalDirection</var> is "inline-start" and <var>inMenubar</var> is false</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is false and
+     <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is null</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is false and
+     <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is not
+     null</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "Home" and <var>inMenubar</var> is false</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "End" and <var>inMenubar</var> is false</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "PageUp" and <var>inMenubar</var> is false</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "PageDown" and <var>inMenubar</var> is false</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is true</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>logicalDirection</var> is "block-end" and <var>inMenubar</var> is true</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>logicalDirection</var> is "inline-start" and <var>inMenubar</var> is true</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is true</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "Home" and <var>inMenubar</var> is true</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "End" and <var>inMenubar</var> is true</dt>
+     <dd>TODO</dd>
+
+     <dt>If <var>key</var> is "Tab"</dt>
+     <dd>TODO</dd>
+
+     <dt>Otherwise</dt>
+     <dd>Do nothing.</dd>
+    </dl>
+   </li>
+
+  </ol>
+  </div>
 
 
   <h3 split-filename="scripting">Scripting</h3>

--- a/source
+++ b/source
@@ -3360,6 +3360,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
              <dfn data-x-href="https://dom.spec.whatwg.org/#remove-all-event-listeners">remove all event listeners</dfn> algorithms</li>
      <li><dfn data-x="dom-EventListener" data-x-href="https://dom.spec.whatwg.org/#callbackdef-eventlistener"><code>EventListener</code></dfn> callback interface</li>
      <li>The <dfn data-x="concept-event-type" data-x-href="https://dom.spec.whatwg.org/#dom-event-type">type</dfn> of an event</li>
+     <li>The <dfn data-x="concept-event-path" data-x-href="https://dom.spec.whatwg.org/#event-path">path</dfn> of an event</li>
+     <li>The <dfn data-x="concept-event-path-invocation-target" data-x-href="https://dom.spec.whatwg.org/#event-path-invocation-target">invocation target</dfn> of an event path item</li>
      <li>An <dfn data-x-href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</dfn> and its
             <dfn data-x="event listener type" data-x-href="https://dom.spec.whatwg.org/#event-listener-type">type</dfn> and
             <dfn data-x="event listener callback" data-x-href="https://dom.spec.whatwg.org/#event-listener-callback">callback</dfn></li>
@@ -65978,6 +65980,60 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    left and right arrow keys.</p>
   </div>
 
+  <p>Depending on user agent decisions about matching platform behavior, <code>menuitem</code>
+  elements may activate on <code data-x="event-mouseup">mouseup</code> even when the <code
+  data-x="event-mousedown">mousedown</code> (and thus the <code data-x="event-click">click</code>)
+  event did not got to the <code>menuitem</code> (for example, because a drag gesture that begins
+  on one <code>menuitem</code> and ends on another activates the <code>menuitem</code>).  If a user
+  agent has this behavior, then the <code>menubar</code> element must also implement
+  <span>activation behavior</span> (given a <code data-x="event-click">click</code> event) that
+  will <span>fire click on a menuitem if needed</span> given that event and the
+  <code>menubar</code> element.</p>
+
+  <div algorithm>
+  <p>To <dfn>fire click on a menuitem if needed</dfn> given <var>event</var> and
+  <var>menuContainer</var>, run these steps:</p>
+
+  <ol>
+   <li><p>Let <var>mouseupItem</var> be the result of <span>find the containing
+   <code>menuitem</code> for an event</span> for the most recent <code
+   data-x="event-mouseup">mouseup</code> event dispatched to <var>menuContainer</var>.</p></li>
+
+   <li><p>Let <var>clickItem</var> be the result of <span>find the containing
+   <code>menuitem</code> for an event</span> for <var>event</var>.</p></li>
+
+   <li><p>If <var>mouseupItem</var> is null, or if <var>mouseupItem</var> equals
+   <var>clickItem</var>, then return.</p></li>
+
+   <li><p><span>Fire a <code data-x="event-click">click</code> event</span> at
+   <var>mouseupItem</var>.</p></li>
+
+  </ol>
+
+  <p>To <dfn>find the containing <code>menuitem</code> for an event</dfn> given <var>event</var>
+  and <var>menuContainer</var>, run these steps:</p>
+
+  <ol>
+   <li><p><span>Assert</span>: <var>event</var>'s <span data-x="concept-event-path">path</span>
+   contains exactly one item whose <span data-x="concept-event-path-invocation-target">invocation
+   target</span> is <var>menuContainer</var>.</p></li>
+
+   <li><p>For each <var>item</var> in <var>event</var>'s
+   <span data-x="concept-event-path">path</span>:</p>
+   <ol>
+    <li><p>Let <var>target</var> be <var>item</var>'s <span
+    data-x="concept-event-path-invocation-target">invocation target</span>.</p></li>
+
+    <li><p>If <var>target</var> is a <code>menuitem</code> element, return
+    <var>target</var>.</p></li>
+
+    <li><p>If <var>target</var> is <var>menuContainer</var>, return null.</p></li>
+   </ol>
+   </li>
+
+  </ol>
+  </div>
+
   <h4>The <dfn element><code>menulist</code></dfn> element</h4>
 
   <dl class="element">
@@ -66013,6 +66069,16 @@ interface <dfn interface>HTMLMenuListElement</dfn> : <span>HTMLElement</span> {
   <p class="note"><code>menulist</code> elements are so-called "native" popovers, in that their
   <span>popover state</span> is not <span data-x="popover-state-no-popover">No Popover</span> by
   default, even when the <code data-x="attr-popover">popover</code> attribute is not present.</p>
+
+  <p>Depending on user agent decisions about matching platform behavior, <code>menuitem</code>
+  elements may activate on <code data-x="event-mouseup">mouseup</code> even when the <code
+  data-x="event-mousedown">mousedown</code> (and thus the <code data-x="event-click">click</code>)
+  event did not got to the <code>menuitem</code> (for example, because a drag gesture that begins
+  on one <code>menuitem</code> and ends on another activates the <code>menuitem</code>).  If a user
+  agent has this behavior, then <code>menulist</code> elements whose parent is a
+  <code>submenu</code> element must also implement <span>activation behavior</span> (given a <code
+  data-x="event-click">click</code> event) that will <span>fire click on a menuitem if
+  needed</span> given that event and the <code>menulist</code> element.</p>
 
 
   <h4>The <dfn element><code>submenu</code></dfn> element</h4>

--- a/source
+++ b/source
@@ -65987,6 +65987,7 @@ interface <dfn interface>HTMLMenuBarElement</dfn> : <span>HTMLElement</span> {
    content</span>.</dd>
    <dt><span data-x="concept-element-contexts">Contexts in which this element can be used</span>:</dt>
    <dd>Where <span>flow content</span> is expected.</dd>
+   <dd>As a child of a <code>submenu</code> element.</dd>
    <dt><span data-x="concept-element-content-model">Content model</span>:</dt>
    <dd>Zero or more <span><code>menulist</code> element inner content elements</span>.</dd>
    <dt><span data-x="concept-element-attributes">Content attributes</span>:</dt>
@@ -66061,6 +66062,7 @@ interface <dfn interface>HTMLSubMenuElement</dfn> : <span>HTMLElement</span> {
    <dt><span data-x="concept-element-contexts">Contexts in which this element can be used</span>:</dt>
    <dd>As a descendant of a <code>menubar</code> element.</dd>
    <dd>As a descendant of a <code>menulist</code> element.</dd>
+   <dd>As a child of a <code>submenu</code> element.</dd>
    <dt><span data-x="concept-element-content-model">Content model</span>:</dt>
    <dd>Zero or more <span><code>menuitem</code> element inner content elements</span>.</dd>
    <dt><span data-x="concept-element-attributes">Content attributes</span>:</dt>

--- a/source
+++ b/source
@@ -66352,20 +66352,19 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
-  <p>A <code>menuitem</code> element <dfn data-x="menuitem-is-checkable">is checkable</dfn> if all
-  of the following are true:</p>
+  <p>A <code>menuitem</code> element's <dfn data-x="menuitem-checkable-state">checkable state</dfn>
+  is:</p>
 
-  <ul class="brief">
-   <li><p>its <span>cached ancestor <code>menulist</code> element</span> is non-null;</li>
+  <dl class="switch">
+   <dt>If its <span>cached ancestor <code>menulist</code> element</span> is null, its <span>cached
+   ancestor <code>fieldset</code> element</span> is non-null, or its <span
+   data-x="menuitem-invoked-submenu">invoked submenu</span> is not null</dt>
+   <dd><span data-x="attr-fieldset-checkable-state-none">None</span></dd>
 
-   <li><p>its <span>cached ancestor <code>fieldset</code> element</span> is non-null;</li>
-
-   <li><p>its <span>cached ancestor <code>fieldset</code> element</span>'s <span
-   data-x="attr-fieldset-checkable">checkable</span> attribute is not in the <span
-   data-x="attr-fieldset-checkable-state-none">None</span> state; and</p></li>
-
-   <li><p>its <span data-x="menuitem-invoked-submenu">invoked submenu</span> is null.</p></li>
-  </ul>
+   <dt>Otherwise</dt>
+   <dd>the state of its <span>cached ancestor <code>fieldset</code> element</span>'s <span
+   data-x="attr-fieldset-checkable">checkable</span> attribute</dd>
+  </dl>
   </div>
 
   <div algorithm>
@@ -66457,14 +66456,14 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   <p>The <dfn attribute for="HTMLMenuItemElement"><code
   data-x="dom-menuitem-checked">checked</code></dfn> IDL attribute, on getting, must return
   <span>this</span>'s <span data-x="concept-menuitem-checkedness">checkedness</span>. On setting, it
-  must <span>check a <code>menuitem</code> element</span> given <span>this</span> and the new
-  value.</p>
+  must <span>check a <code>menuitem</code> element</span> given <span>this</span>, the new
+  value, and false.</p>
   </div>
 
   <div algorithm>
   <p>To <dfn>check a <code>menuitem</code> element</dfn> <var>element</var> with a boolean
-  <var>isChecked</var>, run these steps. They return either "<code data-x="">close-menulist</code>"
-  or "<code data-x="">stay-open</code>":</p>
+  <var>isChecked</var> and a boolean <var>fireEvents</var>, run these steps. They return either
+  "<code data-x="">close-menulist</code>" or "<code data-x="">stay-open</code>":</p>
 
   <p class="note">This algorithm has these return values because when a <code>menuitem</code> is
   activated, it needs to know whether checking an item needs to hide the <span>cached ancestor
@@ -66474,9 +66473,13 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   that <span data-x="menuitem-invoked-submenu">invoke a submenu</span> — to let the user interact
   with the item without immediately dismissing it.</p>
 
+  <!-- TODO(dbaron): Should the <var>fireEvents</var> flag exist or should we fire events
+  for IDL setters too? -->
+
   <ol>
-   <li><p>If <var>element</var>'s <span data-x="menuitem-is-checkable">is checkable</span> is false,
-   then return "<code data-x="">stay-open</code>" if <var>element</var>'s <span
+   <li><p>If <var>element</var>'s <span data-x="menuitem-checkable-state">checkable state</span> is
+   <span data-x="attr-fieldset-checkable-state-none">None</span>, then return "<code
+   data-x="">stay-open</code>" if <var>element</var>'s <span
    data-x="menuitem-invoked-submenu">invoked submenu</span> is not null, and "<code
    data-x="">close-menulist</code>" otherwise.</p></li>
 
@@ -66489,12 +66492,21 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <li><p>Set <var>element</var>'s <span data-x="concept-menuitem-dirty-checkedness">dirty
    checkedness</span> to true.</p></li>
 
+   <li><p>If <var>fireEvents</var> is true, <span data-x="concept-event-fire">fire an event</span>
+   named <code data-x="event-checked">checked</code> at <var>element</var>.</p></li>
+
+   <!-- TODO(dbaron): This should fire "checked" events too! -->
+   <!-- TODO(dbaron): This and the reset algorithm should allow other elements between the
+   menuitems and the fieldset. -->
    <li><p>If <var>element</var>'s <span data-x="concept-menuitem-checkedness">checkedness</span> is
-   true and <var>element</var>'s <span>cached ancestor <code>fieldset</code> element</span>'s <span
-   data-x="attr-fieldset-checkable">checkable</span> attribute is in the <span
-   data-x="attr-fieldset-checkable-state-single">Single</span> state, then <span>reset
+   true and <var>element</var>'s <span data-x="menuitem-checkable-state">checkable state</span> is
+   <span data-x="attr-fieldset-checkable-state-single">Single</span>, then <span>reset
    <code>menuitem</code> checkedness</span> given <span>this</span>'s <span>parent</span> and
-   <span>this</span>, and return "<code data-x="">close-menulist</code>".</p></li>
+   <span>this</span>.</p></li>
+
+   <li><p>If <var>element</var>'s <span data-x="menuitem-checkable-state">checkable state</span> is
+   <span data-x="attr-fieldset-checkable-state-single">Single</span>, then return "<code
+   data-x="">close-menulist</code>".</p></li>
 
    <li><p>Return "<code data-x="">stay-open</code>".</p></li>
   </ol>
@@ -66521,22 +66533,14 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     behavior</span> can be triggered in other ways.</p>
    </li>
 
+   <li><p>Set <var>newChecked</var> to false if <var>element</var>'s <span
+   data-x="concept-menuitem-checkedness">checkedness</span> is true; otherwise true.</p></li>
+
    <li>
-    <p>If <var>element</var>'s <span data-x="menuitem-is-checkable">is checkable</span> is true:</p>
+    <p>Let <var>closeBehavior</var> be the result of <span>check a <code>menuitem</code>
+    element</span> given <var>element</var>, <var>newChecked</var>, and true.</p>
 
-    <ol>
-     <li><p>Set <var>newChecked</var> to false if <var>element</var>'s <span
-     data-x="concept-menuitem-checkedness">checkedness</span> is true; otherwise true.</p></li>
-
-     <li><p>Set <var>element</var>'s <span data-x="concept-menuitem-checkedness">checkedness</span> to
-     <var>newChecked</var>.</p></li>
-
-     <li><p>Set <var>element</var>'s <span data-x="concept-menuitem-dirty-checkedness">dirty
-     checkedness</span> to true.</p></li>
-
-     <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
-     data-x="event-checked">checked</code> at <var>element</var>.</p></li>
-    </ol>
+    <p class="note">If <var>element</var> is not checkable, this ignores <var>newChecked</var>.</p>
    </li>
 
    <li>
@@ -66558,9 +66562,9 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     </ol>
    </li>
 
-   <li><p class="XXX">TODO(domfarolino): Invoke steps to close the <span>outermost containing
-   menulist</span> when appropriate (sometimes we don't do this for checkable items?), before
-   running the shared steps below.</p></li>
+   <li><p>If <var>closeBehavior</var> is "close-menulist" then run the <span>hide popover
+   algorithm</span> given <var>element</var>'s <span>outermost containing menulist</span>, true,
+   true, false, and <var>element</var>.</p></li>
 
    <li><p>Run the <span>shared command invoker activation steps</span> given <var>element</var> and
    <var>event</var>.</p></li>
@@ -156441,7 +156445,7 @@ INSERT INTERFACES HERE
      <td> <dfn event for="HTMLElement"><code data-x="event-checked" id="event-menuitem-checked">checked</code></dfn>
      <td> <code>Event</code>
      <td> <code>menuitem</code> elements
-     <td> Fired at <span data-x="menuitem-is-checkable">checkable</span> <code>menuitem</code> elements when their <span data-x="concept-menuitem-checkedness">checkedness</span> changes
+     <td> Fired at checkable <code>menuitem</code> elements when their <span data-x="concept-menuitem-checkedness">checkedness</span> changes
 
     <tr> <!-- click -->
      <td> <code data-x="event-click">click</code>

--- a/source
+++ b/source
@@ -3295,6 +3295,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">shadow-including descendant</dfn>,
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendant</dfn>, and
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</dfn> concepts</li>
+     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-preceding" data-x="concept-tree-preceding">preceding</dfn> and
+             <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-following" data-x="concept-tree-following">following</dfn> concepts.</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-first-child">first child</dfn>,
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-last-child">last child</dfn>,
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-next-sibling">next sibling</dfn>,
@@ -66326,6 +66328,66 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
+  <p>To get the <dfn>menu container</dfn> of a <code>menuitem</code> element <var>item</var>, run
+  the following steps:</p>
+
+  <ol>
+   <li><p><span>Assert</span>: At least one of <var>item</var>'s <span>cached ancestor
+   <code>menubar</code> element</span> or <var>item</var>'s <span>cached ancestor
+   <code>menulist</code> element</span> is null.</p></li>
+
+   <li><p>Return <var>item</var>'s <span>cached ancestor <code>menubar</code>
+   element</span> if it is not null.</p></li>
+
+   <li><p>Return <var>item</var>'s <span>cached ancestor <code>menulist</code>
+   element</span>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>A <code>menuitem</code> element <var>item</var>'s <dfn>next focusable menuitem</dfn> is the
+  result of the following steps:</p>
+
+  <ol>
+   <li><p>Let <var>container</var> be <var>item</var>'s <span>menu container</span>.</p></li>
+
+   <li><p>Let <var>next</var> be the first <code>menuitem</code> descendant of <var>container</var>
+   in <span>tree order</span> that is <span data-x="concept-tree-following">following</span>
+   <var>item</var>, whose <span>menu container</span> is <var>container</var>, and is not <code
+   data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+
+   <li><p>If <var>next</var> is null, let <var>next</var> be the first <code>menuitem</code>
+   descendant of <var>container</var> in <span>tree order</span> whose <span>menu container</span>
+   is <var>container</var> and that is not <code
+   data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+
+   <li><p>Return <var>next</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>A <code>menuitem</code> element <var>item</var>'s <dfn>previous focusable menuitem</dfn> is the
+  result of the following steps:</p>
+
+  <ol>
+   <li><p>Let <var>container</var> be <var>item</var>'s <span>menu container</span>.</p></li>
+
+   <li><p>Let <var>previous</var> be the last <code>menuitem</code> descendant of
+   <var>container</var> in <span>tree order</span> that is <span
+   data-x="concept-tree-preceding">preceding</span> <var>item</var>, whose <span>menu
+   container</span> is <var>container</var>, and is not <code
+   data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+
+   <li><p>If <var>previous</var> is null, let <var>previous</var> be the last <code>menuitem</code>
+   descendant of <var>container</var> in <span>tree order</span> whose <span>menu container</span>
+   is <var>container</var> and that is not <code
+   data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+
+   <li><p>Return <var>previous</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
   <p>The <dfn attribute for="HTMLMenuItemElement"><code
   data-x="dom-menuitem-checked">checked</code></dfn> IDL attribute, on getting, must return
   <span>this</span>'s <span data-x="concept-menuitem-checkedness">checkedness</span>. On setting, it
@@ -66496,9 +66558,7 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <a href="https://drafts.csswg.org/css-writing-modes/#logical-to-physical">Abstract-to-Physical
    Mappings</a>.</p></li>
 
-   <li><p>Let <var>menuContainer</var> be the <span>cached ancestor <code>menulist</code>
-   element</span> of <var>item</var> if it is not null, otherwise the <span>cached ancestor
-   <code>menubar</code> element</span> of <var>item</var>.</p></li>
+   <li><p>Let <var>menuContainer</var> be <var>item</var>'s <span>menu container</span>.</p></li>
 
    <li><p>Let <var>inMenubar</var> be true if <var>menuContainer</var> is a <code>menubar</code>,
    otherwise false.</p></li>
@@ -66506,17 +66566,42 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <li><p>Then:</p>
     <dl class="switch">
      <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is false</dt>
-     <dd>Move focus to the previous <code>menuitem</code> in <var>menuContainer</var> whose
-     <span>cached ancestor <code>menulist</code> element</span> is <var>menuContainer</var>, cycling
-     to the end if there is no such previous item.</dd>
+     <dd>Move focus to the <span>previous focusable menuitem</span> of <var>item</var>.</dd>
 
      <dt>If <var>logicalDirection</var> is "block-end" and <var>inMenubar</var> is false</dt>
-     <dd>Move focus to the next <code>menuitem</code> in <var>menuContainer</var> whose <span>cached
-     ancestor <code>menulist</code> element</span> is <var>menuContainer</var>, cycling to the start
-     if there is no such next item.</dd>
+     <dd>Move focus to the <span>next focusable menuitem</span> of <var>item</var>.</dd>
 
      <dt>If <var>logicalDirection</var> is "inline-start" and <var>inMenubar</var> is false</dt>
-     <dd>TODO</dd>
+     <dd>
+      <p>Execute the following steps:</p>
+
+      <ol>
+       <li><p>Let <var>itemTrigger</var> be <var>menuContainer</var>'s <span>popover
+       trigger</span>.</p></li>
+
+       <li><p>If <var>itemTrigger</var> is not a <code>menuitem</code>, return.</p></li>
+
+       <li><p>Let <var>nextFocus</var> be:</p>
+        <dl class="switch">
+         <dt>If <var>itemTrigger</var>'s <span>cached ancestor <code>menulist</code> element</span>
+         is not null</dt>
+         <dd><var>itemTrigger</var></dd>
+
+         <dt>If <var>itemTrigger</var>'s <span>cached ancestor <code>menubar</code> element</span>
+         is not null</dt>
+         <dd><var>itemTrigger</var>'s <span>previous focusable menuitem</span> if it is not equal to
+         <var>itemTrigger</var>, otherwise null</dd>
+
+         <dt>Otherwise</dt>
+         <dd>null</dd>
+        </dl>
+       </li>
+
+       <li><p>If <var>nextFocus</var> is null, return.</p></li>
+
+       <li><p>TODO</p></li>
+      </ol>
+     </dd>
 
      <dt>If <var>logicalDirection</var> is "inline-end" and <var>inMenubar</var> is false and
      <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is null</dt>

--- a/source
+++ b/source
@@ -66720,10 +66720,18 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
      </dd>
 
      <dt>If <var>key</var> is "PageUp" and <var>inMenubar</var> is false</dt>
-     <dd>TODO</dd>
-
      <dt>If <var>key</var> is "PageDown" and <var>inMenubar</var> is false</dt>
-     <dd>TODO</dd>
+     <dd>
+      <p>The implementation may do one or both of the following:</p>
+
+      <ul>
+       <li><p>Scroll <var>menuContainer</var> or its containing elements.</p></li>
+
+       <li><p>Run the <span>focusing steps</span> for a <code>menuitem</code> element whose
+       <span>menu container</span> is <var>menuContainer</var> and that is not <code
+       data-x="attr-menuitem-disabled">disabled</code>.</p></li>
+      </ul>
+     </dd>
 
      <dt>If <var>logicalDirection</var> is "block-start" and <var>inMenubar</var> is true and
      <var>item</var>'s <span data-x="menuitem-invoked-submenu">invoked submenu</span> is not
@@ -66779,8 +66787,26 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
      <dd>Run the <span>focusing steps</span> for the <span>first focusable menuitem</span> of
      <var>menuContainer</var>, if it is not null.</dd>
 
+     <!-- TODO: Should this instead patch the sequential focus navigation rules?  Also, what should
+     happen before versus after closing?  Do we really need to find the next focusable element
+     before doing the closing, and does that correctly skip over the other menuitems in the menu
+     tree? -->
      <dt>If <var>key</var> is "Tab"</dt>
-     <dd>TODO</dd>
+     <dd>
+      <p>If the user agent normally handles the "Tab" key by running the <span>move focus
+      sequentially</span> algorithm, it should afterwards run the following steps:</p>
+
+      <ol>
+       <li><p>Let <var>outermostMenulist</var> be <var>item</var>'s <span>outermost containing
+       menulist</span>.</p></li>
+
+       <li><p>Let <var>trigger</var> be <var>outermostMenulist</var>'s <span>popover
+       trigger</span>.</p></li>
+
+       <li><p><span data-x="hide popover algorithm">Hide a popover</span> given
+       <var>outermostMenulist</var>, false, true, false, and <var>trigger</var>.</p></li>
+      </ol>
+     </dd>
 
      <dt>Otherwise</dt>
      <dd>Do nothing.</dd>
@@ -86401,7 +86427,8 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
   traversable</span> to the next or previous <span>focusable area</span> (e.g., as the default
   action of pressing the <kbd><kbd>tab</kbd></kbd> key), or when the user requests that focus
   sequentially move to a <span>top-level traversable</span> in the first place (e.g., from the
-  browser's location bar), the user agent must use the following algorithm:</p>
+  browser's location bar), the user agent must use the following algorithm, which is the <dfn>move
+  focus sequentially</dfn> algorithm:</p>
 
   <ol>
    <li><p>Let <var>starting point</var> be the <span>currently focused area of a top-level

--- a/source
+++ b/source
@@ -66492,8 +66492,15 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <li><p>Set <var>element</var>'s <span data-x="concept-menuitem-dirty-checkedness">dirty
    checkedness</span> to true.</p></li>
 
-   <li><p>If <var>fireEvents</var> is true, <span data-x="concept-event-fire">fire an event</span>
-   named <code data-x="event-checked">checked</code> at <var>element</var>.</p></li>
+   <li>
+    <p>If <var>fireEvents</var> is true, <span data-x="concept-event-fire">fire an event</span>
+    named <code data-x="event-checked">checked</code> at <var>element</var>.</p>
+
+    <p class="note">This fires an event for both checking and unchecking.  This matches checkbox
+    <code>input</code>s but not radio <code>input</code>s.  Radio <code>input</code>s fire events
+    only when checking but not when unchecking; however, unlike <code>menuitem</code>s they cannot
+    generally be unchecked by a user gesture.</p>
+   </li>
 
    <!-- TODO(dbaron): This should fire "checked" events too! -->
    <!-- TODO(dbaron): This and the reset algorithm should allow other elements between the

--- a/source
+++ b/source
@@ -66554,6 +66554,9 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
     <p>Let <var>submenu</var> be <var>element</var>'s <span
     data-x="menuitem-invoked-submenu">invoked submenu</span>.</p>
 
+    <p class="XXX">TODO(dbaron): This doesn't belong here for mouse/touch because menus open on
+    mouse/pointer down, not on click.  But does it need to stay here for keyboard activation?</p>
+
     <p>If <var>submenu</var> is not null:</p>
 
     <ol>
@@ -66577,6 +66580,18 @@ interface <dfn interface>HTMLMenuItemElement</dfn> : <span>HTMLElement</span> {
    <var>event</var>.</p></li>
   </ol>
   </div>
+
+  <p>For mouse, pointer, and touch interactions, implementations are expected to open <span
+  data-x="menuitem-invoked-submenu">invoked submenus</span> when the pointer or finger is down, not
+  in response to lifting it.  While the pointer or finger remains down, they are expected to open
+  and close <span data-x="menuitem-invoked-submenu">invoked submenus</span> of different menuitems
+  as long as the opened and closed menus have the same <span>outermost containing menulist</span>.
+  The exact behavior of when <code>menulist</code>s open and close during these interactions is not
+  specified.  However, implementations should implement some sort of "safe triangle" behavior that
+  allows the pointer or finger to cross outside of the menus while moving from or to a
+  <code>menuitem</code> in a submenu.  This means that <code>menulist</code>s may be open during
+  this sort of interaction even while the pointer position is not inside any of the relevant menu
+  elements.</p>
 
   <div algorithm>
   <p>When a <code>menuitem</code> element's <span>outermost menu container</span>'s


### PR DESCRIPTION
This PR introduces the `<menubar>`, `<menulist>`, and `<menuitem>` elements as they appear in Open UI's menu elements proposal: https://open-ui.org/components/menu.explainer/. This includes their integration with popovers, command invokers, `<fieldset>` and checkability, default styles, and variant default styles for the `<menulist>` element depending on how it is rendered. What has not been spec'd yet is:
 - Anchor positioning fallback styles
 - The `orientation` attribute's effect on default styles and keyboard navigability
 - Exact keyboard behavior; we plan to follow customizable select's precedent (see https://github.com/openui/open-ui/issues/1087) of specifying activation behavior, and what happens when you keyboard-navigate _away_ from a menu item (i.e., dismissing `<menulist>` popovers). But to be consistent with customizable select, we're not planning on specifying the exact keyboard behavior for getting from one menulist to another in a menubar, or traversing through menu items in a menu bar or list. These will be covered by examples, notes, and `.optional` WPTs
 - The `checked` event integration discussed in https://github.com/openui/open-ui/issues/1321
 - Figuring out how/if we need to express keyboard type-ahead search (i.e., pressing the `a` key to focus the first menuitem in a menulist that starts with the character `a`)
 - ...

This PR is only a draft. It's suitable for stage 2 evaluation of the menu elements proposal tracked by https://github.com/whatwg/html/issues/11729, but has rough edges and non-trivial TODOs. The API shape is just about fully expressed though.

- [ ] At least two implementers are interested (and none opposed):
   * Chromium
   * [Safari](https://github.com/WebKit/standards-positions/issues/580)
   * [Firefox](https://github.com/mozilla/standards-positions/issues/1317)
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * (in progress) https://github.com/web-platform-tests/wpt/tree/master/html/semantics/menu/tentative
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/406566432
   * Gecko: …
   * WebKit: …
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): N/A
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): N/A
- [ ] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs:
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12011/dom.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/dom.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/dom.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/form-elements.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/form-elements.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/form-elements.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/grouping-content.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/grouping-content.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/grouping-content.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/index.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/index.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/index.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/indices.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/indices.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/indices.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/infrastructure.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/infrastructure.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/interaction.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/interaction.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/interaction.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/interactive-elements.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/interactive-elements.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/interactive-elements.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/obsolete.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/obsolete.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/obsolete.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/popover.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/popover.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/popover.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/rendering.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/rendering.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/rendering.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/semantics-other.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/semantics-other.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/semantics-other.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )
<a href="https://whatpr.org/html/12011/text-level-semantics.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">/text-level-semantics.html</a>  ( <a href="https://whatpr.org/html/12011/68909b2...6153f2d/text-level-semantics.html" title="Last updated on Aug 25, 2026, 7:26 PM UTC (6153f2d)">diff</a> )