### PR TITLE
Order shadow root concepts consistently

### DIFF
--- a/source
+++ b/source
@@ -69161,9 +69161,9 @@ not-slash     = %x0000-002E / %x0030-10FFFF
    <dd><code data-x="attr-template-for">for</code></dd>
    <dd><code data-x="attr-template-shadowrootmode">shadowrootmode</code></dd>
    <dd><code data-x="attr-template-shadowrootdelegatesfocus">shadowrootdelegatesfocus</code></dd>
+   <dd><code data-x="attr-template-shadowrootserializable">shadowrootserializable</code></dd>
    <dd><code data-x="attr-template-shadowrootslotassignment">shadowrootslotassignment</code></dd>
    <dd><code data-x="attr-template-shadowrootclonable">shadowrootclonable</code></dd>
-   <dd><code data-x="attr-template-shadowrootserializable">shadowrootserializable</code></dd>
    <dd><code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></dd>
    <dt><span
    data-x="concept-element-accessibility-considerations">Accessibility considerations</span>:</dt>
@@ -69181,9 +69181,9 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>="<span data-x="attr-template-for">for</span>"] attribute DOMString <dfn attribute for="HTMLTemplateElement" data-x="dom-template-htmlFor">htmlFor</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootmode">shadowRootMode</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootdelegatesfocus">shadowRootDelegatesFocus</dfn>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootSerializable">shadowRootSerializable</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootslotassignment">shadowRootSlotAssignment</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootclonable">shadowRootClonable</dfn>;
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootSerializable">shadowRootSerializable</dfn>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootCustomElementRegistry">shadowRootCustomElementRegistry</dfn>;
 };</code></pre>
 </dd>
@@ -69235,6 +69235,10 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
   attribute is a <span>boolean attribute</span>.</p>
 
   <p>The <dfn element-attr for="template"><code
+  data-x="attr-template-shadowrootserializable">shadowrootserializable</code></dfn> content
+  attribute is a <span>boolean attribute</span>.</p>
+
+  <p>The <dfn element-attr for="template"><code
   data-x="attr-template-shadowrootslotassignment">shadowrootslotassignment</code></dfn> content
   attribute is an <span>enumerated attribute</span> with the following keywords and states:</p>
 
@@ -69263,10 +69267,6 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
   <p>The <dfn element-attr for="template"><code
   data-x="attr-template-shadowrootclonable">shadowrootclonable</code></dfn> content attribute is a
   <span>boolean attribute</span>.</p>
-
-  <p>The <dfn element-attr for="template"><code
-  data-x="attr-template-shadowrootserializable">shadowrootserializable</code></dfn> content
-  attribute is a <span>boolean attribute</span>.</p>
 
   <p>The <dfn element-attr for="template"><code
   data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></dfn>
@@ -145734,6 +145734,14 @@ document.body.appendChild(text);
        <li><p>Let <var>mode</var> be <var>templateStartTag</var>'s <code
        data-x="attr-template-shadowrootmode">shadowrootmode</code> attribute's value.</p></li>
 
+       <li><p>Let <var>delegatesFocus</var> be true if <var>templateStartTag</var> has a <code
+       data-x="attr-template-shadowrootdelegatesfocus">shadowrootdelegatesfocus</code> attribute;
+       otherwise false.</p></li>
+
+       <li><p>Let <var>serializable</var> be true if <var>templateStartTag</var> has a <code
+       data-x="attr-template-shadowrootserializable">shadowrootserializable</code> attribute;
+       otherwise false.</p></li>
+
        <li><p>Let <var>slotAssignment</var> be "<code data-x="">named</code>".</p></li>
 
        <li><p>If <var>templateStartTag</var>'s <code
@@ -145744,14 +145752,6 @@ document.body.appendChild(text);
        <li><p>Let <var>clonable</var> be true if <var>templateStartTag</var> has a <code
        data-x="attr-template-shadowrootclonable">shadowrootclonable</code> attribute; otherwise
        false.</p></li>
-
-       <li><p>Let <var>serializable</var> be true if <var>templateStartTag</var> has a <code
-       data-x="attr-template-shadowrootserializable">shadowrootserializable</code> attribute;
-       otherwise false.</p></li>
-
-       <li><p>Let <var>delegatesFocus</var> be true if <var>templateStartTag</var> has a <code
-       data-x="attr-template-shadowrootdelegatesfocus">shadowrootdelegatesfocus</code> attribute;
-       otherwise false.</p></li>
 
        <li><p>If <var>declarativeShadowHostElement</var> is a <span>shadow host</span>, then
        <span>insert an element at the adjusted insertion location</span> with
@@ -145768,8 +145768,8 @@ document.body.appendChild(text);
 
          <li>
           <p><span data-x="concept-attach-a-shadow-root">Attach a shadow root</span> with
-          <var>declarativeShadowHostElement</var>, <var>mode</var>, <var>clonable</var>,
-          <var>serializable</var>, <var>delegatesFocus</var>, <var>slotAssignment</var>, and
+          <var>declarativeShadowHostElement</var>, <var>mode</var>, <var>delegatesFocus</var>,
+          <var>serializable</var>, <var>slotAssignment</var>, <var>clonable</var>, and
           <var>registry</var>.</p>
 
           <p>If an exception is thrown, then catch it and:</p>

--- a/source
+++ b/source
@@ -3285,7 +3285,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#concept-node-document">node document</dfn> concept</li>
      <li><dfn data-x="concept-document-type" data-x-href="https://dom.spec.whatwg.org/#concept-document-type">document type</dfn> concept</li>
      <li><dfn data-x="concept-DocumentFragment-host" data-x-href="https://dom.spec.whatwg.org/#concept-documentfragment-host">host</dfn> concept</li>
-     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-root">shadow root</dfn> concept, and its <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-delegates-focus">delegates focus</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-available-to-element-internals">available to element internals</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-clonable">clonable</dfn>, <dfn data-x="shadow-serializable" data-x-href="https://dom.spec.whatwg.org/#shadowroot-serializable">serializable</dfn>, <dfn data-x="shadow-root-custom-element-registry" data-x-href="https://dom.spec.whatwg.org/#shadowroot-custom-element-registry">custom element registry</dfn>, and <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-keep-custom-element-registry-null">keep custom element registry null</dfn>.</li>
+     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-root">shadow root</dfn> concept, and its <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-delegates-focus">delegates focus</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-available-to-element-internals">available to element internals</dfn>, <dfn data-x="shadow-serializable" data-x-href="https://dom.spec.whatwg.org/#shadowroot-serializable">serializable</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-clonable">clonable</dfn>, <dfn data-x="shadow-root-custom-element-registry" data-x-href="https://dom.spec.whatwg.org/#shadowroot-custom-element-registry">custom element registry</dfn>, and <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-keep-custom-element-registry-null">keep custom element registry null</dfn>.</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#element-shadow-host">shadow host</dfn> concept</li>
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#interface-htmlcollection"><code>HTMLCollection</code></dfn> interface, its
          <dfn data-x="dom-HTMLCollection-length" data-x-href="https://dom.spec.whatwg.org/#dom-htmlcollection-length"><code>length</code></dfn> attribute, and its
@@ -3337,7 +3337,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#in-a-document-tree">in a document tree</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#in-a-document">in a document</dfn> (legacy), and <dfn data-x-href="https://dom.spec.whatwg.org/#connected">connected</dfn> concepts</li>
      <li>The <dfn data-x="concept-slot" data-x-href="https://dom.spec.whatwg.org/#concept-slot">slot</dfn> concept, and its <dfn data-x="slot-name" data-x-href="https://dom.spec.whatwg.org/#slot-name">name</dfn> and <dfn data-x-href="https://dom.spec.whatwg.org/#slot-assigned-nodes">assigned nodes</dfn></li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#slotable-assigned-slot">assigned slot</dfn> concept</li>
-     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#dom-shadowroot-slot-assignment">slot assignment</dfn> concept</li>
+     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#shadowroot-slot-assignment">slot assignment</dfn> concept</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-slotable">slottable</dfn> concept</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#assign-slotables-for-a-tree">assign slottables for a tree</dfn> algorithm</li>
      <li>The <dfn data-x="event-slotchange" data-x-href="https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange"><code>slotchange</code></dfn> event</li>
@@ -69179,11 +69179,11 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
 
   readonly attribute <span>DocumentFragment</span> <span data-x="dom-template-content">content</span>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>="<span data-x="attr-template-for">for</span>"] attribute DOMString <dfn attribute for="HTMLTemplateElement" data-x="dom-template-htmlFor">htmlFor</dfn>;
-  [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootmode">shadowRootMode</span>;
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootdelegatesfocus">shadowRootDelegatesFocus</dfn>;
+  [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowRootMode">shadowRootMode</span>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootDelegatesFocus">shadowRootDelegatesFocus</dfn>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootSerializable">shadowRootSerializable</dfn>;
-  [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowrootslotassignment">shadowRootSlotAssignment</span>;
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowrootclonable">shadowRootClonable</dfn>;
+  [<span>CEReactions</span>] attribute DOMString <span data-x="dom-template-shadowRootSlotAssignment">shadowRootSlotAssignment</span>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootClonable">shadowRootClonable</dfn>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute DOMString <dfn attribute for="HTMLTemplateElement" data-x="dom-template-shadowRootCustomElementRegistry">shadowRootCustomElementRegistry</dfn>;
 };</code></pre>
 </dd>
@@ -69430,14 +69430,14 @@ interface <dfn interface>HTMLTemplateElement</dfn> : <span>HTMLElement</span> {
 
   <div algorithm>
   <p>The <dfn attribute for="HTMLTemplateElement"><code
-  data-x="dom-template-shadowrootmode">shadowRootMode</code></dfn> IDL attribute must
+  data-x="dom-template-shadowRootMode">shadowRootMode</code></dfn> IDL attribute must
   <span>reflect</span> the <code data-x="attr-template-shadowrootmode">shadowrootmode</code> content
   attribute, <span>limited to only known values</span>.</p>
   </div>
 
   <div algorithm>
   <p>The <dfn attribute for="HTMLTemplateElement"><code
-  data-x="dom-template-shadowrootslotassignment">shadowRootSlotAssignment</code></dfn> IDL attribute
+  data-x="dom-template-shadowRootSlotAssignment">shadowRootSlotAssignment</code></dfn> IDL attribute
   must <span>reflect</span> the <code
   data-x="attr-template-shadowrootslotassignment">shadowrootslotassignment</code> content attribute,
   <span>limited to only known values</span>.</p>
@@ -145787,14 +145787,14 @@ document.body.appendChild(text);
          <li><p>Let <var>shadow</var> be <var>declarativeShadowHostElement</var>'s <span
          data-x="concept-element-shadow-root">shadow root</span>.</p></li>
 
+         <li><p>Set <var>shadow</var>'s <span>available to element internals</span> to
+         true.</p></li>
+
          <li><p>Set <var>shadow</var>'s <span
          data-x="concept-shadow-root-declarative">declarative</span> to true.</p></li>
 
          <li><p>Set <var>template</var>'s <span>template contents</span> to
          <var>shadow</var>.</p></li>
-
-         <li><p>Set <var>shadow</var>'s <span>available to element internals</span> to
-         true.</p></li>
 
          <li><p>If <var>templateStartTag</var> has a <code
          data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code>
@@ -157761,9 +157761,9 @@ interface <dfn interface>External</dfn> {
          <code data-x="attr-template-for">for</code>;
          <code data-x="attr-template-shadowrootmode">shadowrootmode</code>;
          <code data-x="attr-template-shadowrootdelegatesfocus">shadowrootdelegatesfocus</code>;
+         <code data-x="attr-template-shadowrootserializable">shadowrootserializable</code>;
          <code data-x="attr-template-shadowrootslotassignment">shadowrootslotassignment</code>;
          <code data-x="attr-template-shadowrootclonable">shadowrootclonable</code>;
-         <code data-x="attr-template-shadowrootserializable">shadowrootserializable</code>;
          <code data-x="attr-template-shadowrootcustomelementregistry">shadowrootcustomelementregistry</code></td>
      <td><code>HTMLTemplateElement</code></td>
     </tr>


### PR DESCRIPTION
Match DOM's revised shadow root concept order for the `template` IDL, content attributes, parser, and "attach a shadow root" call site: mode, delegates focus, serializable, slot assignment, clonable, custom element registry.

Note this reorders `HTMLTemplateElement` IDL members, which is observable via property enumeration. The HTML fragment serialization order is unchanged.

Depends on whatwg/dom#1496.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12703/indices.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">/indices.html</a>  ( <a href="https://whatpr.org/html/12703/25f1766...767734c/indices.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">diff</a> )
<a href="https://whatpr.org/html/12703/infrastructure.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12703/25f1766...767734c/infrastructure.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">diff</a> )
<a href="https://whatpr.org/html/12703/parsing.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12703/25f1766...767734c/parsing.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">diff</a> )
<a href="https://whatpr.org/html/12703/scripting.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">/scripting.html</a>  ( <a href="https://whatpr.org/html/12703/25f1766...767734c/scripting.html" title="Last updated on Aug 20, 2026, 2:05 PM UTC (767734c)">diff</a> )