### PR TITLE
Expand disabled form control event handling spec text

### DIFF
--- a/source
+++ b/source
@@ -123477,15 +123477,16 @@ import "https://example.com/foo/../module2.mjs";</code></pre>
     must be fired using <span data-x="concept-task">tasks</span> <span data-x="queue a
     task">queued</span> with the <span>user interaction task source</span>. <ref>UIEVENTS</ref></p>
 
-    <p>For trusted <code data-x="event-click">click</code>, <code
+    <p>For <code data-x="event-click">click</code>, <code
     data-x="event-mousedown">mousedown</code>, <code data-x="event-mouseup">mouseup</code>, and
     <code data-x="event-dblclick">dblclick</code> events that are fired from tasks <span
-    data-x="queue a task">queued</span> with this task source: if the event target is a form
-    control that is <span data-x="concept-fe-disabled">disabled</span>, or an <code>option</code>
-    element that is <span data-x="concept-option-disabled">disabled</span>, then the event must not
-    be dispatched on that element; and if the event target is a descendant of a form control that is
-    <span data-x="concept-fe-disabled">disabled</span>, then the event must not be dispatched on
-    that form control or any of its ancestors.</p>
+    data-x="queue a task">queued</span> with this task source: if the event target is an
+    <code>option</code> element that is <span data-x="concept-option-disabled">disabled</span>,
+    then the event must not be dispatched on that element; if the event target is a form control
+    that is <span data-x="concept-fe-disabled">disabled</span>, then the event must not be
+    dispatched on that form control or any of its ancestors; and if the event target is a
+    descendant of a form control that is <span data-x="concept-fe-disabled">disabled</span>, then
+    the event must not be dispatched on that form control or any of its ancestors.</p>
 
     <!-- user interaction events integration point -->
    </dd>

--- a/source
+++ b/source
@@ -58311,6 +58311,17 @@ interface <dfn interface>HTMLOptionElement</dfn> : <span>HTMLElement</span> {
   </ol>
   </div>
 
+  <div w-nodev>
+
+  <p>An <code>option</code> element that is <span data-x="attr-option-disabled">disabled</span> must
+  prevent any <code data-x="event-click">click</code>, <code
+  data-x="event-mousedown">mousedown</code>, <code data-x="event-mouseup">mouseup</code>, and
+  <code data-x="event-dblclick">dblclick</code> events that are <span data-x="queue a
+  task">queued</span> on the <span>user interaction task source</span> from being dispatched on
+  the element.</p>
+
+  </div>
+
   <p class="note">Being <span data-x="concept-option-disabled">disabled</span> does not prevent all
   modifications to the <code>option</code> element. For example, its <span
   data-x="concept-option-selectedness">selectedness</span> could be modified programmatically from
@@ -60994,9 +61005,13 @@ form.method === input; // => true</code></pre>
 
   <div w-nodev>
 
-  <p class="note">For events fired from the <span>user interaction task source</span>, disabled
-  form controls suppress dispatch of some trusted mouse events as defined in the task source's
-  integration requirements below.</p>
+  <p>A form control that is <span data-x="concept-fe-disabled">disabled</span> must prevent any
+  <code data-x="event-click">click</code>, <code data-x="event-mousedown">mousedown</code>, <code
+  data-x="event-mouseup">mouseup</code>, and <code data-x="event-dblclick">dblclick</code> events
+  that are <span data-x="queue a task">queued</span> on the <span>user interaction task
+  source</span> from being dispatched on the form control or any of its ancestors. If such an
+  event would be dispatched on a descendant of the form control, the form control and all of its
+  ancestors must be removed from the event's path so that the event is not dispatched on them.</p>
 
   <p class="note">This does not affect pointer events such as <code
   data-x="event-pointerdown">pointerdown</code> and <code
@@ -123476,17 +123491,6 @@ import "https://example.com/foo/../module2.mjs";</code></pre>
     <p>Events sent in response to user input (e.g., <code data-x="event-click">click</code> events)
     must be fired using <span data-x="concept-task">tasks</span> <span data-x="queue a
     task">queued</span> with the <span>user interaction task source</span>. <ref>UIEVENTS</ref></p>
-
-    <p>For <code data-x="event-click">click</code>, <code
-    data-x="event-mousedown">mousedown</code>, <code data-x="event-mouseup">mouseup</code>, and
-    <code data-x="event-dblclick">dblclick</code> events that are fired from tasks <span
-    data-x="queue a task">queued</span> with this task source: if the event target is an
-    <code>option</code> element that is <span data-x="concept-option-disabled">disabled</span>,
-    then the event must not be dispatched on that element; if the event target is a form control
-    that is <span data-x="concept-fe-disabled">disabled</span>, then the event must not be
-    dispatched on that form control or any of its ancestors; and if the event target is a
-    descendant of a form control that is <span data-x="concept-fe-disabled">disabled</span>, then
-    the event must not be dispatched on that form control or any of its ancestors.</p>
 
     <!-- user interaction events integration point -->
    </dd>

--- a/source
+++ b/source
@@ -58314,11 +58314,11 @@ interface <dfn interface>HTMLOptionElement</dfn> : <span>HTMLElement</span> {
   <div w-nodev>
 
   <p>An <code>option</code> element that is <span data-x="attr-option-disabled">disabled</span> must
-  prevent any <code data-x="event-click">click</code>, <code
-  data-x="event-mousedown">mousedown</code>, <code data-x="event-mouseup">mouseup</code>, and
-  <code data-x="event-dblclick">dblclick</code> events that are <span data-x="queue a
-  task">queued</span> on the <span>user interaction task source</span> from being dispatched on
-  the element.</p>
+  prevent any events whose <code data-x="dom-Event-isTrusted">isTrusted</code> attribute is true and
+  whose <code data-x="dom-Event-type">type</code> is one of "<code
+  data-x="event-click">click</code>", "<code data-x="event-mousedown">mousedown</code>", "<code
+  data-x="event-mouseup">mouseup</code>", or "<code data-x="event-dblclick">dblclick</code>" from
+  being dispatched on the element.</p>
 
   </div>
 
@@ -61006,12 +61006,13 @@ form.method === input; // => true</code></pre>
   <div w-nodev>
 
   <p>A form control that is <span data-x="concept-fe-disabled">disabled</span> must prevent any
-  <code data-x="event-click">click</code>, <code data-x="event-mousedown">mousedown</code>, <code
-  data-x="event-mouseup">mouseup</code>, and <code data-x="event-dblclick">dblclick</code> events
-  that are <span data-x="queue a task">queued</span> on the <span>user interaction task
-  source</span> from being dispatched on the form control or any of its ancestors. If such an
-  event would be dispatched on a descendant of the form control, the form control and all of its
-  ancestors must be removed from the event's path so that the event is not dispatched on them.</p>
+  events whose <code data-x="dom-Event-isTrusted">isTrusted</code> attribute is true and whose <code
+  data-x="dom-Event-type">type</code> is one of "<code data-x="event-click">click</code>", "<code
+  data-x="event-mousedown">mousedown</code>", "<code data-x="event-mouseup">mouseup</code>", or
+  "<code data-x="event-dblclick">dblclick</code>" from being dispatched on the form control or any
+  of its ancestors. If such an event would be dispatched on a descendant of the form control, the
+  form control and all of its ancestors must be removed from the event's path so that the event is
+  not dispatched on them.</p>
 
   <p class="note">This does not affect pointer events such as <code
   data-x="event-pointerdown">pointerdown</code> and <code
@@ -123491,7 +123492,6 @@ import "https://example.com/foo/../module2.mjs";</code></pre>
     <p>Events sent in response to user input (e.g., <code data-x="event-click">click</code> events)
     must be fired using <span data-x="concept-task">tasks</span> <span data-x="queue a
     task">queued</span> with the <span>user interaction task source</span>. <ref>UIEVENTS</ref></p>
-
     <!-- user interaction events integration point -->
    </dd>
 

--- a/source
+++ b/source
@@ -61004,8 +61004,17 @@ form.method === input; // => true</code></pre>
   <div w-nodev>
 
   <p>A form control that is <span data-x="concept-fe-disabled">disabled</span> must prevent any
-  <code data-x="event-click">click</code> events that are <span data-x="queue a task">queued</span>
-  on the <span>user interaction task source</span> from being dispatched on the element.</p>
+  <code data-x="event-click">click</code>, <code data-x="event-mousedown">mousedown</code>, <code
+  data-x="event-mouseup">mouseup</code>, and <code data-x="event-dblclick">dblclick</code> events
+  that are <span data-x="queue a task">queued</span> on the <span>user interaction task
+  source</span> from being dispatched on the element or from bubbling past the element to its
+  ancestors.</p>
+
+  <p class="note">This does not affect pointer events such as <code
+  data-x="event-pointerdown">pointerdown</code> and <code
+  data-x="event-pointerup">pointerup</code>, which are dispatched normally regardless of the
+  disabled state. Authors who wish to observe user interaction with <span
+  data-x="concept-fe-disabled">disabled</span> form controls can use pointer event listeners.</p>
 
   </div>
 

--- a/source
+++ b/source
@@ -58311,15 +58311,6 @@ interface <dfn interface>HTMLOptionElement</dfn> : <span>HTMLElement</span> {
   </ol>
   </div>
 
-  <div w-nodev>
-
-  <p>An <code>option</code> element that is <span data-x="attr-option-disabled">disabled</span> must
-  prevent any <code data-x="event-click">click</code> events that are <span data-x="queue a
-  task">queued</span> on the <span>user interaction task source</span> from being dispatched on the
-  element.</p>
-
-  </div>
-
   <p class="note">Being <span data-x="concept-option-disabled">disabled</span> does not prevent all
   modifications to the <code>option</code> element. For example, its <span
   data-x="concept-option-selectedness">selectedness</span> could be modified programmatically from
@@ -61003,12 +60994,9 @@ form.method === input; // => true</code></pre>
 
   <div w-nodev>
 
-  <p>A form control that is <span data-x="concept-fe-disabled">disabled</span> must prevent any
-  <code data-x="event-click">click</code>, <code data-x="event-mousedown">mousedown</code>, <code
-  data-x="event-mouseup">mouseup</code>, and <code data-x="event-dblclick">dblclick</code> events
-  that are <span data-x="queue a task">queued</span> on the <span>user interaction task
-  source</span> from being dispatched on the element or from bubbling past the element to its
-  ancestors.</p>
+  <p class="note">For events fired from the <span>user interaction task source</span>, disabled
+  form controls suppress dispatch of some trusted mouse events as defined in the task source's
+  integration requirements below.</p>
 
   <p class="note">This does not affect pointer events such as <code
   data-x="event-pointerdown">pointerdown</code> and <code
@@ -123488,6 +123476,17 @@ import "https://example.com/foo/../module2.mjs";</code></pre>
     <p>Events sent in response to user input (e.g., <code data-x="event-click">click</code> events)
     must be fired using <span data-x="concept-task">tasks</span> <span data-x="queue a
     task">queued</span> with the <span>user interaction task source</span>. <ref>UIEVENTS</ref></p>
+
+    <p>For trusted <code data-x="event-click">click</code>, <code
+    data-x="event-mousedown">mousedown</code>, <code data-x="event-mouseup">mouseup</code>, and
+    <code data-x="event-dblclick">dblclick</code> events that are fired from tasks <span
+    data-x="queue a task">queued</span> with this task source: if the event target is a form
+    control that is <span data-x="concept-fe-disabled">disabled</span>, or an <code>option</code>
+    element that is <span data-x="concept-option-disabled">disabled</span>, then the event must not
+    be dispatched on that element; and if the event target is a descendant of a form control that is
+    <span data-x="concept-fe-disabled">disabled</span>, then the event must not be dispatched on
+    that form control or any of its ancestors.</p>
+
     <!-- user interaction events integration point -->
    </dd>
 


### PR DESCRIPTION
The current spec text for disabled form controls says only:

> A form control that is disabled must prevent any **click** events that are queued on the user interaction task source from being dispatched on the element.

This is incomplete. This PR expands it to describe:

- **Full event list**: `click`, `mousedown`, `mouseup`, and `dblclick` are all prevented on disabled form controls (not just `click`)
- **Event path truncation**: When these events target a descendant of a disabled form control, the disabled control and all its ancestors are removed from the event path - the event fires on the descendant but does not bubble through the disabled control
- **Pointer events unaffected**: A note clarifying that `pointerdown`, `pointerup`, etc. are dispatched normally



All three major engines have shipped this behavior.

### Chrome - shipped M120 (Nov 2023)
- [bf57b47](https://chromium.googlesource.com/chromium/src/+/bf57b47313a1bac46397854bd604b10d3d046e76) - "Stop click/mouseup/mousedown propagation at disabled form parents"
- [5a770f4](https://chromium.googlesource.com/chromium/src/+/5a770f441d54b) - Enabled by default (Jun 2023)
- [cd94a8c](https://chromium.googlesource.com/chromium/src/+/cd94a8caa02d5) - Flag removed, behavior permanent (Nov 2023)

### Safari - shipped Safari 17 (Sep 2023)
- [WebKit Bug 251246](https://bugs.webkit.org/show_bug.cgi?id=251246) - "Event dispatching on disabled form controls"
- [WebKit/WebKit#13837](https://github.com/WebKit/WebKit/pull/13837)
- [9ed97a1ca58c](https://commits.webkit.org/264098@main) (May 2023)

### Firefox - shipped Firefox 124 (Jan 2024)
- [Bug 1653882](https://bugzilla.mozilla.org/show_bug.cgi?id=1653882) - main tracking bug
- [Bug 1799565](https://bugzilla.mozilla.org/show_bug.cgi?id=1799565) - "Allow pointer events on disabled form elements on Nightly"
- [Bug 1829874](https://bugzilla.mozilla.org/show_bug.cgi?id=1829874) - "Disabled fieldset should not stop event propagation"
- [87db82da5ead](https://hg.mozilla.org/mozilla-central/rev/87db82da5ead) - `dom.forms.always_allow_pointer_events.enabled` shipped by default (Jan 2024)

## WPT tests

The following WPT tests already verify this behavior but are marked `.tentative` pending this spec change:

- `html/semantics/disabled-elements/disabled-event-dispatch.tentative.html`
- `html/semantics/disabled-elements/event-propagate-disabled.tentative.html`
- `html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html`
- `html/semantics/disabled-elements/fieldset-event-propagation.tentative.html`

Once this lands, these can be renamed to remove `.tentative`.

## Closes

- https://github.com/whatwg/html/issues/5886
- https://github.com/whatwg/html/issues/2368
- https://issues.chromium.org/issues/41302618


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12219/form-control-infrastructure.html" title="Last updated on Aug 18, 2026, 11:01 AM UTC (236b8aa)">/form-control-infrastructure.html</a>  ( <a href="https://whatpr.org/html/12219/ac0389a...236b8aa/form-control-infrastructure.html" title="Last updated on Aug 18, 2026, 11:01 AM UTC (236b8aa)">diff</a> )
<a href="https://whatpr.org/html/12219/form-elements.html" title="Last updated on Aug 18, 2026, 11:01 AM UTC (236b8aa)">/form-elements.html</a>  ( <a href="https://whatpr.org/html/12219/ac0389a...236b8aa/form-elements.html" title="Last updated on Aug 18, 2026, 11:01 AM UTC (236b8aa)">diff</a> )