### PR TITLE
 Add assertion for ancestorOrigins

### DIFF
--- a/source
+++ b/source
@@ -11761,6 +11761,8 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
    data-x="concept-document-internal-ancestor-origin-objects-list">internal ancestor origin objects
    list</span>.</p></li>
 
+   <li><p><span>Assert</span>: <var>ancestorOrigins</var> is not null.</p></li>
+
    <li><p>Let <var>masked</var> be false.</p></li>
 
    <li><p>If <var>referrerPolicy</var> is "<code data-x="">no-referrer</code>", then set


### PR DESCRIPTION
It can be `null`, as initially "internal ancestor origin objects"
is `null` and is only initialized later. The assertion makes sure
that it happens first in the parent and then in the child.

The previous step referenced a variable that is no longer
present in the algorithm after e161310ae7951d27791f59123871c147541d6624

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12630/dom.html" title="Last updated on Jun 28, 2026, 11:38 AM UTC (4443676)">/dom.html</a>  ( <a href="https://whatpr.org/html/12630/4adc122...4443676/dom.html" title="Last updated on Jun 28, 2026, 11:38 AM UTC (4443676)">diff</a> )