### PR TITLE
Clarify when a parser-inserted element is dropped on the floor

### DIFF
--- a/source
+++ b/source
@@ -144611,7 +144611,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <div algorithm>
   <p>The <dfn>appropriate place for inserting a node</dfn>, optionally using a particular
-  <i>override target</i>, is the position in an element returned by running the following steps:</p>
+  <i>override target</i>, is the position in a node returned by running the following steps:</p>
 
   <ol>
    <li>
@@ -144870,10 +144870,12 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <div algorithm>
   <p>To <dfn>insert an element at the adjusted insertion location</dfn> with an element
-  <var>element</var>:</p>
+  <var>element</var> and an optional insertion location <var>insertionLocation</var> (default
+  null):</p>
 
   <ol>
-   <li><p>Let <var>insertionLocation</var> be the <span>adjusted insertion location</span>.</p></li>
+   <li><p>Set <var>insertionLocation</var> to the <span>adjusted insertion location</span> given
+   <var>insertionLocation</var>.</p></li>
 
    <li><p>If <var>insertionLocation</var> is in a <code>Document</code> node and that
    <code>Document</code> node has an element child, then return.</p></li>
@@ -144910,7 +144912,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
    <li><p>Let <var>element</var> be the result of <span data-x="create an element for the
    token">creating an element for the token</span> given <var>token</var>, <var>namespace</var>,
-   and the element in which the <var>adjustedInsertionLocation</var> finds itself.</p></li>
+   and the node in which the <var>adjustedInsertionLocation</var> finds itself.</p></li>
 
    <li><p>If <var>onlyAddToElementStack</var> is false, then run <span>insert an element at the
    adjusted insertion location</span> with <var>element</var>.</p></li>
@@ -145059,7 +145061,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
     data-x="concept-cd-data">data</span>.</p>
 
     <p>Otherwise, let <var>text</var> be the result of <span data-x="create a text node">creating a
-    text node</span> given the <span>node document</span> of the element in which
+    text node</span> given the <span>node document</span> of the node in which
     <var>insertionLocation</var> finds itself and <var>data</var>, and insert <var>text</var> at
     <var>insertionLocation</var>.</p>
    </li>
@@ -145250,8 +145252,9 @@ document.body.appendChild(text);
     doctype</span> given the <code>Document</code> node, the name given in the DOCTYPE token (or the
     empty string if the name was missing), the public identifier given in the DOCTYPE token (or the
     empty string if the public identifier was missing), and the system identifier given in the
-    DOCTYPE token (or the empty string if the system identifier was missing). Then append
-    <var>doctype</var> to the <code>Document</code> node.</p>
+    DOCTYPE token (or the empty string if the system identifier was missing). Then, if the
+    <code>Document</code> node has neither a <code>DocumentType</code> child nor an element child,
+    append <var>doctype</var> to the <code>Document</code> node.</p>
 
     <p class="note">This also ensures that the <code>DocumentType</code> node is returned as the
     value of the <code data-x="dom-Document-doctype">doctype</code> attribute of the
@@ -145397,8 +145400,9 @@ document.body.appendChild(text);
    <dt>A start tag whose tag name is "html"</dt>
    <dd>
     <p><span>Create an element for the token</span> in the <span>HTML namespace</span>, with the
-    <code>Document</code> as the intended parent. Append it to the <code>Document</code> object. Put
-    this element in the <span>stack of open elements</span>.</p>
+    <code>Document</code> as the intended parent. <span>Insert an element at the adjusted insertion
+    location</span> with that element and the <code>Document</code>, after its last child (if any).
+    Put this element in the <span>stack of open elements</span>.</p>
 
     <p>Switch the <span>insertion mode</span> to "<span data-x="insertion mode: before head">before
     head</span>".</p>
@@ -145617,7 +145621,7 @@ document.body.appendChild(text);
      inserting a node</span>.</p></li>
 
      <li><p><span>Create an element for the token</span> in the <span>HTML namespace</span>, with
-     the intended parent being the element in which the <var>adjustedInsertionLocation</var> finds
+     the intended parent being the node in which the <var>adjustedInsertionLocation</var> finds
      itself.</p></li>
 
      <li>
@@ -145704,7 +145708,7 @@ document.body.appendChild(text);
      <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for
      inserting a node</span>.</p></li>
 
-     <li><p>Let <var>intendedParent</var> be the element in which the
+     <li><p>Let <var>intendedParent</var> be the node in which the
      <var>adjustedInsertionLocation</var> finds itself.</p></li>
 
      <li><p>Let <var>document</var> be <var>intendedParent</var>'s <span>node

--- a/source
+++ b/source
@@ -3344,7 +3344,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <dfn data-x="finding flattened slottables" data-x-href="https://dom.spec.whatwg.org/#find-flattened-slotables">find flattened slottables</dfn> algorithm</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#slottable-manual-slot-assignment">manual slot assignment</dfn> concept</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#assign-a-slot">assign a slot</dfn> algorithm</li>
-     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-node-pre-insert">pre-insert</dfn>, <dfn data-x="concept-node-insert" data-x-href="https://dom.spec.whatwg.org/#concept-node-insert">insert</dfn>, <dfn data-x="concept-node-append" data-x-href="https://dom.spec.whatwg.org/#concept-node-append">append</dfn>, <dfn data-x="concept-node-replace" data-x-href="https://dom.spec.whatwg.org/#concept-node-replace">replace</dfn>, <dfn data-x="concept-node-replace-all" data-x-href="https://dom.spec.whatwg.org/#concept-node-replace-all">replace all</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#string-replace-all">string replace all</dfn>, <dfn data-x="concept-node-remove" data-x-href="https://dom.spec.whatwg.org/#concept-node-remove">remove</dfn>, and <dfn data-x="concept-node-adopt" data-x-href="https://dom.spec.whatwg.org/#concept-node-adopt">adopt</dfn> algorithms for nodes</li>
+     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-node-pre-insert">pre-insert</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity">ensure pre-insert validity</dfn>, <dfn data-x="concept-node-insert" data-x-href="https://dom.spec.whatwg.org/#concept-node-insert">insert</dfn>, <dfn data-x="concept-node-append" data-x-href="https://dom.spec.whatwg.org/#concept-node-append">append</dfn>, <dfn data-x="concept-node-replace" data-x-href="https://dom.spec.whatwg.org/#concept-node-replace">replace</dfn>, <dfn data-x="concept-node-replace-all" data-x-href="https://dom.spec.whatwg.org/#concept-node-replace-all">replace all</dfn>, <dfn data-x-href="https://dom.spec.whatwg.org/#string-replace-all">string replace all</dfn>, <dfn data-x="concept-node-remove" data-x-href="https://dom.spec.whatwg.org/#concept-node-remove">remove</dfn>, and <dfn data-x="concept-node-adopt" data-x-href="https://dom.spec.whatwg.org/#concept-node-adopt">adopt</dfn> algorithms for nodes</li>
      <li>The <dfn data-x="concept-node-insert-ext" data-x-href="https://dom.spec.whatwg.org/#concept-node-insert-ext">insertion steps</dfn>,
      <li>The <dfn data-x="concept-node-post-connection-ext" data-x-href="https://dom.spec.whatwg.org/#concept-node-post-connection-ext">post-connection steps</dfn>,
              <dfn data-x="concept-node-remove-ext" data-x-href="https://dom.spec.whatwg.org/#concept-node-remove-ext">removing steps</dfn>,
@@ -144875,8 +144875,11 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   <ol>
    <li><p>Let <var>insertionLocation</var> be the <span>adjusted insertion location</span>.</p></li>
 
-   <li><p>If it is not possible to insert <var>element</var> at <var>insertionLocation</var>, abort
-   these steps.</p></li>
+   <li><p>If <var>insertionLocation</var> is in a <code>Document</code> node and that
+   <code>Document</code> node has an element child, then return.</p></li>
+
+   <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given <var>element</var>, the
+   node in which <var>insertionLocation</var> finds itself, null, and « » does not throw.</p></li>
 
    <li><p>If the parser was not created as part of the <span>HTML fragment parsing
    algorithm</span>, then push a new <span>element queue</span> onto <var>element</var>'s
@@ -144889,10 +144892,6 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <span>relevant agent</span>'s <span>custom element reactions stack</span>, and <span>invoke
    custom element reactions</span> in that queue.</p></li>
   </ol>
-
-  <p class="note">If the <span>adjusted insertion location</span> cannot accept more elements, e.g.,
-  because it's a <code>Document</code> that already has an element child, then <var>element</var> is
-  dropped on the floor.</p>
   </div>
 
   <!-- The names of these algorithms are kinda confusing; e.g. see the confusion in


### PR DESCRIPTION
Clarify when a parser-inserted element is dropped on the floor

"Insert an element at the adjusted insertion location" previously aborted when
it was "not possible to insert" the element, without defining what that meant.
Replace it with an explicit condition — the adjusted insertion location is in a
Document that already has an element child — mirroring the analogous check in
"insert a character", and assert that the insertion then satisfies the DOM's
"ensure pre-insert validity".

Tests: https://github.com/web-platform-tests/wpt/pull/61396

See #1706.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome (already does this)
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61396
   * https://github.com/web-platform-tests/wpt/pull/62020
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2064077
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=319780
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12708/infrastructure.html" title="Last updated on Aug 20, 2026, 8:24 AM UTC (ac66b72)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12708/5633568...ac66b72/infrastructure.html" title="Last updated on Aug 20, 2026, 8:24 AM UTC (ac66b72)">diff</a> )
<a href="https://whatpr.org/html/12708/parsing.html" title="Last updated on Aug 20, 2026, 8:24 AM UTC (ac66b72)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12708/5633568...ac66b72/parsing.html" title="Last updated on Aug 20, 2026, 8:24 AM UTC (ac66b72)">diff</a> )