### PR TITLE
Add `<meta name="responsive-embedded-sizing">`

### DIFF
--- a/source
+++ b/source
@@ -4015,6 +4015,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
       <li><dfn data-x-href="https://drafts.csswg.org/css-sizing/#fit-content-inline-size">fit-content inline size</dfn></li>
       <li><dfn data-x-href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">'aspect-ratio'</dfn> property</li>
       <li><dfn data-x-href="https://drafts.csswg.org/css-sizing/#intrinsic-size">intrinsic size</dfn></li>
+      <li><dfn data-x-href="https://drafts.csswg.org/css-sizing-4/#responsive-iframes">responsively-sized iframes</dfn></li>
     </ul>
 
     <p>The following features are defined in <cite>CSS Lists and Counters</cite>.
@@ -4476,6 +4477,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <dfn data-x="csp-EnsureCSPDoesNotBlockStringCompilation" data-x-href="https://w3c.github.io/webappsec-csp/#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation</dfn> abstract operation</li>
      <li>The <dfn data-x-href="https://w3c.github.io/webappsec-csp/#allow-base-for-document">Is base allowed for Document?</dfn> algorithm</li>
      <li>The <dfn data-x-href="https://w3c.github.io/webappsec-csp/#frame-ancestors"><code data-x="">frame-ancestors</code> directive</dfn></li>
+     <li>The <dfn data-x-href="https://w3c.github.io/webappsec-csp/#grammardef-ancestor-source-list">ancestor-source-list</dfn> syntax</li>
+     <li>The <dfn data-x-href="https://w3c.github.io/webappsec-csp/#match-url-to-source-list">Does url match source list in origin with redirect count?</dfn> algorithm</li>
      <li>The <dfn data-x-href="https://w3c.github.io/webappsec-csp/#sandbox"><code data-x="">sandbox</code> directive</dfn></li>
      <li>The <dfn data-x-href="https://w3c.github.io/webappsec-csp/#contains-a-header-delivered-content-security-policy">contains a header-delivered Content Security Policy</dfn> property.</li>
      <li>The <dfn data-x="parse-response-csp" data-x-href="https://w3c.github.io/webappsec-csp/#parse-response-csp">Parse a response's Content Security Policies</dfn> algorithm.</li>
@@ -11723,6 +11726,16 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
   the <span>ongoing navigation</span>. This eventually gets set back to null, after <cite>WebDriver
   BiDi</cite> considers the loading process to be finished. <ref>BIDI</ref></p>
 
+  <p>Each <code>Document</code> has a
+  <dfn export for="Document" data-x="concept-document-responsive-embedded-sizing-flag">responsive
+  embedded sizing flag</dfn>, which is a boolean or null, initially null.</p>
+
+  <p class="note">This can be set to true by <code>meta</code> elements whose
+  <code data-x="attr-meta-name">name</code> attribute is
+  <code data-x="meta-responsive-embedded-sizing">responsive-embedded-sizing</code>,
+  set to false when <span data-x="reveal">revealing</span> the <code>Document</code>,
+  and used by <span>responsively-sized iframes</span>.</p>
+
   <p>Each <code>Document</code> has an <dfn data-x="concept-document-about-base-url">about base
   URL</dfn>, which is a <span>URL</span> or null, initially null.</p>
 
@@ -18042,6 +18055,100 @@ interface <dfn interface>HTMLMetaElement</dfn> : <span>HTMLElement</span> {
     model for <code data-x="meta-referrer">referrer</code> is not responsive to element removals,
     and does not use <span>tree order</span>. Only the most-recently-inserted or
     most-recently-modified <code>meta</code> element in this state has an effect.</p>
+
+    </div>
+   </dd>
+
+   <dt><dfn attr-value for="meta/name"><code
+   data-x="meta-responsive-embedded-sizing">responsive-embedded-sizing</code></dfn></dt>
+
+   <dd>
+    <p>The <code data-x="meta-responsive-embedded-sizing">responsive-embedded-sizing</code>
+    metadata name allows a document to opt in to <span>responsively-sized iframes</span> when
+    embedded by an allowed container origin. <ref>CSSSIZING</ref></p>
+
+    <p>The value must be the string "<code data-x="">allow-origins=</code>" followed by an
+    <span>ancestor-source-list</span>. <ref>CSP</ref></p>
+
+    <p>There must not be more than one <code>meta</code> element where the
+    <code data-x="attr-meta-name">name</code> attribute value is an
+    <span>ASCII case-insensitive</span> match for
+    <code data-x="meta-responsive-embedded-sizing">responsive-embedded-sizing</code>
+    per document.</p>
+
+    <div class="example">
+     <p>The following declaration allows the document to be responsively sized when embedded in an
+     <code>iframe</code> by a page from the <code data-x="">https://example.com</code> origin:</p>
+
+     <pre><code class="html">&lt;meta name="responsive-embedded-sizing"
+      content="allow-origins=https://example.com"></code></pre>
+    </div>
+
+    <div w-nodev>
+
+    <div algorithm>
+    <p>If any <code>meta</code> element <var>element</var> is <span data-x="node is inserted into a
+    document">inserted into the document</span>, or has its <code
+    data-x="attr-meta-name">name</code> or <code data-x="attr-meta-content">content</code>
+    attributes changed, user agents must run the following algorithm:</p>
+
+    <ol>
+     <li><p>Let <var>document</var> be <var>element</var>'s <span>node document</span>.</p></li>
+
+     <li>
+      <p>If any of the following are true:</p>
+
+      <ul>
+       <li><p><var>element</var> is not <span>in a document tree</span>;</p></li>
+
+       <li><p><var>document</var>'s <span data-x="doc-container-document">container document</span>
+       is null;</p></li>
+
+       <li><p><var>document</var>'s
+       <span data-x="concept-document-responsive-embedded-sizing-flag">responsive embedded sizing
+       flag</span> is not null;</p></li>
+
+       <li><p><var>element</var> does not have a <code data-x="attr-meta-name">name</code>
+       attribute whose value is an <span>ASCII case-insensitive</span> match for <code
+       data-x="meta-responsive-embedded-sizing">responsive-embedded-sizing</code>; or</p></li>
+
+       <li><p><var>element</var> does not have a <code data-x="attr-meta-content">content</code>
+       attribute,</p></li>
+      </ul>
+
+      <p>then return.</p>
+     </li>
+
+     <li><p>Let <var>value</var> be the value of <var>element</var>'s <code
+     data-x="attr-meta-content">content</code> attribute.</p></li>
+
+     <li><p>If <var>value</var> does not <span data-x="starts with">start with</span> "<code
+     data-x="">allow-origins=</code>", then return.</p></li>
+
+     <li><p>Let <var>tokens</var> be the substring of <var>value</var> that follows the
+     "<code data-x="">allow-origins=</code>" prefix, <span data-x="split a string on ASCII
+     whitespace">split on ASCII whitespace</span>.</p></li>
+
+     <li><p>Let <var>sourceList</var> be the result of <span data-x="set create">creating a
+     set</span> from <var>tokens</var>.</p></li>
+
+     <li><p>Let <var>containerOriginURL</var> be the result of applying the <span>URL parser</span>
+     to the <span data-x="serialization of an origin">ASCII serialization</span> of
+     <var>document</var>'s <span data-x="doc-container-document">container document</span>'s
+     <span data-x="concept-document-origin">origin</span>.</p></li>
+
+     <li><p>If <var>containerOriginURL</var> is failure, then return.</p></li>
+
+     <li><p>If running <span>Does url match source list in origin with redirect count?</span> on
+     <var>containerOriginURL</var>, <var>sourceList</var>, <var>document</var>'s
+     <span data-x="concept-document-origin">origin</span>, and 0 returns
+     "<code data-x="">Does Not Match</code>", then return.</p></li>
+
+     <li><p>Set <var>document</var>'s <span
+     data-x="concept-document-responsive-embedded-sizing-flag">responsive embedded sizing
+     flag</span> to true.</p></li>
+    </ol>
+    </div>
 
     </div>
    </dd>
@@ -112806,6 +112913,10 @@ location.href = '#foo';</code></pre>
    <li><p>If <var>document</var>'s <span>has been revealed</span> is true, then return.</p></li>
 
    <li><p>Set <var>document</var>'s <span>has been revealed</span> to true.</p></li>
+
+   <li><p>If <var>document</var>'s <span
+   data-x="concept-document-responsive-embedded-sizing-flag">responsive embedded sizing flag</span>
+   is null, then set it to false.</p></li>
 
    <li><p>Let <var>transition</var> be the result of
    <span>resolving inbound cross-document view-transition</span> for <var>document</var>.</p></li>


### PR DESCRIPTION
This adds `<meta name="responsive-embedded-sizing">` as an immutable standardized name.

This is used by the CSS [responsive embedded sizing flag].

[responsive embedded sizing flag]: https://drafts.csswg.org/css-sizing-4/#document-responsive-embedded-sizing-flag

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chromium: https://chromestatus.com/feature/5108373464547328
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/css/css-sizing/responsive-iframe?label=master&label=experimental&aligned
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/418397278
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2039202
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=314714
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: In Chromium Documentation Tracker https://issuetracker.google.com/issues/511947520
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12444/browsing-the-web.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">/browsing-the-web.html</a>  ( <a href="https://whatpr.org/html/12444/ae6c5d8...1d50e5d/browsing-the-web.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">diff</a> )
<a href="https://whatpr.org/html/12444/dom.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">/dom.html</a>  ( <a href="https://whatpr.org/html/12444/ae6c5d8...1d50e5d/dom.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">diff</a> )
<a href="https://whatpr.org/html/12444/infrastructure.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12444/ae6c5d8...1d50e5d/infrastructure.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">diff</a> )
<a href="https://whatpr.org/html/12444/semantics.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">/semantics.html</a>  ( <a href="https://whatpr.org/html/12444/ae6c5d8...1d50e5d/semantics.html" title="Last updated on Aug 26, 2026, 2:17 PM UTC (1d50e5d)">diff</a> )