### PR TITLE
Add HTMLScriptElement IDL changes for Trusted Types

### DIFF
--- a/source
+++ b/source
@@ -67243,6 +67243,10 @@ interface <dfn interface>HTMLScriptElement</dfn> : <span>HTMLElement</span> {
    <dd w-dev>Uses <code>HTMLScriptElement</code>.</dd>
   </dl>
 
+  <p class="XXX">The <code>script</code> element processing by <cite>Trusted Types</cite> is still
+  largely defined in that specification, and has some missing steps that are expected of
+  implementations. See <a href="https://github.com/w3c/trusted-types/issues/507">issue #507</a>.</p>
+
   <p>The <code>script</code> element allows authors to include dynamic script, instructions to the
   user agent, and data blocks in their documents. The element does not <span
   data-x="represents">represent</span> content for the user.</p>

--- a/source
+++ b/source
@@ -3450,6 +3450,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#valid-attribute-local-name">valid attribute local name</dfn></li>
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#valid-element-local-name">valid element local name</dfn></li>
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#is-a-global-custom-element-registry">is a global custom element registry</dfn></li>
+     <li><dfn data-x-href="https://dom.spec.whatwg.org/#get-text-content">get text content</dfn></li>
+     <li><dfn data-x-href="https://dom.spec.whatwg.org/#set-text-content">set text content</dfn></li>
     </ul>
 
     <p>The following features are defined in <cite>UI Events</cite>: <ref>UIEVENTS</ref></p>
@@ -4995,6 +4997,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x="tt-trustedscript-data" data-x-href="https://w3c.github.io/trusted-types/dist/spec/#trustedscript-data"><code>data</code></dfn></li>
      <li><dfn data-x="tt-trustedscripturl" data-x-href="https://w3c.github.io/trusted-types/dist/spec/#trustedscripturl"><code>TrustedScriptURL</code></dfn></li>
      <li><dfn data-x="tt-getcompliantstring" data-x-href="https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-compliant-string">get trusted type compliant string</dfn></li>
+     <li><dfn data-x="tt-update-script-trustedness" data-x-href="https://w3c.github.io/trusted-types/dist/spec/#update-script-trustedness-algorithm">update script trustedness</dfn></li>
     </ul>
    </dd>
 
@@ -67218,7 +67221,7 @@ interface <dfn interface>HTMLScriptElement</dfn> : <span>HTMLElement</span> {
   [<span>HTMLConstructor</span>] constructor();
 
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLScriptElement" data-x="dom-script-type">type</dfn>;
-  [<span>CEReactions</span>, <span data-x="xattr-ReflectURL">ReflectURL</span>] attribute USVString <dfn attribute for="HTMLScriptElement" data-x="dom-script-src">src</dfn>;
+  [<span>CEReactions</span>] attribute (TrustedScriptURL or USVString) <span data-x="dom-script-src">src</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLScriptElement" data-x="dom-script-noModule">noModule</dfn>;
   [<span>CEReactions</span>] attribute boolean <span data-x="dom-script-async">async</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLScriptElement" data-x="dom-script-defer">defer</dfn>;
@@ -67228,7 +67231,9 @@ interface <dfn interface>HTMLScriptElement</dfn> : <span>HTMLElement</span> {
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLScriptElement" data-x="dom-script-integrity">integrity</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-script-fetchPriority">fetchPriority</span>;
 
-  [<span>CEReactions</span>] attribute DOMString <span data-x="dom-script-text">text</span>;
+  [<span>CEReactions</span>] attribute (TrustedScript or [LegacyNullToEmptyString] DOMString) <span data-x="dom-script-innerText">innerText</span>;
+  [<span>CEReactions</span>] attribute (TrustedScript or DOMString)? <span data-x="dom-script-textContent">textContent</span>;
+  [<span>CEReactions</span>] attribute (TrustedScript or DOMString) <span data-x="dom-script-text">text</span>;
 
   static boolean <span data-x="dom-script-supports">supports</span>(DOMString type);
 
@@ -67603,8 +67608,108 @@ interface <dfn interface>HTMLScriptElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
-  <p>The <code data-x="dom-script-text">text</code> setter steps are to <span>string replace
-  all</span> with the given value within <span>this</span>.</p>
+  <p>The <code data-x="dom-script-text">text</code> setter steps are:</p>
+
+  <ol>
+   <li><p>Let <var>compliantScript</var> be the result of invoking the <span
+   data-x="tt-getcompliantstring">get trusted type compliant string</span> algorithm with <code
+   data-x="tt-trustedscript">TrustedScript</code>, <span>this</span>'s <span>relevant global
+   object</span>, the given value, "<code data-x="">HTMLScriptElement text</code>", and "<code
+   data-x="">script</code>".</p></li>
+
+   <li><p><span data-x="tt-update-script-trustedness">Update script trustedness</span> for
+   <span>this</span> with <var>compliantScript</var>.</p></li>
+
+   <li><p><span>String replace all</span> with <var>compliantScript</var> within
+   <span>this</span>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>The <dfn attribute for="HTMLScriptElement"><code
+  data-x="dom-script-innerText">innerText</code></dfn> getter steps are to return the result of
+  running <span>get the text steps</span> with <span>this</span>.</p>
+  </div>
+
+  <div algorithm>
+  <p>The <code data-x="dom-script-innerText">innerText</code> setter steps are:</p>
+
+  <ol>
+   <li><p>Let <var>compliantScript</var> be the result of invoking the <span
+   data-x="tt-getcompliantstring">get trusted type compliant string</span> algorithm with <code
+   data-x="tt-trustedscript">TrustedScript</code>, <span>this</span>'s <span>relevant global
+   object</span>, the given value, "<code data-x="">HTMLScriptElement innerText</code>", and "<code
+   data-x="">script</code>".</p></li>
+
+   <li><p><span data-x="tt-update-script-trustedness">Update script trustedness</span> for
+   <span>this</span> with <var>compliantScript</var>.</p></li>
+
+   <li><p>Run <span>set the inner text steps</span> with <span>this</span> and
+   <var>compliantScript</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>The <dfn attribute for="HTMLScriptElement"><code
+  data-x="dom-script-textContent">textContent</code></dfn> getter steps are to return the result of
+  running <span>get text content</span> with <span>this</span>.</p>
+  </div>
+
+  <div algorithm>
+  <p>The <code data-x="dom-script-textContent">textContent</code> setter steps are:</p>
+
+  <ol>
+   <li><p>Let <var>compliantScript</var> be the result of invoking the <span
+   data-x="tt-getcompliantstring">get trusted type compliant string</span> algorithm with <code
+   data-x="tt-trustedscript">TrustedScript</code>, <span>this</span>'s <span>relevant global
+   object</span>, the given value, "<code data-x="">HTMLScriptElement textContent</code>", and
+   "<code data-x="">script</code>".</p></li>
+
+   <li><p><span data-x="tt-update-script-trustedness">Update script trustedness</span> for
+   <span>this</span> with <var>compliantScript</var>.</p></li>
+
+   <li><p>Run <span>set text content</span> with <span>this</span> and
+   <var>compliantScript</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>The <dfn attribute for="HTMLScriptElement"><code data-x="dom-script-src">src</code></dfn>
+  getter steps are:</p>
+
+  <ol>
+   <li><p>Let <var>element</var> be the result of running <span>this</span>'s <span>get the
+   element</span>.</p></li>
+
+   <li><p>Let <var>contentAttributeValue</var> be the result of running <span>this</span>'s
+   <span>get the content attribute</span>.</p></li>
+
+   <li><p>If <var>contentAttributeValue</var> is null, then return the empty string.</p></li>
+
+   <li><p>Let <var>urlString</var> be the result of be the result of
+   <span>encoding-parsing-and-serializing a URL</span> given <var>contentAttributeValue</var>,
+   relative to <var>element</var>'s <span>node document</span>.</p></li>
+
+   <li><p>If <var>urlString</var> is not failure, then return <var>urlString</var>.</p></li>
+
+   <li><p>Return <var>contentAttributeValue</var>, <span data-x="convert">converted to a scalar
+   value string</span>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>The <code data-x="dom-script-src">src</code> setter steps are:</p>
+
+  <ol>
+   <li><p>Let <var>compliantScriptURL</var> be the result of invoking the <span
+   data-x="tt-getcompliantstring">get trusted type compliant string</span> algorithm with <code
+   data-x="tt-trustedscripturl">TrustedScriptURL</code>, <span>this</span>'s <span>relevant global
+   object</span>, the given value, "<code data-x="">HTMLScriptElement src</code>", and "<code
+   data-x="">script</code>".</p></li>
+
+   <li><p>Set <span>this</span>'s <code data-x="attr-script-src">src</code> content attribute to
+   <var>compliantScriptURL</var>.</p></li>
+  </ol>
   </div>
 
   <div algorithm>


### PR DESCRIPTION
Add HTMLScriptElement IDL changes for Trusted Types

This upstreams the changes to HTMLScriptElement's IDL that was previously patched by the trusted types specification.

HTMLScriptElement now shadows innerText and textContent, so these can take a TrustedScript object.

Its src and text properties are also updated to take TrustedScriptURL and TrustedScript respectively.

Depends on https://github.com/w3c/trusted-types/pull/607

This has no behaviour changes and is just moving spec text from Trusted Types to the HTML spec.
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * ...
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …
- [ ] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs:
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Wattsi server error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 8, 2026, 2:20 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Wattsi Server](https://github.com/domenic/wattsi-server) - Wattsi Server is the web service used to build the WHATWG HTML spec.

:link: [Related URL](https://build.whatwg.org/wattsi)

**Error output:**

```
      <!DOCTYPE html>
      <html>
      <head>
          <meta name="viewport" content="width=device-width, initial-scale=1">
          <meta name="robots" content="noindex">
          <style>body,html{height:100%;margin:0}body{display:flex;align-items:center;justify-content:center;flex-direction:column;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}p{text-align:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;color:#000;font-size:14px;margin-top:-50px}p.code{font-size:24px;font-weight:500;border-bottom:1px solid #e0e1e2;padding:0 20px 15px}p.text{margin:0}a,a:visited{color:#aaa}</style>
      </head>
      <body>
      <p class="code">
        Error code: 503      </p>
      <p class="text">
        Well, This is unexpected. An Error has occurred, and we are working to fix the problem! We will be up and running shortly. Try refreshing the page or try again in a few minutes.
      </p>
        <div style="display:none;">
          <h1>
    upstream_reset_before_response_started{connection_termination} (503 UC)      </h1>
          <p data-translate="connection_timed_out">App Platform failed to forward this request to the application.</p>
      </div>
      </body>
      </html>
    
```

_This seems to be an issue with the [Wattsi Server](https://github.com/domenic/wattsi-server) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Wattsi Server](https://github.com/domenic/wattsi-server/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Wattsi Server, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/html%2312195.)._

</details>
