### PR TITLE
Replace fallback base URL with DOM's base URL override

### DIFF
--- a/source
+++ b/source
@@ -3402,7 +3402,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
              <dfn data-x="concept-document-allow-declarative-shadow-roots" data-x-href="https://dom.spec.whatwg.org/#concept-document-allow-declarative-shadow-roots">allow declarative shadow roots</dfn>, and
              <dfn data-x="concept-document-content-type" data-x-href="https://dom.spec.whatwg.org/#concept-document-content-type">content type</dfn> of a <code>Document</code></li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#get-the-base-url">get the base URL</dfn> algorithm and
-             <dfn data-x-href="https://dom.spec.whatwg.org/#base-url-override">base URL override</dfn> of a <code>Document</code></li>
+             <dfn data-x-href="https://dom.spec.whatwg.org/#document-base-url-override">base URL override</dfn> of a <code>Document</code></li>
      <li>The distinction between <dfn data-x-href="https://dom.spec.whatwg.org/#xml-document">XML documents</dfn> and
                                  <dfn data-x-href="https://dom.spec.whatwg.org/#html-document">HTML documents</dfn></li>
      <li>The terms <dfn data-x-href="https://dom.spec.whatwg.org/#concept-document-quirks">quirks mode</dfn>,

--- a/source
+++ b/source
@@ -7764,21 +7764,16 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
   <span>URL record</span> obtained by running these steps:</p>
 
   <ol>
-   <li>
-    <p>If <var>document</var> has no <span>descendant</span> <code>base</code> element that has an
-    <code data-x="attr-base-href">href</code> attribute:</p>
+   <li><p>If <var>document</var> has a <span>descendant</span> <code>base</code> element that has an
+   <code data-x="attr-base-href">href</code> attribute, then return the <span>frozen base URL</span>
+   of the first such <code>base</code> element in <span>tree order</span>.</p></li>
 
-    <ol>
-     <li><p>If <var>document</var>'s <span>base URL override</span> is non-null, then return
-     <var>document</var>'s <span>base URL override</span>.</p></li>
+   <li><p>If <var>document</var>'s <span>base URL override</span> is non-null, then return
+   <var>document</var>'s <span>base URL override</span>.</p></li>
 
-     <li><p>Return <var>document</var>'s <span>fallback base URL</span>.</p></li>
-    </ol>
-   </li>
+   <!-- https://www.hixie.ch/tests/adhoc/dom/level0/history/pushState/001/ -->
 
-   <li><p>Return the <span>frozen base URL</span> of the first <code>base</code> element in
-   <var>document</var> that has an <code data-x="attr-base-href">href</code> attribute, in
-   <span>tree order</span>.</p></li>
+   <li><p>Return <var>document</var>'s <span data-x="concept-document-url">URL</span>.</p></li>
   </ol>
   </div>
 
@@ -7787,35 +7782,12 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
   <var>document</var>'s <span>document base URL</span>.</p>
   </div>
 
-  <div algorithm>
-  <p>The <dfn>fallback base URL</dfn> of a <code>Document</code> object <var>document</var> is the
-  <span>URL record</span> obtained by running these steps:</p>
-
-  <ol>
-   <li>
-    <p>If <var>document</var> is <span data-x="an iframe srcdoc document">an <code>iframe</code>
-    <code data-x="attr-iframe-srcdoc">srcdoc</code> document</span>:</p>
-
-    <ol>
-     <li><p><span>Assert</span>: <var>document</var>'s <span
-     data-x="concept-document-about-base-url">about base URL</span> is non-null.</p></li>
-
-     <li><p>Return <var>document</var>'s <span data-x="concept-document-about-base-url">about base
-     URL</span>.</p></li>
-    </ol>
-   </li>
-
-   <li><p>If <var>document</var>'s <span data-x="concept-document-url">URL</span> <span>matches
-   <code>about:blank</code></span> and <var>document</var>'s <span
-   data-x="concept-document-about-base-url">about base URL</span> is non-null, then return
-   <var>document</var>'s <span data-x="concept-document-about-base-url">about base
-   URL</span>.</p></li>
-
-   <!-- https://www.hixie.ch/tests/adhoc/dom/level0/history/pushState/001/ -->
-
-   <li><p>Return <var>document</var>'s <span data-x="concept-document-url">URL</span>.</p></li>
-  </ol>
-  </div>
+  <p class="note">A relative <code data-x="attr-base-href">href</code> on a <code>base</code> element
+  resolves against the <code>Document</code>'s <span data-x="concept-document-url">URL</span>, not
+  against the <span>base URL override</span>. For "<code data-x="">about:</code>"-schemed
+  <code>Document</code>s such an <code data-x="attr-base-href">href</code> therefore does not
+  resolve, as their <span data-x="concept-document-url">URL</span> has an <span>opaque
+  path</span>.</p>
 
   <hr>
 
@@ -11732,12 +11704,6 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
   <span>navigation ID</span> used when the navigation that created this <code>Document</code> was
   the <span>ongoing navigation</span>. This eventually gets set back to null, after <cite>WebDriver
   BiDi</cite> considers the loading process to be finished. <ref>BIDI</ref></p>
-
-  <p>Each <code>Document</code> has an <dfn data-x="concept-document-about-base-url">about base
-  URL</dfn>, which is a <span>URL</span> or null, initially null.</p>
-
-  <p class="note">This is only populated for "<code data-x="">about:</code>"-schemed
-  <code>Document</code>s.</p>
 
   <p>Each <code>Document</code> has a <dfn
   data-x="concept-document-bfcache-blocking-details">bfcache blocking details</dfn>, which is a
@@ -16439,9 +16405,9 @@ interface <dfn interface>HTMLBaseElement</dfn> : <span>HTMLElement</span> {
 
    <li><p>Let <var>urlRecord</var> be the result of <span data-x="URL parser">parsing</span> the
    value of <var>element</var>'s <code data-x="attr-base-href">href</code> content attribute with
-   <var>document</var>'s <span>fallback base URL</span>, and <var>document</var>'s <span
-   data-x="document's character encoding">character encoding</span>. (Thus, the <code>base</code>
-   element isn't affected by itself.)</p></li>
+   <var>document</var>'s <span data-x="concept-document-url">URL</span>, and <var>document</var>'s
+   <span data-x="document's character encoding">character encoding</span>. (Thus, the
+   <code>base</code> element isn't affected by itself.)</p></li>
    <!-- This uses the URL parser rather than encoding-parse a URL since otherwise we'd have to
         unnecessarily complicate the latter for two callsites. -->
 
@@ -16458,8 +16424,8 @@ interface <dfn interface>HTMLBaseElement</dfn> : <span>HTMLElement</span> {
      <var>document</var> returns "<code data-x="">Blocked</code>",</p></li>
     </ul>
 
-    <p>then set <var>element</var>'s <span>frozen base URL</span> to <var>document</var>'s
-    <span>fallback base URL</span> and return.</p>
+    <p>then set <var>element</var>'s <span>frozen base URL</span> to <var>document</var>'s <span
+    data-x="concept-document-url">URL</span> and return.</p>
    </li>
 
    <li><p>Set <var>element</var>'s <span>frozen base URL</span> to <var>urlRecord</var>.</p></li>
@@ -16481,7 +16447,7 @@ interface <dfn interface>HTMLBaseElement</dfn> : <span>HTMLElement</span> {
    attribute of this element, if it has one, and the empty string otherwise.</p></li>
 
    <li><p>Let <var>urlRecord</var> be the result of <span data-x="URL parser">parsing</span>
-   <var>url</var> with <var>document</var>'s <span>fallback base URL</span>, and
+   <var>url</var> with <var>document</var>'s <span data-x="concept-document-url">URL</span>, and
    <var>document</var>'s <span data-x="document's character encoding">character encoding</span>.
    (Thus, the <code>base</code> element isn't affected by other <code>base</code> elements or
    itself.)</p></li>
@@ -105199,8 +105165,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
      <dd><var>targetName</var></dd>
 
      <dt><span data-x="document-state-about-base-url">about base URL</span></dt>
-     <dd><var>document</var>'s <span data-x="concept-document-about-base-url">about base
-     URL</span></dd>
+     <dd><var>document</var>'s <span>base URL override</span></dd>
     </dl>
    </li>
 
@@ -105389,8 +105354,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
      <dd><var>targetName</var></dd>
 
      <dt><span data-x="document-state-about-base-url">about base URL</span></dt>
-     <dd><var>document</var>'s <span data-x="concept-document-about-base-url">about base
-     URL</span></dd>
+     <dd><var>document</var>'s <span>base URL override</span></dd>
     </dl>
    </li>
 
@@ -106384,7 +106348,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
      <dt><span>is initial <code>about:blank</code></span></dt>
      <dd>true</dd>
 
-     <dt><span data-x="concept-document-about-base-URL">about base URL</span></dt>
+     <dt><span>base URL override</span></dt>
      <dd><var>creatorBaseURL</var></dd>
 
      <dt><span data-x="concept-document-allow-declarative-shadow-roots">allow declarative shadow
@@ -107117,7 +107081,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
     which is a <span>URL</span> or null, initially null.</p>
 
     <p class="note">This will be populated only for "<code data-x="">about:</code>"-schemed
-    <code>Document</code>s and will be the <span>fallback base URL</span> for those
+    <code>Document</code>s and will be the <span>base URL override</span> for those
     <code>Document</code>s. It is a snapshot of the initiator <code>Document</code>'s <span>document
     base URL</span>.</p>
    </li>
@@ -107921,8 +107885,8 @@ location.href = '#foo';</code></pre>
 
    <dt><dfn data-x="navigation-params-about-base-url" for="navigation params">about base
    URL</dfn></dt>
-   <dd>a <span>URL</span> or null used to populate the new <code>Document</code>'s <span
-   data-x="concept-document-about-base-url">about base URL</span></dd>
+   <dd>a <span>URL</span> or null used to populate the new <code>Document</code>'s <span>base URL
+   override</span></dd>
 
    <dt><dfn data-x="navigation-params-user-involvement" for="navigation params">user
    involvement</dfn></dt>
@@ -108942,8 +108906,8 @@ location.href = '#foo';</code></pre>
      <dd>"<code data-x="dom-navigationtimingtype-navigate">navigate</code>"</dd>
 
      <dt><span data-x="navigation-params-about-base-url">about base URL</span></dt>
-     <dd><var>targetNavigable</var>'s <span data-x="nav-document">active document</span>'s <span
-     data-x="concept-document-about-base-url">about base URL</span></dd>
+     <dd><var>targetNavigable</var>'s <span data-x="nav-document">active document</span>'s
+     <span>base URL override</span></dd>
 
      <dt><span data-x="navigation-params-user-involvement">user involvement</span></dt>
      <dd><var>userInvolvement</var></dd>
@@ -113314,8 +113278,8 @@ location.href = '#foo';</code></pre>
      <dt><span>current document readiness</span></dt>
      <dd>"<code data-x="">loading</code>"</dd>
 
-     <dt><span data-x="concept-document-about-base-url">about base URL</span></dt>
-     <dd><var>navigationParams</var>'s <span data-x="navigation-params-about-base-URL">about base URL</span></dd>
+     <dt><span>base URL override</span></dt>
+     <dd><var>navigationParams</var>'s <span data-x="navigation-params-about-base-url">about base URL</span></dd>
 
      <dt><span data-x="concept-document-allow-declarative-shadow-roots">allow declarative shadow
      roots</span></dt>

--- a/source
+++ b/source
@@ -3401,6 +3401,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
              <dfn data-x="document-custom-element-registry" data-x-href="https://dom.spec.whatwg.org/#document-custom-element-registry">custom element registry</dfn>,
              <dfn data-x="concept-document-allow-declarative-shadow-roots" data-x-href="https://dom.spec.whatwg.org/#concept-document-allow-declarative-shadow-roots">allow declarative shadow roots</dfn>, and
              <dfn data-x="concept-document-content-type" data-x-href="https://dom.spec.whatwg.org/#concept-document-content-type">content type</dfn> of a <code>Document</code></li>
+     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#get-the-base-url">get the base URL</dfn> algorithm and
+             <dfn data-x-href="https://dom.spec.whatwg.org/#base-url-override">base URL override</dfn> of a <code>Document</code></li>
      <li>The distinction between <dfn data-x-href="https://dom.spec.whatwg.org/#xml-document">XML documents</dfn> and
                                  <dfn data-x-href="https://dom.spec.whatwg.org/#html-document">HTML documents</dfn></li>
      <li>The terms <dfn data-x-href="https://dom.spec.whatwg.org/#concept-document-quirks">quirks mode</dfn>,
@@ -7762,14 +7764,27 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
   <span>URL record</span> obtained by running these steps:</p>
 
   <ol>
-   <li><p>If <var>document</var> has no <span>descendant</span> <code>base</code> element that has
-   an <code data-x="attr-base-href">href</code> attribute, then return <var>document</var>'s
-   <span>fallback base URL</span>.</p></li>
+   <li>
+    <p>If <var>document</var> has no <span>descendant</span> <code>base</code> element that has an
+    <code data-x="attr-base-href">href</code> attribute:</p>
 
-   <li><p>Otherwise, return the <span>frozen base URL</span> of the first <code>base</code> element
-   in <var>document</var> that has an <code data-x="attr-base-href">href</code> attribute, in
+    <ol>
+     <li><p>If <var>document</var>'s <span>base URL override</span> is non-null, then return
+     <var>document</var>'s <span>base URL override</span>.</p></li>
+
+     <li><p>Return <var>document</var>'s <span>fallback base URL</span>.</p></li>
+    </ol>
+   </li>
+
+   <li><p>Return the <span>frozen base URL</span> of the first <code>base</code> element in
+   <var>document</var> that has an <code data-x="attr-base-href">href</code> attribute, in
    <span>tree order</span>.</p></li>
   </ol>
+  </div>
+
+  <div algorithm>
+  <p>A <code>Document</code> <var>document</var>'s <span>get the base URL</span> algorithm returns
+  <var>document</var>'s <span>document base URL</span>.</p>
   </div>
 
   <div algorithm>


### PR DESCRIPTION
Replace fallback base URL with DOM's base URL override

A Document's base URL now comes from a single field, DOM's base URL override, replacing the fallback base URL and a Document's about base URL. The document base URL consults it when there is no base element. It is populated at creation for "about:"-schemed Documents from the initiator's base URL, and by DOM when a Document is cloned, so that a clone without a base element reports the base URL of the Document it was cloned from. DOM's baseURI getter defers to a new get the base URL algorithm, which this specification overrides to return the document base URL, so DOM no longer reaches into HTML for a value returned by a DOM API.

As a consequence a base element resolves its href against its Document's URL instead of the inherited base URL. A relative href in an "about:"-schemed Document therefore no longer resolves, as those URLs have an opaque path; ordinary relative URLs keep inheriting.

See https://github.com/whatwg/dom/issues/454.

Tests: https://github.com/web-platform-tests/wpt/pull/61231 & https://github.com/web-platform-tests/wpt/pull/61232.

- [ ] At least two implementers are interested (and none opposed):
   * 
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61231 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
   * https://github.com/web-platform-tests/wpt/pull/61232
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-( 
   * Gecko: …
   * WebKit: …
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12674/browsing-the-web.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/browsing-the-web.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/browsing-the-web.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )
<a href="https://whatpr.org/html/12674/document-lifecycle.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/document-lifecycle.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/document-lifecycle.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )
<a href="https://whatpr.org/html/12674/document-sequences.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/document-sequences.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/document-sequences.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )
<a href="https://whatpr.org/html/12674/dom.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/dom.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/dom.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )
<a href="https://whatpr.org/html/12674/infrastructure.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/infrastructure.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )
<a href="https://whatpr.org/html/12674/semantics.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/semantics.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/semantics.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )
<a href="https://whatpr.org/html/12674/urls-and-fetching.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">/urls-and-fetching.html</a>  ( <a href="https://whatpr.org/html/12674/25f1766...bd9c747/urls-and-fetching.html" title="Last updated on Aug 27, 2026, 8:42 AM UTC (bd9c747)">diff</a> )