### PR TITLE
Also check CORS-same-origin in the <link> quirk

### DIFF
--- a/source
+++ b/source
@@ -29615,9 +29615,10 @@ document.body.appendChild(wbr);</code></pre>
   </ul>
   </div>
 
-  <p><strong>Quirk</strong>: If the document has been set to <span>quirks mode</span>, has the
-  <span>same origin</span> as the <span>URL</span> of the external resource<!-- CVE-2010-0654 -->,
-  the external resource is <span>CORS-same-origin</span>, and the <span
+  <p><strong>Quirk</strong>: If the document has been set to <span>quirks mode</span>, the external
+  resource is <span>CORS-same-origin</span>, the document has the <span>same origin</span> as the
+  external resource's <span data-x="concept-response">response</span>'s <span
+  data-x="concept-response-url">URL</span><!-- CVE-2010-0654 -->, and the <span
   data-x="Content-Type">Content-Type metadata</span> of the external resource is not a supported
   style sheet type, the user agent must instead assume it to be <code>text/css</code>.</p>
 


### PR DESCRIPTION
The quirks-mode quirk that assumes text/css for a style sheet served with
another Content-Type now also requires the response to be CORS-same-origin.
That excludes opaque responses, in particular a no-cors cross-origin load
that redirects back to a same-origin URL, and makes the quirk agree with the
style sheet's origin-clean flag.

The same-origin condition is now stated against the response's URL. Reading
it as the request's URL would let an attacker-controlled same-origin
redirect serve cross-origin bytes as CSS, which is the data theft the quirk
was restricted for in the first place (CVE-2010-0654).

Tests: web-platform-tests/wpt#62516.

Fixes #12403.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit (https://github.com/whatwg/html/issues/12403#issuecomment-4442385605)
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62516
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/558037053
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2070130
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=323654
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12468/links.html" title="Last updated on May 18, 2026, 12:19 PM UTC (a9fe935)">/links.html</a>  ( <a href="https://whatpr.org/html/12468/6f84b26...a9fe935/links.html" title="Last updated on May 18, 2026, 12:19 PM UTC (a9fe935)">diff</a> )