### PR TITLE
Module Stylesheet <link> tags

### DIFF
--- a/source
+++ b/source
@@ -16577,8 +16577,9 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The address of the link(s) is given by the <dfn element-attr for="link"><code
   data-x="attr-link-href">href</code></dfn> attribute. If the <code
-  data-x="attr-link-href">href</code> attribute is present, then its value must be a <span>valid
-  non-empty URL potentially surrounded by spaces</span>. One or both of the <code
+  data-x="attr-link-href">href</code> attribute is present and the element is not a <span>module
+  stylesheet link</span>, then its value must be a <span>valid non-empty URL potentially surrounded
+  by spaces</span>. One or both of the <code
   data-x="attr-link-href">href</code> or <code data-x="attr-link-imagesrcset">imagesrcset</code>
   attributes must be present.</p>
 
@@ -16722,7 +16723,11 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The <dfn element-attr for="link"><code data-x="attr-link-type">type</code></dfn> attribute
   gives the <span>MIME type</span> of the linked resource. It is purely advisory. The value must be
-  a <span>valid MIME type string</span>.</p>
+  a <span>valid MIME type string</span>. One exception to this is when its value is an <span>ASCII
+  case-insensitive</span> match for the string "<code data-x="">module</code>" and the element's
+  <code data-x="attr-link-rel">rel</code> attribute contains the <code
+  data-x="rel-stylesheet">stylesheet</code> keyword, which causes the stylesheet link to be
+  processed as a <span>module stylesheet link</span>.</p>
 
   <p>For <span data-x="external resource link">external resource links</span>, the <code
   data-x="attr-link-type">type</code> attribute is used as a hint to user agents so that they can
@@ -16737,7 +16742,8 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The <dfn element-attr for="link"><code data-x="attr-link-title">title</code></dfn> attribute
   gives the title of the link. With one exception, it is purely advisory. The value is text. The
-  exception is for style sheet links that are <span>in a document tree</span>, for which the <code
+  exception is for style sheet links that are <span>in a document tree</span> and are not <span
+  data-x="module stylesheet link">module stylesheet links</span>, for which the <code
   data-x="attr-link-title">title</code> attribute defines <span data-x="CSS style sheet set">CSS
   style sheet sets</span>.</p>
 
@@ -16973,12 +16979,13 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <h5>Processing the <code data-x="attr-link-type">type</code> attribute</h5>
 
-  <p>If the <code data-x="attr-link-type">type</code> attribute is present, then the user agent must
-  assume that the resource is of the given type (even if that is not a <span>valid MIME type
-  string</span>, e.g. the empty string). If the attribute is omitted, but the <span>external
-  resource link</span> type has a default type defined, then the user agent must assume that the
-  resource is of that type. If the UA does not support the given <span>MIME type</span> for the
-  given link relationship, then the UA should not <span>fetch and process the linked
+  <p>If the <code data-x="attr-link-type">type</code> attribute is present and the element is not a
+  <span>module stylesheet link</span>, then the user agent must assume that the resource is of the
+  given type (even if that is not a <span>valid MIME type string</span>, e.g. the empty string). If
+  the attribute is omitted, but the <span>external resource link</span> type has a default type
+  defined, then the user agent must assume that the resource is of that type. If the UA does not
+  support the given <span>MIME type</span> for the given link relationship, then the UA should not
+  <span>fetch and process the linked
   resource</span>; if the UA does support the given <span>MIME type</span> for the given link
   relationship, then the UA should <span>fetch and process the linked resource</span> at the
   appropriate time as specified for the <span>external resource link</span>'s particular type.
@@ -29806,13 +29813,30 @@ document.body.appendChild(wbr);</code></pre>
   link</span> that contributes to the styling processing model. This keyword is
   <span>body-ok</span>.</p>
 
+  <div algorithm>
+  <p>A <code>link</code> element is a <dfn>module stylesheet link</dfn> if its <code
+  data-x="attr-link-rel">rel</code> attribute contains the <code
+  data-x="rel-stylesheet">stylesheet</code> keyword, and its <code
+  data-x="attr-link-type">type</code> attribute's value is an <span>ASCII
+  case-insensitive</span> match for the string "<code data-x="">module</code>".</p>
+  </div>
+
+  <div w-nodev>
+
+  <p>A <code>link</code> element has an associated <dfn id="link-module-css-style-sheet"
+  data-x="link module CSS style sheet" for="link">module CSS style sheet</dfn>, which is a
+  <code>CSSStyleSheet</code> or null. It is initially null.</p>
+
+  </div>
+
   <p>The specified resource is a <span>CSS style sheet</span> that describes how to present the
   document.</p>
 
   <p>If the <code data-x="rel-alternate">alternate</code> keyword is also specified on the
-  <code>link</code> element, then <dfn id="the-link-is-an-alternative-stylesheet">the link is an
-  alternative style sheet</dfn>; in this case, the <code data-x="attr-title">title</code> attribute
-  must be specified on the <code>link</code> element, with a non-empty value.</p>
+  <code>link</code> element and the element is not a <span>module stylesheet link</span>, then <dfn
+  id="the-link-is-an-alternative-stylesheet">the link is an alternative style sheet</dfn>; in
+  this case, the <code data-x="attr-title">title</code> attribute must be specified on the
+  <code>link</code> element, with a non-empty value.</p>
 
   <p>The default type for resources given by the <code data-x="rel-stylesheet">stylesheet</code>
   keyword is <code>text/css</code>.</p>
@@ -29826,8 +29850,10 @@ document.body.appendChild(wbr);</code></pre>
 
   <div algorithm>
   <p>When the <code data-x="attr-link-disabled">disabled</code> attribute of a <code>link</code>
-  element with a <code data-x="rel-stylesheet">stylesheet</code> keyword is set, <span
-  data-x="disable a CSS style sheet">disable</span> the <span>associated CSS style sheet</span>.</p>
+  element with a <code data-x="rel-stylesheet">stylesheet</code> keyword is set, set the element's
+  <span>module CSS style sheet</span> to null if it is a <span>module stylesheet link</span>;
+  otherwise, <span data-x="disable a CSS style sheet">disable</span> its <span>associated CSS style
+  sheet</span>.</p>
   </div>
 
   <div algorithm>
@@ -29872,6 +29898,10 @@ document.body.appendChild(wbr);</code></pre>
    <li><p>When the <span>external resource link</span> that is already <span>browsing-context
    connected</span> changes from being <span data-x="the link is an alternative style sheet">an
    alternative style sheet</span> to not being one, or vice versa.</p></li>
+
+   <li><p>When an external resource link that is already <span>browsing-context connected</span>
+   changes from being a <span>module stylesheet link</span> to not being one, or vice
+   versa.</p></li>
   </ul>
   </div>
 
@@ -29912,6 +29942,137 @@ document.body.appendChild(wbr);</code></pre>
   subresource</span> <span data-x="concept-request">request</span> should have its <span
   data-x="concept-request-render-blocking">render-blocking</span> set to whether or not the
   <code>link</code> element is currently <span>render-blocking</span>.</p>
+
+  <div algorithm>
+  <p>The <span>fetch and process the linked resource</span> algorithm for a <span>module stylesheet
+  link</span> <var>el</var> is as follows:</p>
+
+  <ol>
+   <li><p>If <var>el</var>'s <code data-x="attr-link-disabled">disabled</code> attribute is set,
+   then return.</p></li>
+
+   <li><p>Set <var>el</var>'s <span>module CSS style sheet</span> to null.</p></li>
+
+   <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
+   empty string, then return.</p></li>
+
+   <li><p>Let <var>document</var> be <var>el</var>'s <span>node document</span>.</p></li>
+
+   <li><p>Let <var>settingsObject</var> be <var>document</var>'s <span>relevant settings
+   object</span>.</p></li>
+
+   <li><p>Let <var>specifier</var> be the value of <var>el</var>'s <code
+   data-x="attr-link-href">href</code> attribute.</p></li>
+
+   <li><p>Let <var>moduleRequest</var> be the <span>ModuleRequest Record</span> { [[Specifier]]:
+   <var>specifier</var>, [[Attributes]]: « { [[Key]]: "<code data-x="">type</code>", [[Value]]:
+   "<code data-x="">css</code>" } » }.</p></li>
+
+   <li><p>Let <var>url</var> be the result of <span>resolving a module specifier given a settings
+   object</span> given <var>settingsObject</var>, <var>document</var>'s <span>document base
+   URL</span>, and <var>specifier</var>, catching any exceptions. If this threw an exception, then
+   <span data-x="concept-event-fire">fire an event</span> named <code
+   data-x="event-error">error</code> at <var>el</var> and return.</p></li>
+
+   <li><p>Let <var>credentialsMode</var> be the <span>CORS settings attribute credentials
+   mode</span> for <var>el</var>'s <code data-x="attr-link-crossorigin">crossorigin</code>
+   attribute.</p></li>
+
+   <li><p>Let <var>integrityMetadata</var> be the value of <var>el</var>'s <code
+   data-x="attr-link-integrity">integrity</code> attribute, if it is specified, or the empty string
+   otherwise.</p></li>
+
+   <li><p>If <var>el</var> does not have an <code data-x="attr-link-integrity">integrity</code>
+   attribute, then set <var>integrityMetadata</var> to the result of <span>resolving a module
+   integrity metadata</span> with <var>url</var> and <var>settingsObject</var>.</p></li>
+
+   <li><p>If <var>el</var> <span>contributes a script-blocking style sheet</span>, then <span
+   data-x="set append">append</span> <var>el</var> to <var>document</var>'s <span>script-blocking
+   style sheet set</span>.</p></li>
+
+   <li><p>If <var>el</var>'s <code data-x="attr-link-media">media</code> attribute's value
+   <span>matches the environment</span> and <var>el</var> is
+   <span>potentially render-blocking</span>, then <span>block rendering</span> on
+   <var>el</var>.</p></li>
+
+   <li><p>Let <var>options</var> be a <span>script fetch options</span> whose <span
+   data-x="concept-script-fetch-options-nonce">cryptographic nonce</span> is
+   <var>el</var>.<span>[[CryptographicNonce]]</span>, <span
+   data-x="concept-script-fetch-options-integrity">integrity metadata</span> is
+   <var>integrityMetadata</var>, <span data-x="concept-script-fetch-options-parser">parser
+   metadata</span> is "<code data-x="">not-parser-inserted</code>", <span
+   data-x="concept-script-fetch-options-credentials">credentials mode</span> is
+   <var>credentialsMode</var>, <span data-x="concept-script-fetch-options-referrer-policy">referrer
+   policy</span> is the current state of <var>el</var>'s <code
+   data-x="attr-link-referrerpolicy">referrerpolicy</code> attribute, <span
+   data-x="concept-script-fetch-options-render-blocking">render-blocking</span> is whether
+   <var>el</var> is currently <span>render-blocking</span>, and <span
+   data-x="concept-script-fetch-options-fetch-priority">fetch priority</span> is the current state
+   of <var>el</var>'s <code data-x="attr-link-fetchpriority">fetchpriority</code>
+   attribute.</p></li>
+
+   <li>
+    <p><span>Fetch a single module script</span> given <var>url</var>, <var>settingsObject</var>,
+    "<code data-x="">style</code>", <var>options</var>, <var>settingsObject</var>, "<code
+    data-x="">client</code>", <var>moduleRequest</var>, true, and with the following steps given
+    <var>result</var>:</p>
+
+    <ol>
+     <li>
+      <p>If <var>el</var> no longer creates an <span>external resource link</span> that contributes
+      to the styling processing model, or if, since the module was fetched, it has become
+      appropriate to <span data-x="fetch and process the linked resource">fetch</span> it again:
+      </p>
+
+      <ol>
+       <li><p><span data-x="list remove">Remove</span> <var>el</var> from <var>el</var>'s <span>node
+       document</span>'s <span>script-blocking style sheet set</span>.</p></li>
+
+       <li><p><span>Unblock rendering</span> on <var>el</var>.</p></li>
+
+       <li><p>Return.</p></li>
+      </ol>
+     </li>
+
+     <li><p>If <var>result</var> is null or its <span
+     data-x="concept-script-parse-error">parse error</span> is non-null, then set
+     <var>el</var>'s <span>module CSS style sheet</span> to null, and <span
+     data-x="concept-event-fire">fire an event</span> named <code
+     data-x="event-error">error</code> at <var>el</var>.</p></li>
+
+     <li>
+      <p>Otherwise:</p>
+
+      <ol>
+       <li><p>Let <var>sheet</var> be the <code>CSSStyleSheet</code> passed to
+       <span>CreateDefaultExportSyntheticModule</span> when <var>result</var>'s <span
+       data-x="concept-script-record">record</span> was created.</p></li>
+
+       <li><p>Set <var>el</var>'s <span data-x="link module CSS style sheet">module CSS style
+       sheet</span> to <var>sheet</var>, and <span
+       data-x="concept-event-fire">fire an event</span> named <code
+       data-x="event-load">load</code> at <var>el</var>.</p></li>
+      </ol>
+     </li>
+
+     <li>
+      <p>If <var>el</var> <span>contributes a script-blocking style sheet</span>:</p>
+
+      <ol>
+       <li><p><span>Assert</span>: <var>el</var>'s <span>node document</span>'s <span
+       data-x="script-blocking style sheet set">script-blocking style sheet set</span> <span
+       data-x="list contains">contains</span> <var>el</var>.</p></li>
+
+       <li><p><span data-x="list remove">Remove</span> <var>el</var> from its <span>node
+       document</span>'s <span>script-blocking style sheet set</span>.</p></li>
+      </ol>
+     </li>
+
+     <li><p><span>Unblock rendering</span> on <var>el</var>.</p></li>
+    </ol>
+   </li>
+  </ol>
+  </div>
 
   <div algorithm>
   <p>To <span data-x="process the linked resource">process this type of linked resource</span>
@@ -120209,6 +120370,18 @@ dictionary <dfn dictionary>PromiseRejectionEventInit</dfn> : <span>EventInit</sp
     </ol>
    </li>
 
+   <li><p>Return the result of <span>resolving a module specifier given a settings object</span>
+   given <var>settingsObject</var>, <var>baseURL</var>, and <var>specifier</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>To <dfn data-x="resolving a module specifier given a settings object">resolve a module
+  specifier given a settings object</dfn>, given an <span>environment settings object</span>
+  <var>settingsObject</var>, a <span>URL</span> <var>baseURL</var>, and a
+  <span>string</span> <var>specifier</var>:</p>
+
+  <ol>
    <li><p>Let <var>importMap</var> be an <span>empty import map</span>.</p></li>
 
    <li><p>If <var>settingsObject</var>'s <span data-x="concept-settings-object-global">global
@@ -158455,8 +158628,9 @@ interface <dfn interface>External</dfn> {
     <tr>
      <th> <code data-x="">href</code>
      <td> <code data-x="attr-link-href">link</code>
-     <td> Address of the <span>hyperlink</span>
-     <td> <span>Valid non-empty URL potentially surrounded by spaces</span>
+     <td> Address of the <span>hyperlink</span>, or module specifier for a <span>module stylesheet
+          link</span>
+     <td> <span>Valid non-empty URL potentially surrounded by spaces</span>; text*
     <tr>
      <th> <code data-x="">href</code>
      <td> <code data-x="attr-base-href">base</code>
@@ -159053,10 +159227,14 @@ interface <dfn interface>External</dfn> {
      <td> "<code data-x="">yes</code>"; "<code data-x="">no</code>"; the empty string
     <tr>
      <th> <code data-x="">type</code>
-     <td> <code data-x="attr-hyperlink-type">a</code>;
-          <code data-x="attr-link-type">link</code>
+     <td> <code data-x="attr-hyperlink-type">a</code>
      <td> Hint for the type of the referenced resource
      <td> <span>Valid MIME type string</span>
+    <tr>
+     <th> <code data-x="">type</code>
+     <td> <code data-x="attr-link-type">link</code>
+     <td> Hint for the type of the referenced resource, or module stylesheet mode
+     <td> "<code data-x="">module</code>"; <span>Valid MIME type string</span>*
     <tr>
      <th> <code data-x="">type</code>
      <td> <code data-x="attr-button-type">button</code>

--- a/source
+++ b/source
@@ -4150,7 +4150,6 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#create-a-constructed-cssstylesheet">create a constructed <code>CSSStyleSheet</code></dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#synchronously-replace-the-rules-of-a-cssstylesheet">synchronously replace the rules of a <code>CSSStyleSheet</code></dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#disable-a-css-style-sheet">disable a CSS style sheet</dfn></li>
-     <li><dfn data-x-href="https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync">replaceSync</dfn></li>
      <li>
       <dfn data-x="CSS style sheet"
       data-x-href="https://drafts.csswg.org/cssom/#css-style-sheet">CSS style sheets</dfn> and their
@@ -4176,13 +4175,6 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#serialize-a-css-value">Serializing a CSS value</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps">run the resize steps</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#document-run-the-scroll-steps">run the scroll steps</dfn></li>
-     <li>
-      <dfn data-x="concept-documentorshadowroot-extensions-mixin"
-      data-x-href="https://drafts.csswg.org/cssom/#extensions-to-the-document-or-shadow-root-interface">Extensions to the <code>DocumentOrShadowRoot</code> Interface Mixin</dfn>:
-      <ul class="brief">
-       <li><dfn data-x="adoptedstylesheets" data-x-href="https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</dfn></li>
-      </ul>
-     </li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes">evaluate media queries and report changes</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#scroll-a-target-into-view">Scroll a target into view</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#scroll-to-the-beginning-of-the-document">Scroll to the beginning of the document</dfn></li>
@@ -69342,7 +69334,6 @@ not-slash     = %x0000-002E / %x0030-10FFFF
    <dd><code data-x="attr-template-shadowrootclonable">shadowrootclonable</code></dd>
    <dd><code data-x="attr-template-shadowrootserializable">shadowrootserializable</code></dd>
    <dd><code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></dd>
-   <dd><code data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></dd>
    <dt><span
    data-x="concept-element-accessibility-considerations">Accessibility considerations</span>:</dt>
    <dd><a href="https://w3c.github.io/html-aria/#el-template">For authors</a>.</dd>
@@ -69357,7 +69348,6 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
 
   readonly attribute <span>DocumentFragment</span> <span data-x="dom-template-content">content</span>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootmode">shadowRootMode</span>;
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootadoptedstylesheets">shadowRootAdoptedStyleSheets</dfn>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootdelegatesfocus">shadowRootDelegatesFocus</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootslotassignment">shadowRootSlotAssignment</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootclonable">shadowRootClonable</dfn>;
@@ -69440,11 +69430,6 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
   <p>The <dfn element-attr for="template"><code
   data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></dfn>
   content attribute is a <span>boolean attribute</span>.</p>
-
-  <p>The <dfn element-attr for="template"><code
-  data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></dfn> content
-  contributes to the <span data-x="concept-DocumentFragment-host">host's</span>
-  <span>adoptedStyleSheets</span>.</p>
 
   <p>The <span>template contents</span> of a <code>template</code> element <a
   href="#template-syntax">are not children of the element itself</a>.</p>
@@ -69685,79 +69670,7 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
 
   </div>
 
-<hr>
 
-  <div algorithm>
-  <p>The <dfn>stylesheet adopting steps</dfn> for <code>template</code> elements are:</p>
-
-  <ol>
-   <li><p>If the value of
-   <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span> is
-   empty, then return.</p></li>
-   <li><p>Let <var>adoptedStyleSheets</var> be an empty array.</p></li>
-   <li><p><span data-x="split a string on ASCII whitespace">Split the attribute's value on ASCII
-   whitespace</span>, and let <var>specifiers</var> be the resulting tokens.</p></li>
-   <li><p><span data-x="list iterate">For each</span> <var>specifier</var> of <var>specifiers</var>:</p>
-    <ol>
-      <li><p>Let <var>url</var> be the result of <span data-x="resolve a module specifier">resolving
-      a module specifier</span> with <var>specifier</var>.</p> If
-      any errors occur, then <span>continue</span>.</li>
-      <li><p>Let <var>settingsObject</var> be the <span>current settings object</span>.</li>
-      <li><p>Let <var>moduleType</var> be "<code data-x="">css</code>".</p></li>
-      <li><p>Let <var>moduleMap</var> be <var>settingsObject</var>'s <span
-      data-x="concept-settings-object-module-map">module map</span>.</p></li>
-      <li><p>Let <var>moduleScript</var> be
-      <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)].</p></li>
-      <li><p>If <var>moduleScript</var> is null, <span>fetch a single module script</span> given
-      <var>url</var>, <var>settingsObject</var>, "<code data-x="">style</code>", the
-      <span>default script fetch options</span>, <var>settingsObject</var>, "<code
-      data-x="">client</code>", true</p></li>
-      <li><p>Extract the <code>CSSStyleSheet</code> from <var>moduleScript</var>'s
-      <span data-x="concept-script-record">record</span> and append it to
-      <var>adoptedStyleSheets</var>. If any error occurs, remove all instances of the associated
-      <code>CSSStyleSheet</code> from <var>adoptedStyleSheets</var>and <span>continue</span>.</p></li>
-    </ol>
-   </li>
-   <li><p><span data-x="list extend">Extend</span> <span data-x="concept-DocumentFragment-host">host</span>'s
-   <span>adoptedStyleSheets</span> with <var>adoptedStyleSheets</var>.</p></li>
-  </ol>
-  </div>
-
-  <div class="example">
-
-   <p>This example demonstrates two equivalent methods to import CSS module scripts, the
-   first using the JavaScript <code data-x="">import</code> method and the second using the
-   <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>
-   attribute.</p>
-
-   <pre><code class="html">
-&lt;script type="importmap">
-{
-  "imports": {
-    "foo": "data:text/css,div {color:blue}"
-  }
-}
-&lt;/script>
-&lt;div id="host">
-  &lt;template shadowrootmode="open">
-    &lt;script type="module">
-      import styles from "foo" with { type: "css"};
-      document.getElementById("host").shadowRoot.adoptedStyleSheets = [styles];
-    &lt;/script>
-    &lt;div>test&lt;/div>
-  &lt;/template>
-&lt;/div>
-&lt;div id="host_shadowrootadoptedstylesheets_attribute">
-  &lt;template shadowrootmode="open" shadowrootadoptedstylesheets="foo">
-    &lt;div>test&lt;/div>
-  &lt;/template>
-&lt;/div></code></pre>
-
-  <p class="note">Note that these two examples are functionally equivalent, but the example with
-  <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>
-  might initially render without styles applied.</p>
-
-  </div>
 
   <div w-nodev>
 
@@ -119106,16 +119019,6 @@ document.querySelector("button").addEventListener("click", bound);
    <li><p><span data-x="map set">Set</span> <var>moduleMap</var>[(<var>url</var>,
    <var>moduleType</var>)] to « <var>onComplete</var> ».</p></li>
 
-   <li><p>If <var>destination</var> is "<code data-x="">style</code>", then:</p>
-    <ol>
-      <li><p>Let <var>emptyStyleScript</var> be the result of <span>creating a CSS module
-      script</span> with an empty <var>source</var> and <var>settingsObject</var></p></li>
-      <li><p><span data-x="map set">set</span> <var>moduleMap</var>[(<var>url</var>,
-      <var>moduleType</var>)] to <var>emptyStyleScript</var>, retaining the "<code
-      data-x="">fetching</code>" status.</p></li>
-    </ol>
-  </li>
-
    <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose
    <span data-x="concept-request-url">URL</span> is <var>url</var>, <span
    data-x="concept-request-mode">mode</span> is "<code data-x="">cors</code>", <span
@@ -119223,8 +119126,8 @@ document.querySelector("button").addEventListener("click", bound);
 
        <li><p>If the <span>MIME type essence</span> of <var>mimeType</var> is "<code>text/css</code>"
        and <var>moduleType</var> is "<code data-x="">css</code>", then set <var>moduleScript</var> to
-       the result of <span>updating a CSS module script</span> given <var>sourceText</var> and
-       <var>moduleMap</var>[(<var>url</var>,<var>moduleType</var>)].</p></li>
+       the result of <span>creating a CSS module script</span> given <var>sourceText</var> and
+       <var>settingsObject</var>.</p></li>
 
        <li><p>If <var>mimeType</var> is a <span>JSON MIME type</span> and
        <var>moduleType</var> is "<code data-x="">json</code>", then set <var>moduleScript</var> to
@@ -119537,32 +119440,6 @@ document.querySelector("button").addEventListener("click", bound);
 
    <li><p>Set <var>script</var>'s <span data-x="concept-script-record">record</span> to the result
    of <span>CreateDefaultExportSyntheticModule</span>(<var>sheet</var>).</p></li>
-
-   <li><p>Return <var>script</var>.</p></li>
-  </ol>
-  </div>
-
-  <div algorithm>
-  <p>To <dfn data-x="updating a CSS module script">update a CSS module script</dfn>, given a
-  string <var>source</var> and a <var>script</var> <span>module script</span> :</p>
-
-  <ol>
-   <li><p>Let <var>sheet</var> be the default export of <var>script</var></p></li>
-
-   <li>
-    <p>Run the steps to <span>synchronously replace the rules of a <code>CSSStyleSheet</code></span>
-    on <var>sheet</var> given <var>source</var>.</p>
-
-    <p>If this throws an exception, catch it, and set <var>script</var>'s <span
-    data-x="concept-script-parse-error">parse error</span> to that exception, and return
-    <var>script</var>.</p>
-
-    <p class="note">The steps to <span>synchronously replace the rules of a
-    <code>CSSStyleSheet</code></span> will throw if <var>source</var> contains any <code
-    data-x="">@import</code> rules.  This is by-design for now because there is not yet an
-    agreement on how to handle these for CSS module scripts; therefore they are blocked altogether
-    until a consensus is reached.</p>
-   </li>
 
    <li><p>Return <var>script</var>.</p></li>
   </ol>
@@ -145849,10 +145726,6 @@ document.body.appendChild(text);
          data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code>
          attribute, then set <var>shadow</var>'s <span>keep custom element registry null</span> to
          true.</p></li>
-
-         <li><p>If <var>templateStartTag</var> has a <code
-         data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code>
-         attribute, then perform the <span>stylesheet adopting steps</span> on <var>template</var>.</p></li>
         </ol>
        </li>
       </ol>
@@ -149677,11 +149550,6 @@ document.body.appendChild(text);
 
        <li><p>If <var>shadow</var>'s <span>clonable</span> is set, then append
        "<code data-x=""> shadowrootclonable=&quot;&quot;</code>".</p></li>
-
-       <li><p>If <var>shadow</var>'s <code
-       data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code> is set, then append
-       the value of <code
-       data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></p></li>
 
        <li>
         <p>Let <var>shouldAppendRegistryAttribute</var> be the result of running these steps:</p>
@@ -157680,8 +157548,7 @@ interface <dfn interface>External</dfn> {
          <code data-x="attr-template-shadowrootslotassignment">shadowrootslotassignment</code>;
          <code data-x="attr-template-shadowrootclonable">shadowrootclonable</code>;
          <code data-x="attr-template-shadowrootserializable">shadowrootserializable</code>;
-         <code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code>;
-         <code data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></td>
+         <code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></td>
      <td><code>HTMLTemplateElement</code></td>
     </tr>
 
@@ -159185,11 +159052,6 @@ interface <dfn interface>External</dfn> {
      <td> <code data-x="attr-option-selected">option</code>
      <td> Whether the option is selected by default
      <td> <span>Boolean attribute</span>
-    <tr>
-     <th> <code data-x="">shadowrootadoptedstylesheets</code>
-     <td> <code data-x="attr-template-shadowrootadoptedstylesheets">template</code>
-     <td> Sets <span>adoptedStyleSheets</span> on a declarative shadow root
-     <td> <span>Ordered set of unique space-separated tokens</span> consisting of module specifiers*
     <tr>
      <th> <code data-x="">shadowrootclonable</code>
      <td> <code data-x="attr-template-shadowrootclonable">template</code>

--- a/source
+++ b/source
@@ -16579,9 +16579,8 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
   data-x="attr-link-href">href</code></dfn> attribute. If the <code
   data-x="attr-link-href">href</code> attribute is present and the element is not a <span>module
   stylesheet link</span>, then its value must be a <span>valid non-empty URL potentially surrounded
-  by spaces</span>. One or both of the <code
-  data-x="attr-link-href">href</code> or <code data-x="attr-link-imagesrcset">imagesrcset</code>
-  attributes must be present.</p>
+  by spaces</span>. One or both of the <code  data-x="attr-link-href">href</code> or
+  <code data-x="attr-link-imagesrcset">imagesrcset</code> attributes must be present.</p>
 
   <p w-nodev>If both the <code data-x="attr-link-href">href</code> and <code
   data-x="attr-link-imagesrcset">imagesrcset</code> attributes are absent, then the element does not
@@ -29851,8 +29850,9 @@ document.body.appendChild(wbr);</code></pre>
   <div algorithm>
   <p>When the <code data-x="attr-link-disabled">disabled</code> attribute of a <code>link</code>
   element with a <code data-x="rel-stylesheet">stylesheet</code> keyword is set, set the element's
-  <span data-x="link module CSS style sheet">module CSS style sheet</span> to null if it is a <span>module stylesheet link</span>;
-  otherwise, <span data-x="disable a CSS style sheet">disable</span> its <span>associated CSS style
+  <span data-x="link module CSS style sheet">module CSS style sheet</span> to null if it is a
+  <span>module stylesheet link</span>; otherwise,
+  <span data-x="disable a CSS style sheet">disable</span> its <span>associated CSS style
   sheet</span>.</p>
   </div>
 
@@ -29951,7 +29951,8 @@ document.body.appendChild(wbr);</code></pre>
    <li><p>If <var>el</var>'s <code data-x="attr-link-disabled">disabled</code> attribute is set,
    then return.</p></li>
 
-   <li><p>Set <var>el</var>'s <span data-x="link module CSS style sheet">module CSS style sheet</span> to null.</p></li>
+   <li><p>Set <var>el</var>'s <span
+   data-x="link module CSS style sheet">module CSS style sheet</span> to null.</p></li>
 
    <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
    empty string, then return.</p></li>
@@ -30036,7 +30037,8 @@ document.body.appendChild(wbr);</code></pre>
 
      <li><p>If <var>result</var> is null or its <span
      data-x="concept-script-parse-error">parse error</span> is non-null, then set
-     <var>el</var>'s <span data-x="link module CSS style sheet">module CSS style sheet</span> to null, and <span
+     <var>el</var>'s <span
+     data-x="link module CSS style sheet">module CSS style sheet</span> to null, and <span
      data-x="concept-event-fire">fire an event</span> named <code
      data-x="event-error">error</code> at <var>el</var>.</p></li>
 

--- a/source
+++ b/source
@@ -69695,9 +69695,9 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
    <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span> is
    empty, then return.</p></li>
    <li><p>Let <var>adoptedStyleSheets</var> be an empty array.</p></li>
-
-   <li><p>For each <span>ordered set of unique space-separated tokens</span> <var>specifier</var> in
-   <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>:</p>
+   <li><p><span data-x="split a string on ASCII whitespace">Split the attribute's value on ASCII
+   whitespace</span>, and let <var>specifiers</var> be the resulting tokens.</p></li>
+   <li><p><span data-x="list iterate">For each</span> <var>specifier</var> of <var>specifiers</var>:</p>
     <ol>
       <li><p>Let <var>url</var> be the result of <span data-x="resolve a module specifier">resolving
       a module specifier</span> with <var>specifier</var>.</p> If

--- a/source
+++ b/source
@@ -16521,6 +16521,7 @@ interface <dfn interface>HTMLBaseElement</dfn> : <span>HTMLElement</span> {
    <dt><span data-x="concept-element-attributes">Content attributes</span>:</dt>
    <dd><span>Global attributes</span></dd>
    <dd><code data-x="attr-link-href">href</code></dd>
+   <dd><code data-x="attr-link-import">import</code></dd>
    <dd><code data-x="attr-link-crossorigin">crossorigin</code></dd>
    <dd><code data-x="attr-link-rel">rel</code></dd>
    <dd><code data-x="attr-link-media">media</code></dd>
@@ -16550,6 +16551,7 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
   [<span>HTMLConstructor</span>] constructor();
 
   [<span>CEReactions</span>, <span data-x="xattr-ReflectURL">ReflectURL</span>] attribute USVString <dfn attribute for="HTMLLinkElement" data-x="dom-link-href">href</dfn>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLLinkElement" data-x="dom-link-import">import</dfn>;
   [<span>CEReactions</span>] attribute DOMString? <span data-x="dom-link-crossOrigin">crossOrigin</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLLinkElement" data-x="dom-link-rel">rel</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-link-as">as</span>;
@@ -16577,14 +16579,21 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The address of the link(s) is given by the <dfn element-attr for="link"><code
   data-x="attr-link-href">href</code></dfn> attribute. If the <code
-  data-x="attr-link-href">href</code> attribute is present and the element is not a <span>module
-  stylesheet link</span>, then its value must be a <span>valid non-empty URL potentially surrounded
-  by spaces</span>. One or both of the <code  data-x="attr-link-href">href</code> or
-  <code data-x="attr-link-imagesrcset">imagesrcset</code> attributes must be present.</p>
+  data-x="attr-link-href">href</code> attribute is present, then its value must be a <span>valid
+  non-empty URL potentially surrounded by spaces</span>. One or more of the <code
+  data-x="attr-link-href">href</code>, <code data-x="attr-link-import">import</code>, or <code
+  data-x="attr-link-imagesrcset">imagesrcset</code> attributes must be present.</p>
 
-  <p w-nodev>If both the <code data-x="attr-link-href">href</code> and <code
-  data-x="attr-link-imagesrcset">imagesrcset</code> attributes are absent, then the element does not
-  define a link.</p>
+  <p>The <dfn element-attr for="link"><code data-x="attr-link-import">import</code></dfn>
+  attribute specifies that a stylesheet link is a <span>module stylesheet link</span>, and its value
+  is the module specifier. The <code data-x="attr-link-import">import</code> attribute must only be
+  specified on <code>link</code> elements whose <code data-x="attr-link-rel">rel</code> attribute
+  contains the <code data-x="rel-stylesheet">stylesheet</code> keyword.</p>
+
+  <p w-nodev>If the <code data-x="attr-link-href">href</code>, <code
+  data-x="attr-link-import">import</code>, and <code
+  data-x="attr-link-imagesrcset">imagesrcset</code> attributes are absent, then the element does
+  not define a link.</p>
 
   <p>The types of link indicated (the relationships) are given by the value of the <dfn element-attr
   for="link"><code data-x="attr-link-rel">rel</code></dfn> attribute, which, if present, must have a
@@ -16722,11 +16731,7 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The <dfn element-attr for="link"><code data-x="attr-link-type">type</code></dfn> attribute
   gives the <span>MIME type</span> of the linked resource. It is purely advisory. The value must be
-  a <span>valid MIME type string</span>, or an <span>ASCII case-insensitive</span> match for the
-  string "<code data-x="">module</code>". In the latter case, if the element's <code
-  data-x="attr-link-rel">rel</code> attribute contains the <code
-  data-x="rel-stylesheet">stylesheet</code> keyword, the stylesheet link will be processed as a
-  <span>module stylesheet link</span>.</p>
+  a <span>valid MIME type string</span>.</p>
 
   <p>For <span data-x="external resource link">external resource links</span>, the <code
   data-x="attr-link-type">type</code> attribute is used as a hint to user agents so that they can
@@ -16977,13 +16982,12 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <h5>Processing the <code data-x="attr-link-type">type</code> attribute</h5>
 
-  <p>If the <code data-x="attr-link-type">type</code> attribute is present and the element is not a
-  <span>module stylesheet link</span>, then the user agent must assume that the resource is of the
-  given type (even if that is not a <span>valid MIME type string</span>, e.g. the empty string). If
-  the attribute is omitted, but the <span>external resource link</span> type has a default type
-  defined, then the user agent must assume that the resource is of that type. If the UA does not
-  support the given <span>MIME type</span> for the given link relationship, then the UA should not
-  <span>fetch and process the linked
+  <p>If the <code data-x="attr-link-type">type</code> attribute is present, then the user agent must
+  assume that the resource is of the given type (even if that is not a <span>valid MIME type
+  string</span>, e.g. the empty string). If the attribute is omitted, but the <span>external
+  resource link</span> type has a default type defined, then the user agent must assume that the
+  resource is of that type. If the UA does not support the given <span>MIME type</span> for the
+  given link relationship, then the UA should not <span>fetch and process the linked
   resource</span>; if the UA does support the given <span>MIME type</span> for the given link
   relationship, then the UA should <span>fetch and process the linked resource</span> at the
   appropriate time as specified for the <span>external resource link</span>'s particular type.
@@ -26368,6 +26372,9 @@ document.body.appendChild(wbr);</code></pre>
   <code data-x="attr-link-rel">rel</code> attribute, as defined for those keywords in the <a
   href="#linkTypes">link types</a> section.</p>
 
+  <p>For <span>module stylesheet links</span>, a link must be created for the <code
+  data-x="rel-stylesheet">stylesheet</code> keyword.</p>
+
   <p>Similarly, for <code>a</code> and <code>area</code> elements with an <code
   data-x="attr-hyperlink-href">href</code> attribute and a <code
   data-x="attr-hyperlink-rel">rel</code> attribute, links must be created for the keywords of the
@@ -29814,9 +29821,8 @@ document.body.appendChild(wbr);</code></pre>
   <div algorithm>
   <p>A <code>link</code> element is a <dfn>module stylesheet link</dfn> if its <code
   data-x="attr-link-rel">rel</code> attribute contains the <code
-  data-x="rel-stylesheet">stylesheet</code> keyword, and its <code
-  data-x="attr-link-type">type</code> attribute's value is an <span>ASCII
-  case-insensitive</span> match for the string "<code data-x="">module</code>".</p>
+  data-x="rel-stylesheet">stylesheet</code> keyword and it has an <code
+  data-x="attr-link-import">import</code> attribute.</p>
   </div>
 
   <div w-nodev>
@@ -29868,7 +29874,8 @@ document.body.appendChild(wbr);</code></pre>
 
    <li><p>When the <code data-x="attr-link-href">href</code> attribute of the <code>link</code>
    element of an <span>external resource link</span> that is already <span>browsing-context
-   connected</span> is changed.</p></li>
+   connected</span> and does not have an <code data-x="attr-link-import">import</code> attribute is
+   changed.</p></li>
    <!-- https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=2588 -->
 
    <li><p>When the <code data-x="attr-link-disabled">disabled</code> attribute of the
@@ -29896,9 +29903,8 @@ document.body.appendChild(wbr);</code></pre>
    connected</span> changes from being <span data-x="the link is an alternative style sheet">an
    alternative style sheet</span> to not being one, or vice versa.</p></li>
 
-   <li><p>When an external resource link that is already <span>browsing-context connected</span>
-   changes from being a <span>module stylesheet link</span> to not being one, or vice
-   versa.</p></li>
+   <li><p>When the <code data-x="attr-link-import">import</code> attribute of a stylesheet link
+   that is already <span>browsing-context connected</span> is set, changed, or removed.</p></li>
   </ul>
   </div>
 
@@ -29952,16 +29958,13 @@ document.body.appendChild(wbr);</code></pre>
    <li><p>If <var>el</var>'s <code data-x="attr-link-disabled">disabled</code> attribute is set,
    then return.</p></li>
 
-   <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
-   empty string, then return.</p></li>
-
    <li><p>Let <var>document</var> be <var>el</var>'s <span>node document</span>.</p></li>
 
    <li><p>Let <var>settingsObject</var> be <var>document</var>'s <span>relevant settings
    object</span>.</p></li>
 
    <li><p>Let <var>specifier</var> be the value of <var>el</var>'s <code
-   data-x="attr-link-href">href</code> attribute.</p></li>
+   data-x="attr-link-import">import</code> attribute.</p></li>
 
    <li><p>Let <var>moduleRequest</var> be the <span>ModuleRequest Record</span> { [[Specifier]]:
    <var>specifier</var>, [[Attributes]]: « <span>Record</span> { [[Key]]: "<code
@@ -156912,6 +156915,7 @@ interface <dfn interface>External</dfn> {
      <td>empty</td>
      <td><span data-x="global attributes">globals</span>;
          <code data-x="attr-link-href">href</code>;
+         <code data-x="attr-link-import">import</code>;
          <code data-x="attr-link-crossorigin">crossorigin</code>;
          <code data-x="attr-link-rel">rel</code>;
          <code data-x="attr-link-as">as</code>;
@@ -158628,9 +158632,8 @@ interface <dfn interface>External</dfn> {
     <tr>
      <th> <code data-x="">href</code>
      <td> <code data-x="attr-link-href">link</code>
-     <td> Address of the <span>hyperlink</span>, or module specifier for a <span>module stylesheet
-          link</span>
-     <td> <span>Valid non-empty URL potentially surrounded by spaces</span>; text*
+     <td> Address of the <span>hyperlink</span>
+     <td> <span>Valid non-empty URL potentially surrounded by spaces</span>
     <tr>
      <th> <code data-x="">href</code>
      <td> <code data-x="attr-base-href">base</code>
@@ -158666,6 +158669,11 @@ interface <dfn interface>External</dfn> {
      <td> <code data-x="attr-link-imagesrcset">link</code>
      <td> Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for <code data-x="attr-link-rel">rel</code>="<code data-x="rel-preload">preload</code>")
      <td> Comma-separated list of <span data-x="image candidate string">image candidate strings</span>
+    <tr>
+     <th> <code data-x="">import</code>
+     <td> <code data-x="attr-link-import">link</code>
+     <td> Module specifier for a <span>module stylesheet link</span>
+     <td> <a href="#attribute-text">Text</a>*
     <tr>
      <th> <code data-x="">inert</code>
      <td> <span data-x="attr-inert">HTML elements</span>
@@ -159227,14 +159235,10 @@ interface <dfn interface>External</dfn> {
      <td> "<code data-x="">yes</code>"; "<code data-x="">no</code>"; the empty string
     <tr>
      <th> <code data-x="">type</code>
-     <td> <code data-x="attr-hyperlink-type">a</code>
+     <td> <code data-x="attr-hyperlink-type">a</code>;
+          <code data-x="attr-link-type">link</code>
      <td> Hint for the type of the referenced resource
      <td> <span>Valid MIME type string</span>
-    <tr>
-     <th> <code data-x="">type</code>
-     <td> <code data-x="attr-link-type">link</code>
-     <td> Hint for the type of the referenced resource, or module stylesheet mode
-     <td> "<code data-x="">module</code>"; <span>Valid MIME type string</span>*
     <tr>
      <th> <code data-x="">type</code>
      <td> <code data-x="attr-button-type">button</code>

--- a/source
+++ b/source
@@ -69357,6 +69357,7 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
 
   readonly attribute <span>DocumentFragment</span> <span data-x="dom-template-content">content</span>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootmode">shadowRootMode</span>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootadoptedstylesheets">shadowRootAdoptedStyleSheets</dfn>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootdelegatesfocus">shadowRootDelegatesFocus</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootslotassignment">shadowRootSlotAssignment</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootclonable">shadowRootClonable</dfn>;
@@ -69713,7 +69714,8 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
       data-x="">client</code>", true</p></li>
       <li><p>Extract the <code>CSSStyleSheet</code> from <var>moduleScript</var>'s
       <span data-x="concept-script-record">record</span> and append it to
-      <var>adoptedStyleSheets</var>. If any error occurs, then <span>continue</span>.</p></li>
+      <var>adoptedStyleSheets</var>. If any error occurs, remove all instances of the associated
+      <code>CSSStyleSheet</code> from <var>adoptedStyleSheets</var>and <span>continue</span>.</p></li>
     </ol>
    </li>
    <li><p><span data-x="list extend">Extend</span> <span data-x="concept-DocumentFragment-host">host</span>'s
@@ -149675,6 +149677,11 @@ document.body.appendChild(text);
 
        <li><p>If <var>shadow</var>'s <span>clonable</span> is set, then append
        "<code data-x=""> shadowrootclonable=&quot;&quot;</code>".</p></li>
+
+       <li><p>If <var>shadow</var>'s <code
+       data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code> is set, then append
+       the value of <code
+       data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></p></li>
 
        <li>
         <p>Let <var>shouldAppendRegistryAttribute</var> be the result of running these steps:</p>

--- a/source
+++ b/source
@@ -69707,32 +69707,10 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
       data-x="concept-settings-object-module-map">module map</span>.</p></li>
       <li><p>Let <var>moduleScript</var> be
       <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)].</p></li>
-      <li><p>If <var>moduleScript</var> is null:</p>
-        <ul>
-          <li><p>Set <var>moduleScript</var> to the result of <span
-          data-x="creating a CSS module script">create a CSS module script</span> with an empty
-          <var>source</var> and <var>settingsObject</var>.</p></li>
-          <li><p>Set <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] to
-          <var>moduleScript</var>.</p></li>
-          <li><p><span>Fetch a single module script</span> given <var>url</var>,
-          <var>settingsObject</var>, "<code data-x="">style</code>", the
-          <span>default script fetch options</span>, <var>settingsObject</var>, "<code
-          data-x="">client</code>", true, and with the following steps given <var>result</var>:</p>
-            <ul>
-              <li><p>If <var>result</var> is null, then abort these steps.</p></li>
-              <li><p>Let <var>fetchedSheet</var> be the <code>CSSStyleSheet</code> extracted from
-              <var>result</var>'s <span
-              data-x="concept-script-record">record</span>.</p></li>
-              <li><p>Let <var>existingSheet</var> be the <code>CSSStyleSheet</code> extracted from
-              <var>moduleScript</var>'s <span
-              data-x="concept-script-record">record</span>.</p></li>
-              <li><p>Call <span>replaceSync</span> on <var>existingSheet</var> given the
-              <span data-x="concept-CSSStyleSheet-CSS-text">CSS text</span> of
-              <var>fetchedSheet</var>.</p></li>
-            </ul>
-          </li>
-        </ul>
-      </li>
+      <li><p>If <var>moduleScript</var> is null, <span>fetch a single module script</span> given
+      <var>url</var>, <var>settingsObject</var>, "<code data-x="">style</code>", the
+      <span>default script fetch options</span>, <var>settingsObject</var>, "<code
+      data-x="">client</code>", true</p></li>
       <li><p>Extract the <code>CSSStyleSheet</code> from <var>moduleScript</var>'s
       <span data-x="concept-script-record">record</span> and append it to
       <var>adoptedStyleSheets</var>. If any error occurs, then <span>continue</span>.</p></li>
@@ -119122,6 +119100,16 @@ document.querySelector("button").addEventListener("click", bound);
    <li><p><span data-x="map set">Set</span> <var>moduleMap</var>[(<var>url</var>,
    <var>moduleType</var>)] to « <var>onComplete</var> ».</p></li>
 
+   <li><p>If <var>destination</var> is "<code data-x="">style</code>", then:</p>
+    <ol>
+      <li><p>Let <var>emptyStyleScript</var> be the result of <span>creating a CSS module
+      script</span> with an empty <var>source</var> and <var>settingsObject</var></p></li>
+      <li><p><span data-x="map set">set</span> <var>moduleMap</var>[(<var>url</var>,
+      <var>moduleType</var>)] to <var>emptyStyleScript</var>, retaining the "<code
+      data-x="">fetching</code>" status.</p></li>
+    </ol>
+  </li>
+
    <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose
    <span data-x="concept-request-url">URL</span> is <var>url</var>, <span
    data-x="concept-request-mode">mode</span> is "<code data-x="">cors</code>", <span
@@ -119229,8 +119217,8 @@ document.querySelector("button").addEventListener("click", bound);
 
        <li><p>If the <span>MIME type essence</span> of <var>mimeType</var> is "<code>text/css</code>"
        and <var>moduleType</var> is "<code data-x="">css</code>", then set <var>moduleScript</var> to
-       the result of <span>creating a CSS module script</span> given <var>sourceText</var> and
-       <var>settingsObject</var>.</p></li>
+       the result of <span>updating a CSS module script</span> given <var>sourceText</var> and
+       <var>moduleMap</var>[(<var>url</var>,<var>moduleType</var>)].</p></li>
 
        <li><p>If <var>mimeType</var> is a <span>JSON MIME type</span> and
        <var>moduleType</var> is "<code data-x="">json</code>", then set <var>moduleScript</var> to
@@ -119543,6 +119531,32 @@ document.querySelector("button").addEventListener("click", bound);
 
    <li><p>Set <var>script</var>'s <span data-x="concept-script-record">record</span> to the result
    of <span>CreateDefaultExportSyntheticModule</span>(<var>sheet</var>).</p></li>
+
+   <li><p>Return <var>script</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>To <dfn data-x="updating a CSS module script">update a CSS module script</dfn>, given a
+  string <var>source</var> and a <var>script</var> <span>module script</span> :</p>
+
+  <ol>
+   <li><p>Let <var>sheet</var> be the default export of <var>script</var></p></li>
+
+   <li>
+    <p>Run the steps to <span>synchronously replace the rules of a <code>CSSStyleSheet</code></span>
+    on <var>sheet</var> given <var>source</var>.</p>
+
+    <p>If this throws an exception, catch it, and set <var>script</var>'s <span
+    data-x="concept-script-parse-error">parse error</span> to that exception, and return
+    <var>script</var>.</p>
+
+    <p class="note">The steps to <span>synchronously replace the rules of a
+    <code>CSSStyleSheet</code></span> will throw if <var>source</var> contains any <code
+    data-x="">@import</code> rules.  This is by-design for now because there is not yet an
+    agreement on how to handle these for CSS module scripts; therefore they are blocked altogether
+    until a consensus is reached.</p>
+   </li>
 
    <li><p>Return <var>script</var>.</p></li>
   </ol>

--- a/source
+++ b/source
@@ -69719,10 +69719,16 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
           <span>default script fetch options</span>, <var>settingsObject</var>, "<code
           data-x="">client</code>", true, and with the following steps given <var>result</var>:</p>
             <ul>
-              <li><p>If <var>result</var> is null, then <span>continue</span>.</p></li>
-              <li><p>Extract the <code>CSSStyleSheet</code> from <var>result</var>'s <span
-              data-x="concept-script-record">record</span> and <span>replaceSync</span> on the
-              underlying <code>CSSStyleSheet</code> with the contents of <var>result</var>.</p></li>
+              <li><p>If <var>result</var> is null, then abort these steps.</p></li>
+              <li><p>Let <var>fetchedSheet</var> be the <code>CSSStyleSheet</code> extracted from
+              <var>result</var>'s <span
+              data-x="concept-script-record">record</span>.</p></li>
+              <li><p>Let <var>existingSheet</var> be the <code>CSSStyleSheet</code> extracted from
+              <var>moduleScript</var>'s <span
+              data-x="concept-script-record">record</span>.</p></li>
+              <li><p>Call <span>replaceSync</span> on <var>existingSheet</var> given the
+              <span data-x="concept-CSSStyleSheet-CSS-text">CSS text</span> of
+              <var>fetchedSheet</var>.</p></li>
             </ul>
           </li>
         </ul>

--- a/source
+++ b/source
@@ -4150,6 +4150,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#create-a-constructed-cssstylesheet">create a constructed <code>CSSStyleSheet</code></dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#synchronously-replace-the-rules-of-a-cssstylesheet">synchronously replace the rules of a <code>CSSStyleSheet</code></dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#disable-a-css-style-sheet">disable a CSS style sheet</dfn></li>
+     <li><dfn data-x-href="https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync">replaceSync</dfn></li>
      <li>
       <dfn data-x="CSS style sheet"
       data-x-href="https://drafts.csswg.org/cssom/#css-style-sheet">CSS style sheets</dfn> and their
@@ -69698,7 +69699,7 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
    <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>:</p>
     <ol>
       <li><p>Let <var>url</var> be the result of <span data-x="resolve a module specifier">resolving
-      a module specifier</span> given <var>moduleScript</var> and <var>specifier</var>.</p> If
+      a module specifier</span> with <var>specifier</var>.</p> If
       any errors occur, then <span>continue</span>.</li>
       <li><p>Let <var>settingsObject</var> be the <span>current settings object</span>.</li>
       <li><p>Let <var>moduleType</var> be "<code data-x="">css</code>".</p></li>
@@ -69706,7 +69707,26 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
       data-x="concept-settings-object-module-map">module map</span>.</p></li>
       <li><p>Let <var>moduleScript</var> be
       <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)].</p></li>
-      <li><p>If <var>moduleScript</var> is null, then <span>continue</span>.</p></li> // TODO(kschmi): Add fetch!!!!!!!!!!!!!!!!!
+      <li><p>If <var>moduleScript</var> is null:</p>
+        <ul>
+          <li><p>Set <var>moduleScript</var> to the result of <span
+          data-x="creating a CSS module script">create a CSS module script</span> with an empty
+          <var>source</var> and <var>settingsObject</var>.</p></li>
+          <li><p>Set <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] to
+          <var>moduleScript</var>.</p></li>
+          <li><p><span>Fetch a single module script</span> given <var>url</var>,
+          <var>settingsObject</var>, "<code data-x="">style</code>", the
+          <span>default script fetch options</span>, <var>settingsObject</var>, "<code
+          data-x="">client</code>", true, and with the following steps given <var>result</var>:</p>
+            <ul>
+              <li><p>If <var>result</var> is null, then <span>continue</span>.</p></li>
+              <li><p>Extract the <code>CSSStyleSheet</code> from <var>result</var>'s <span
+              data-x="concept-script-record">record</span> and <span>replaceSync</span> on the
+              underlying <code>CSSStyleSheet</code> with the contents of <var>result</var>.</p></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
       <li><p>Extract the <code>CSSStyleSheet</code> from <var>moduleScript</var>'s
       <span data-x="concept-script-record">record</span> and append it to
       <var>adoptedStyleSheets</var>. If any error occurs, then <span>continue</span>.</p></li>

--- a/source
+++ b/source
@@ -29905,7 +29905,8 @@ document.body.appendChild(wbr);</code></pre>
   <p><strong>Quirk</strong>: If the document has been set to <span>quirks mode</span>, has the
   <span>same origin</span> as the <span>URL</span> of the external resource<!-- CVE-2010-0654 -->,
   and the <span data-x="Content-Type">Content-Type metadata</span> of the external resource is not a
-  supported style sheet type, the user agent must instead assume it to be <code>text/css</code>.</p>
+  supported style sheet type, and the link is not a <span>module stylesheet link</span>, the user
+  agent must instead assume it to be <code>text/css</code>.</p>
 
   <div algorithm>
   <p>The <span>linked resource fetch setup steps</span> for this type of linked resource, given a
@@ -29945,11 +29946,11 @@ document.body.appendChild(wbr);</code></pre>
   link</span> <var>el</var> is as follows:</p>
 
   <ol>
-   <li><p>If <var>el</var>'s <code data-x="attr-link-disabled">disabled</code> attribute is set,
-   then return.</p></li>
-
    <li><p>Set <var>el</var>'s <span
    data-x="link module CSS style sheet">module CSS style sheet</span> to null.</p></li>
+
+   <li><p>If <var>el</var>'s <code data-x="attr-link-disabled">disabled</code> attribute is set,
+   then return.</p></li>
 
    <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
    empty string, then return.</p></li>
@@ -29963,8 +29964,8 @@ document.body.appendChild(wbr);</code></pre>
    data-x="attr-link-href">href</code> attribute.</p></li>
 
    <li><p>Let <var>moduleRequest</var> be the <span>ModuleRequest Record</span> { [[Specifier]]:
-   <var>specifier</var>, [[Attributes]]: « { [[Key]]: "<code data-x="">type</code>", [[Value]]:
-   "<code data-x="">css</code>" } » }.</p></li>
+   <var>specifier</var>, [[Attributes]]: « <span>Record</span> { [[Key]]: "<code
+   data-x="">type</code>", [[Value]]: "<code data-x="">css</code>" } » }.</p></li>
 
    <li><p>Let <var>url</var> be the result of <span>resolving a module specifier given a settings
    object</span> given <var>settingsObject</var>, <var>document</var>'s <span>document base

--- a/source
+++ b/source
@@ -69751,6 +69751,10 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
   &lt;/template>
 &lt;/div></code></pre>
 
+  <p class="note">Note that these two examples are functionally equivalent, but the example with
+  <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>
+  might initially render without styles applied.</p>
+
   </div>
 
   <div w-nodev>

--- a/source
+++ b/source
@@ -29968,8 +29968,8 @@ document.body.appendChild(wbr);</code></pre>
 
    <li><p>Let <var>url</var> be the result of <span>resolving a module specifier given a settings
    object</span> given <var>settingsObject</var>, <var>document</var>'s <span>document base
-   URL</span>, and <var>specifier</var>, catching any exceptions. If this threw an exception, then
-   <span data-x="concept-event-fire">fire an event</span> named <code
+   URL</span>, and <var>specifier</var>. If this threw an exception, then <span
+   data-x="concept-event-fire">fire an event</span> named <code
    data-x="event-error">error</code> at <var>el</var> and return.</p></li>
 
    <li><p>Let <var>credentialsMode</var> be the <span>CORS settings attribute credentials

--- a/source
+++ b/source
@@ -69695,7 +69695,7 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
    empty, then return.</p></li>
    <li><p>Let <var>adoptedStyleSheets</var> be an empty array.</p></li>
 
-   <li><p>For each <span>unordered set of unique space-separated tokens</span> <var>specifier</var> in
+   <li><p>For each <span>ordered set of unique space-separated tokens</span> <var>specifier</var> in
    <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>:</p>
     <ol>
       <li><p>Let <var>url</var> be the result of <span data-x="resolve a module specifier">resolving
@@ -159178,7 +159178,7 @@ interface <dfn interface>External</dfn> {
      <th> <code data-x="">shadowrootadoptedstylesheets</code>
      <td> <code data-x="attr-template-shadowrootadoptedstylesheets">template</code>
      <td> Sets <span>adoptedStyleSheets</span> on a declarative shadow root
-     <td> <a href="#attribute-text">Text</a>
+     <td> <span>Ordered set of unique space-separated tokens</span> consisting of module specifiers*
     <tr>
      <th> <code data-x="">shadowrootclonable</code>
      <td> <code data-x="attr-template-shadowrootclonable">template</code>

--- a/source
+++ b/source
@@ -16722,11 +16722,11 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The <dfn element-attr for="link"><code data-x="attr-link-type">type</code></dfn> attribute
   gives the <span>MIME type</span> of the linked resource. It is purely advisory. The value must be
-  a <span>valid MIME type string</span>. One exception to this is when its value is an <span>ASCII
-  case-insensitive</span> match for the string "<code data-x="">module</code>" and the element's
-  <code data-x="attr-link-rel">rel</code> attribute contains the <code
-  data-x="rel-stylesheet">stylesheet</code> keyword, which causes the stylesheet link to be
-  processed as a <span>module stylesheet link</span>.</p>
+  a <span>valid MIME type string</span>, or an <span>ASCII case-insensitive</span> match for the
+  string "<code data-x="">module</code>". In the latter case, if the element's <code
+  data-x="attr-link-rel">rel</code> attribute contains the <code
+  data-x="rel-stylesheet">stylesheet</code> keyword, the stylesheet link will be processed as a
+  <span>module stylesheet link</span>.</p>
 
   <p>For <span data-x="external resource link">external resource links</span>, the <code
   data-x="attr-link-type">type</code> attribute is used as a hint to user agents so that they can
@@ -16741,8 +16741,7 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
   <p>The <dfn element-attr for="link"><code data-x="attr-link-title">title</code></dfn> attribute
   gives the title of the link. With one exception, it is purely advisory. The value is text. The
-  exception is for style sheet links that are <span>in a document tree</span> and are not <span
-  data-x="module stylesheet link">module stylesheet links</span>, for which the <code
+  exception is for style sheet links that are <span>in a document tree</span>, for which the <code
   data-x="attr-link-title">title</code> attribute defines <span data-x="CSS style sheet set">CSS
   style sheet sets</span>.</p>
 
@@ -29832,10 +29831,9 @@ document.body.appendChild(wbr);</code></pre>
   document.</p>
 
   <p>If the <code data-x="rel-alternate">alternate</code> keyword is also specified on the
-  <code>link</code> element and the element is not a <span>module stylesheet link</span>, then <dfn
-  id="the-link-is-an-alternative-stylesheet">the link is an alternative style sheet</dfn>; in
-  this case, the <code data-x="attr-title">title</code> attribute must be specified on the
-  <code>link</code> element, with a non-empty value.</p>
+  <code>link</code> element, then <dfn id="the-link-is-an-alternative-stylesheet">the link is an
+  alternative style sheet</dfn>; in this case, the <code data-x="attr-title">title</code> attribute
+  must be specified on the <code>link</code> element, with a non-empty value.</p>
 
   <p>The default type for resources given by the <code data-x="rel-stylesheet">stylesheet</code>
   keyword is <code>text/css</code>.</p>
@@ -29849,11 +29847,10 @@ document.body.appendChild(wbr);</code></pre>
 
   <div algorithm>
   <p>When the <code data-x="attr-link-disabled">disabled</code> attribute of a <code>link</code>
-  element with a <code data-x="rel-stylesheet">stylesheet</code> keyword is set, set the element's
-  <span data-x="link module CSS style sheet">module CSS style sheet</span> to null if it is a
-  <span>module stylesheet link</span>; otherwise,
-  <span data-x="disable a CSS style sheet">disable</span> its <span>associated CSS style
-  sheet</span>.</p>
+  element with a <code data-x="rel-stylesheet">stylesheet</code> keyword is set, if the element is
+  a <span>module stylesheet link</span>, then set its <span
+  data-x="link module CSS style sheet">module CSS style sheet</span> to null. Otherwise, <span
+  data-x="disable a CSS style sheet">disable</span> its <span>associated CSS style sheet</span>.</p>
   </div>
 
   <div algorithm>

--- a/source
+++ b/source
@@ -16551,7 +16551,8 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
   [<span>HTMLConstructor</span>] constructor();
 
   [<span>CEReactions</span>, <span data-x="xattr-ReflectURL">ReflectURL</span>] attribute USVString <dfn attribute for="HTMLLinkElement" data-x="dom-link-href">href</dfn>;
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLLinkElement" data-x="dom-link-import">import</dfn>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn
+      attribute for="HTMLLinkElement" data-x="dom-link-import">import</dfn>;
   [<span>CEReactions</span>] attribute DOMString? <span data-x="dom-link-crossOrigin">crossOrigin</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLLinkElement" data-x="dom-link-rel">rel</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-link-as">as</span>;
@@ -16585,10 +16586,11 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
   data-x="attr-link-imagesrcset">imagesrcset</code> attributes must be present.</p>
 
   <p>The <dfn element-attr for="link"><code data-x="attr-link-import">import</code></dfn>
-  attribute specifies that a stylesheet link is a <span>module stylesheet link</span>, and its value
-  is the module specifier. The <code data-x="attr-link-import">import</code> attribute must only be
-  specified on <code>link</code> elements whose <code data-x="attr-link-rel">rel</code> attribute
-  contains the <code data-x="rel-stylesheet">stylesheet</code> keyword.</p>
+  attribute specifies that a <code>link</code> element whose <code
+  data-x="attr-link-rel">rel</code> attribute contains the <code
+  data-x="rel-stylesheet">stylesheet</code> keyword is a <span>module stylesheet link</span>, and
+  its value is the module specifier. The <code data-x="attr-link-import">import</code> attribute
+  must only be specified on such elements.</p>
 
   <p w-nodev>If the <code data-x="attr-link-href">href</code>, <code
   data-x="attr-link-import">import</code>, and <code
@@ -26372,7 +26374,8 @@ document.body.appendChild(wbr);</code></pre>
   <code data-x="attr-link-rel">rel</code> attribute, as defined for those keywords in the <a
   href="#linkTypes">link types</a> section.</p>
 
-  <p>For <span>module stylesheet links</span>, a link must be created for the <code
+  <p>For <span data-x="module stylesheet link">module stylesheet links</span> without an <code
+  data-x="attr-link-href">href</code> attribute, a link must be created for the <code
   data-x="rel-stylesheet">stylesheet</code> keyword.</p>
 
   <p>Similarly, for <code>a</code> and <code>area</code> elements with an <code
@@ -29903,8 +29906,10 @@ document.body.appendChild(wbr);</code></pre>
    connected</span> changes from being <span data-x="the link is an alternative style sheet">an
    alternative style sheet</span> to not being one, or vice versa.</p></li>
 
-   <li><p>When the <code data-x="attr-link-import">import</code> attribute of a stylesheet link
-   that is already <span>browsing-context connected</span> is set, changed, or removed.</p></li>
+   <li><p>When the <code data-x="attr-link-import">import</code> attribute of a <code>link</code>
+   element whose <code data-x="attr-link-rel">rel</code> attribute contains the <code
+   data-x="rel-stylesheet">stylesheet</code> keyword and that is already <span>browsing-context
+   connected</span> is set, changed, or removed.</p></li>
   </ul>
   </div>
 

--- a/source
+++ b/source
@@ -29851,7 +29851,7 @@ document.body.appendChild(wbr);</code></pre>
   <div algorithm>
   <p>When the <code data-x="attr-link-disabled">disabled</code> attribute of a <code>link</code>
   element with a <code data-x="rel-stylesheet">stylesheet</code> keyword is set, set the element's
-  <span>module CSS style sheet</span> to null if it is a <span>module stylesheet link</span>;
+  <span data-x="link module CSS style sheet">module CSS style sheet</span> to null if it is a <span>module stylesheet link</span>;
   otherwise, <span data-x="disable a CSS style sheet">disable</span> its <span>associated CSS style
   sheet</span>.</p>
   </div>
@@ -29951,7 +29951,7 @@ document.body.appendChild(wbr);</code></pre>
    <li><p>If <var>el</var>'s <code data-x="attr-link-disabled">disabled</code> attribute is set,
    then return.</p></li>
 
-   <li><p>Set <var>el</var>'s <span>module CSS style sheet</span> to null.</p></li>
+   <li><p>Set <var>el</var>'s <span data-x="link module CSS style sheet">module CSS style sheet</span> to null.</p></li>
 
    <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
    empty string, then return.</p></li>
@@ -30036,7 +30036,7 @@ document.body.appendChild(wbr);</code></pre>
 
      <li><p>If <var>result</var> is null or its <span
      data-x="concept-script-parse-error">parse error</span> is non-null, then set
-     <var>el</var>'s <span>module CSS style sheet</span> to null, and <span
+     <var>el</var>'s <span data-x="link module CSS style sheet">module CSS style sheet</span> to null, and <span
      data-x="concept-event-fire">fire an event</span> named <code
      data-x="event-error">error</code> at <var>el</var>.</p></li>
 

--- a/source
+++ b/source
@@ -4175,6 +4175,13 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://drafts.csswg.org/cssom/#serialize-a-css-value">Serializing a CSS value</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps">run the resize steps</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#document-run-the-scroll-steps">run the scroll steps</dfn></li>
+     <li>
+      <dfn data-x="concept-documentorshadowroot-extensions-mixin"
+      data-x-href="https://drafts.csswg.org/cssom/#extensions-to-the-document-or-shadow-root-interface">Extensions to the <code>DocumentOrShadowRoot</code> Interface Mixin</dfn>:
+      <ul class="brief">
+       <li><dfn data-x="adoptedstylesheets" data-x-href="https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</dfn></li>
+      </ul>
+     </li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes">evaluate media queries and report changes</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#scroll-a-target-into-view">Scroll a target into view</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/cssom-view/#scroll-to-the-beginning-of-the-document">Scroll to the beginning of the document</dfn></li>
@@ -69334,6 +69341,7 @@ not-slash     = %x0000-002E / %x0030-10FFFF
    <dd><code data-x="attr-template-shadowrootclonable">shadowrootclonable</code></dd>
    <dd><code data-x="attr-template-shadowrootserializable">shadowrootserializable</code></dd>
    <dd><code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></dd>
+   <dd><code data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></dd>
    <dt><span
    data-x="concept-element-accessibility-considerations">Accessibility considerations</span>:</dt>
    <dd><a href="https://w3c.github.io/html-aria/#el-template">For authors</a>.</dd>
@@ -69430,6 +69438,11 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
   <p>The <dfn element-attr for="template"><code
   data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></dfn>
   content attribute is a <span>boolean attribute</span>.</p>
+
+  <p>The <dfn element-attr for="template"><code
+  data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></dfn> content
+  contributes to the <span data-x="concept-DocumentFragment-host">host's</span>
+  <span>adoptedStyleSheets</span>.</p>
 
   <p>The <span>template contents</span> of a <code>template</code> element <a
   href="#template-syntax">are not children of the element itself</a>.</p>
@@ -69670,7 +69683,71 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
 
   </div>
 
+<hr>
 
+  <div algorithm>
+  <p>The <dfn>stylesheet adopting steps</dfn> for <code>template</code> elements are:</p>
+
+  <ol>
+   <li><p>If the value of
+   <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span> is
+   empty, then return.</p></li>
+   <li><p>Let <var>adoptedStyleSheets</var> be an empty array.</p></li>
+
+   <li><p>For each <span>unordered set of unique space-separated tokens</span> <var>specifier</var> in
+   <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>:</p>
+    <ol>
+      <li><p>Let <var>url</var> be the result of <span data-x="resolve a module specifier">resolving
+      a module specifier</span> given <var>moduleScript</var> and <var>specifier</var>.</p> If
+      any errors occur, then <span>continue</span>.</li>
+      <li><p>Let <var>settingsObject</var> be the <span>current settings object</span>.</li>
+      <li><p>Let <var>moduleType</var> be "<code data-x="">css</code>".</p></li>
+      <li><p>Let <var>moduleMap</var> be <var>settingsObject</var>'s <span
+      data-x="concept-settings-object-module-map">module map</span>.</p></li>
+      <li><p>Let <var>moduleScript</var> be
+      <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)].</p></li>
+      <li><p>If <var>moduleScript</var> is null, then <span>continue</span>.</p></li> // TODO(kschmi): Add fetch!!!!!!!!!!!!!!!!!
+      <li><p>Extract the <code>CSSStyleSheet</code> from <var>moduleScript</var>'s
+      <span data-x="concept-script-record">record</span> and append it to
+      <var>adoptedStyleSheets</var>. If any error occurs, then <span>continue</span>.</p></li>
+    </ol>
+   </li>
+   <li><p><span data-x="list extend">Extend</span> <span data-x="concept-DocumentFragment-host">host</span>'s
+   <span>adoptedStyleSheets</span> with <var>adoptedStyleSheets</var>.</p></li>
+  </ol>
+  </div>
+
+  <div class="example">
+
+   <p>This example demonstrates two equivalent methods to import CSS module scripts, the
+   first using the JavaScript <code data-x="">import</code> method and the second using the
+   <span data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</span>
+   attribute.</p>
+
+   <pre><code class="html">
+&lt;script type="importmap">
+{
+  "imports": {
+    "foo": "data:text/css,div {color:blue}"
+  }
+}
+&lt;/script>
+&lt;div id="host">
+  &lt;template shadowrootmode="open">
+    &lt;script type="module">
+      import styles from "foo" with { type: "css"};
+      document.getElementById("host").shadowRoot.adoptedStyleSheets = [styles];
+    &lt;/script>
+    &lt;div>test&lt;/div>
+  &lt;/template>
+&lt;/div>
+&lt;div id="host_shadowrootadoptedstylesheets_attribute">
+  &lt;template shadowrootmode="open" shadowrootadoptedstylesheets="foo">
+    &lt;div>test&lt;/div>
+  &lt;/template>
+&lt;/div></code></pre>
+
+  </div>
 
   <div w-nodev>
 
@@ -145726,6 +145803,10 @@ document.body.appendChild(text);
          data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code>
          attribute, then set <var>shadow</var>'s <span>keep custom element registry null</span> to
          true.</p></li>
+
+         <li><p>If <var>templateStartTag</var> has a <code
+         data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code>
+         attribute, then perform the <span>stylesheet adopting steps</span> on <var>template</var>.</p></li>
         </ol>
        </li>
       </ol>
@@ -157548,7 +157629,8 @@ interface <dfn interface>External</dfn> {
          <code data-x="attr-template-shadowrootslotassignment">shadowrootslotassignment</code>;
          <code data-x="attr-template-shadowrootclonable">shadowrootclonable</code>;
          <code data-x="attr-template-shadowrootserializable">shadowrootserializable</code>;
-         <code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></td>
+         <code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code>;
+         <code data-x="attr-template-shadowrootadoptedstylesheets">shadowrootadoptedstylesheets</code></td>
      <td><code>HTMLTemplateElement</code></td>
     </tr>
 
@@ -159052,6 +159134,11 @@ interface <dfn interface>External</dfn> {
      <td> <code data-x="attr-option-selected">option</code>
      <td> Whether the option is selected by default
      <td> <span>Boolean attribute</span>
+    <tr>
+     <th> <code data-x="">shadowrootadoptedstylesheets</code>
+     <td> <code data-x="attr-template-shadowrootadoptedstylesheets">template</code>
+     <td> Sets <span>adoptedStyleSheets</span> on a declarative shadow root
+     <td> <a href="#attribute-text">Text</a>
     <tr>
      <th> <code data-x="">shadowrootclonable</code>
      <td> <code data-x="attr-template-shadowrootclonable">template</code>


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Adds support for `<link type=module rel=stylesheet>`.

- [ ] At least two implementers are interested (and none opposed):
   * Chromium
   * …
- [] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:

- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/448174611
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2037650
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=314242
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …
- [X] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [X] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/824
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

Addresses https://github.com/whatwg/html/issues/10673


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12339/indices.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">/indices.html</a>  ( <a href="https://whatpr.org/html/12339/ac0389a...5fdf497/indices.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">diff</a> )
<a href="https://whatpr.org/html/12339/links.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">/links.html</a>  ( <a href="https://whatpr.org/html/12339/ac0389a...5fdf497/links.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">diff</a> )
<a href="https://whatpr.org/html/12339/semantics.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">/semantics.html</a>  ( <a href="https://whatpr.org/html/12339/ac0389a...5fdf497/semantics.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">diff</a> )
<a href="https://whatpr.org/html/12339/webappapis.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">/webappapis.html</a>  ( <a href="https://whatpr.org/html/12339/ac0389a...5fdf497/webappapis.html" title="Last updated on Aug 28, 2026, 12:14 AM UTC (5fdf497)">diff</a> )