### PR TITLE
Fix insertion location of <template> for declarative shadow roots

### DIFF
--- a/source
+++ b/source
@@ -145749,7 +145749,7 @@ document.body.appendChild(text);
 
        <li><p>If <var>declarativeShadowHostElement</var> is a <span>shadow host</span>, then
        <span>insert an element at the adjusted insertion location</span> with
-       <var>template</var>.</p></li>
+       <var>template</var> and <var>adjustedInsertionLocation</var>.</p></li>
 
        <li>
         <p>Otherwise:</p>
@@ -145770,7 +145770,7 @@ document.body.appendChild(text);
 
           <ol>
            <li><p><span>Insert an element at the adjusted insertion location</span> with
-           <var>template</var>.</p></li>
+           <var>template</var> and <var>adjustedInsertionLocation</var>.</p></li>
 
            <li><p>The user agent may report an error to the developer console.</p></li>
 

--- a/source
+++ b/source
@@ -145709,12 +145709,6 @@ document.body.appendChild(text);
      <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for
      inserting a node</span>.</p></li>
 
-     <li><p>Let <var>intendedParent</var> be the node in which the
-     <var>adjustedInsertionLocation</var> finds itself.</p></li>
-
-     <li><p>Let <var>document</var> be <var>intendedParent</var>'s <span>node
-     document</span>.</p></li>
-
      <li>
       <p>If <var>templateStartTag</var>'s <code
       data-x="attr-template-shadowrootmode">shadowrootmode</code> is not in the <span


### PR DESCRIPTION
Recomputing the adjusted insertion location after `<template>` was pushed
onto the stack of open elements caused it to be inserted into itself for
two templates in a row. Fix by reusing the location computed before
`<template>` is created.

NB: though this area was changed around recently in #12624, this issue existed before that.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * All browsers implement
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/declarative/declarative-shadow-dom-basic.html
   * https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/declarative/declarative-shadow-dom-attachment.html
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12666/parsing.html" title="Last updated on Aug 21, 2026, 6:26 AM UTC (c37c9f2)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12666/58eecd0...c37c9f2/parsing.html" title="Last updated on Aug 21, 2026, 6:26 AM UTC (c37c9f2)">diff</a> )