### PR TITLE
Add MathML `<a>` handling to sanitization algorithms

### DIFF
--- a/source
+++ b/source
@@ -4587,6 +4587,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-fence">MathML <code>fence</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-form">MathML <code>form</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-height">MathML <code>height</code></dfn> attribute</li>
+     <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-href">MathML <code>href</code></dfn> attribute</li>
+     <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-hreflang">MathML <code>hreflang</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-largeop">MathML <code>largeop</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-lspace">MathML <code>lspace</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-maxsize">MathML <code>maxsize</code></dfn> attribute</li>
@@ -4597,6 +4599,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-separator">MathML <code>separator</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-stretchy">MathML <code>stretchy</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-symmetric">MathML <code>symmetric</code></dfn> attribute</li>
+     <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-type">MathML <code>type</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-voffset">MathML <code>voffset</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-width">MathML <code>width</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-displaystyle">MathML <code>displaystyle</code></dfn> attribute</li>
@@ -128742,7 +128745,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <tr>
       <td><code data-x="MathML a">a</code></td>
       <td><span data-x="MathML namespace">MathML</span></td>
-      <td><code data-x="">href</code>, <code data-x="">hreflang</code>, <code data-x="">type</code></td>
+      <td><code data-x="MathML href">href</code>, <code data-x="MathML hreflang">hreflang</code>, <code data-x="MathML type">type</code></td>
     </tr>
     <tr>
       <td><code data-x="MathML math">math</code></td>
@@ -129000,7 +129003,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <tr>
      <td><code data-x="MathML a">a</code>
      <td><span data-x="MathML namespace">MathML</span>
-     <td><code data-x="">href</code>
+     <td><code data-x="MathML href">href</code>
      <td>no namespace
     <tr>
      <td><code data-x="SVG a">a</code>

--- a/source
+++ b/source
@@ -4606,6 +4606,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-fence">MathML <code>fence</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-form">MathML <code>form</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-height">MathML <code>height</code></dfn> attribute</li>
+     <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-href">MathML <code>href</code></dfn> attribute</li>
+     <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-hreflang">MathML <code>hreflang</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-largeop">MathML <code>largeop</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-lspace">MathML <code>lspace</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-maxsize">MathML <code>maxsize</code></dfn> attribute</li>
@@ -4616,6 +4618,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-separator">MathML <code>separator</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-stretchy">MathML <code>stretchy</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-symmetric">MathML <code>symmetric</code></dfn> attribute</li>
+     <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-type">MathML <code>type</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-voffset">MathML <code>voffset</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-width">MathML <code>width</code></dfn> attribute</li>
      <li><dfn data-x-href="https://w3c.github.io/mathml-core/#dfn-displaystyle">MathML <code>displaystyle</code></dfn> attribute</li>
@@ -129181,7 +129184,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <tr>
       <td><code data-x="MathML a">a</code></td>
       <td><span data-x="MathML namespace">MathML</span></td>
-      <td><code data-x="">href</code>, <code data-x="">hreflang</code>, <code data-x="">type</code></td>
+      <td><code data-x="MathML href">href</code>, <code data-x="MathML hreflang">hreflang</code>, <code data-x="MathML type">type</code></td>
     </tr>
     <tr>
       <td><code data-x="MathML math">math</code></td>
@@ -129439,7 +129442,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <tr>
      <td><code data-x="MathML a">a</code>
      <td><span data-x="MathML namespace">MathML</span>
-     <td><code data-x="">href</code>
+     <td><code data-x="MathML href">href</code>
      <td>no namespace
     <tr>
      <td><code data-x="SVG a">a</code>

--- a/source
+++ b/source
@@ -129440,11 +129440,6 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
      <th>Attribute namespace
    <tbody>
     <tr>
-     <td><code data-x="MathML a">a</code>
-     <td><span data-x="MathML namespace">MathML</span>
-     <td><code data-x="MathML href">href</code>
-     <td>no namespace
-    <tr>
      <td><code data-x="SVG a">a</code>
      <td><span data-x="SVG namespace">SVG</span>
      <td><code data-x="SVG href">href</code>
@@ -129455,6 +129450,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
      <td><code data-x="SVG href">href</code>
      <td><span data-x="XLink namespace">XLink</span>
   </table>
+
+  <p class="note">The <span>MathML <code>a</code></span> element is not listed here because the
+  <span>inner sanitize steps</span> remove an <code data-x="">href</code> attribute that
+  <span>contains a <code>javascript:</code> URL</span> from any MathML element, whether the
+  attribute is in no namespace or in the <span>XLink namespace</span>.</p>
 
   <p>The <dfn>built-in animating URL attributes list</dfn> is the list of element-attribute pairs
   represented by the following table. For each row in the table, the element corresponds to a

--- a/source
+++ b/source
@@ -129181,7 +129181,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <tr>
       <td><code data-x="MathML a">a</code></td>
       <td><span data-x="MathML namespace">MathML</span></td>
-      <td><code data-x="MathML href">href</code>, <code data-x="MathML hreflang">hreflang</code>, <code data-x="MathML type">type</code></td>
+      <td><code data-x="">href</code>, <code data-x="">hreflang</code>, <code data-x="">type</code></td>
     </tr>
     <tr>
       <td><code data-x="MathML math">math</code></td>
@@ -129439,7 +129439,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <tr>
      <td><code data-x="MathML a">a</code>
      <td><span data-x="MathML namespace">SVG</span>
-     <td><code data-x="MathML href">href</code>
+     <td><code data-x="">href</code>
      <td>no namespace
     <tr>
      <td><code data-x="SVG a">a</code>

--- a/source
+++ b/source
@@ -129179,6 +129179,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
    </thead>
    <tbody>
     <tr>
+      <td><code data-x="MathML a">a</code></td>
+      <td><span data-x="MathML namespace">MathML</span></td>
+      <td><code data-x="MathML href">href</code>, <code data-x="MathML hreflang">hreflang</code>, <code data-x="MathML type">type</code></td>
+    </tr>
+    <tr>
       <td><code data-x="MathML math">math</code></td>
       <td><span data-x="MathML namespace">MathML</span></td>
       <td></td>
@@ -129431,6 +129436,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
      <th>Attribute
      <th>Attribute namespace
    <tbody>
+    <tr>
+     <td><code data-x="MathML a">a</code>
+     <td><span data-x="MathML namespace">SVG</span>
+     <td><code data-x="MathML href">href</code>
+     <td>no namespace
     <tr>
      <td><code data-x="SVG a">a</code>
      <td><span data-x="SVG namespace">SVG</span>

--- a/source
+++ b/source
@@ -129438,7 +129438,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
    <tbody>
     <tr>
      <td><code data-x="MathML a">a</code>
-     <td><span data-x="MathML namespace">SVG</span>
+     <td><span data-x="MathML namespace">MathML</span>
      <td><code data-x="">href</code>
      <td>no namespace
     <tr>


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Add MathML `<a>` handling to sanitization algorithms

This adds MathML a with href, hreflang and type attributes to the safe default configuration, this matches SVG and HTML's a elements.

- [ ] At least two implementers are interested (and none opposed):
   * Gecko
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/8212842
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/510487697 (mathml a meta bug)
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2060531
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=303808 (sanitizer meta bug)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12592/dynamic-markup-insertion.html" title="Last updated on Aug 4, 2026, 2:12 PM UTC (1a324ca)">/dynamic-markup-insertion.html</a>  ( <a href="https://whatpr.org/html/12592/b9110b8...1a324ca/dynamic-markup-insertion.html" title="Last updated on Aug 4, 2026, 2:12 PM UTC (1a324ca)">diff</a> )
<a href="https://whatpr.org/html/12592/infrastructure.html" title="Last updated on Aug 4, 2026, 2:12 PM UTC (1a324ca)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12592/b9110b8...1a324ca/infrastructure.html" title="Last updated on Aug 4, 2026, 2:12 PM UTC (1a324ca)">diff</a> )