### PR TITLE
Don't update active document too early for same-origin navigations

### DIFF
--- a/source
+++ b/source
@@ -105285,7 +105285,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
   context</span> has a corresponding <code>WindowProxy</code> object, as well as the following:</p>
 
   <ul>
-   <li><p>An <dfn>active document</dfn>, a <code>Document</code>.</p></li>
+   <li><p>An <dfn>active document</dfn>, a <code>Document</code> or null, initially null.</p></li>
 
    <li><p>An <dfn export>opener browsing context</dfn>, a <span>browsing context</span> or null,
    initially null.</p></li>


### PR DESCRIPTION
The active document was previously derived from the active window's
associated Document, which changes during create-and-initialize for
an initial about:blank same-origin navigation before the new document
is made active. By making active document a variable of browsing context
only set by the make active algorithm, this allows the document to be
updated at the right time.

One note - I have uncertainties here about how this interacts with "[queue a global task](https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task)" for tasks which are queued in the time between [create-and-intialize](https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object) and the point which make-active is made. But this is a little beyond my mental model for lifecycle of queued tasks. A potential fix there might be to change some instances of "queue a global task on the navigation and traversal task source given navigable's active window" to instead use "queue a task on the navigation and traversal task source given navigable's active document" - see: https://github.com/whatwg/html/issues/12415#issuecomment-4392722417. Even without that, I think this is an improvement anyhow, but let me know if I should investigate that more / improve my mental model of intended behavior.

- [x] At least two implementers are interested (and none opposed):
   * Chromium/Webkit/Gecko already implements AFIKT
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/1cd72b546cd6b3b0a667b8af7c788aad29ed1869/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.html
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12421/browsing-the-web.html" title="Last updated on Aug 24, 2026, 6:25 PM UTC (99348fe)">/browsing-the-web.html</a>  ( <a href="https://whatpr.org/html/12421/cf4109f...99348fe/browsing-the-web.html" title="Last updated on Aug 24, 2026, 6:25 PM UTC (99348fe)">diff</a> )
<a href="https://whatpr.org/html/12421/document-sequences.html" title="Last updated on Aug 24, 2026, 6:25 PM UTC (99348fe)">/document-sequences.html</a>  ( <a href="https://whatpr.org/html/12421/cf4109f...99348fe/document-sequences.html" title="Last updated on Aug 24, 2026, 6:25 PM UTC (99348fe)">diff</a> )