### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/upcoming-whatnot-meeting.md
+++ b/.github/ISSUE_TEMPLATE/upcoming-whatnot-meeting.md
@@ -1,0 +1,14 @@
+---
+name: Upcoming WHATNOT meeting
+about: Create a new WHATNOT meeting announcement
+title: Upcoming WHATNOT meeting on 20XX-XX-XX
+labels: agenda+
+assignees: ''
+
+---
+
+[DELETE ONE OF THE FOLLOWING LINES AND FILL IN THE DATE]
+The next WHATNOT triage meeting is scheduled for [DATE], at 9AM PT (AMER-EMEA friendly time).
+The next WHATNOT triage meeting is scheduled for [DATE], at 1AM PT (APAC-EMEA friendly time).
+
+We would like to invite anyone that can contribute to join us.  If you are interested in attending the next call and need the invite please respond here or reach out privately to the editors.  Please tag issues and PRs for the next call using agenda+ in all WHATWG repositories across [issues](https://github.com/search?q=org%3Awhatwg+is%3Aopen+label%3Aagenda%2B&type=issues) and [pull requests](https://github.com/search?q=org%3Awhatwg+is%3Aopen+label%3Aagenda%2B&type=pullrequests) .


### PR DESCRIPTION
Just adding a default template for "new WHATNOT meeting", which I should have thought of a long time ago.