### PR TITLE
Drop a node the adoption agency cannot reinsert

### DIFF
--- a/source
+++ b/source
@@ -147378,7 +147378,11 @@ document.body.appendChild(text);
        not <var>target</var>,</li>
       </ul>
 
-      <p>then <var>lastNode</var> is dropped on the floor. Otherwise:</p>
+      <p>then <var>lastNode</var> is dropped on the floor.</p>
+     </li>
+
+     <li>
+      <p>Otherwise:</p>
 
       <ol>
        <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given

--- a/source
+++ b/source
@@ -3324,8 +3324,9 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</dfn>,
              <dfn data-x="concept-shadow-including-ancestor" data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor">shadow-including ancestor</dfn>,
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">shadow-including descendant</dfn>,
-             <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendant</dfn>, and
-             <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</dfn> concepts</li>
+             <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendant</dfn>,
+             <dfn data-x-href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</dfn>, and
+             <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</dfn> concepts</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-first-child">first child</dfn>,
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-last-child">last child</dfn>,
              <dfn data-x-href="https://dom.spec.whatwg.org/#concept-tree-next-sibling">next sibling</dfn>,
@@ -147342,8 +147343,32 @@ document.body.appendChild(text);
      <li><p>Let <var>insertionLocation</var> be <var>commonAncestor</var>, after its last child, if
      any.</p></li>
 
-     <li><p>Insert whatever <var>lastNode</var> ended up being in the previous step at the
-     <span>adjusted insertion location</span> given <var>insertionLocation</var>.</p></li>
+     <li><p>Let <var>adjustedInsertionLocation</var> be the <span>adjusted insertion location</span>
+     given <var>insertionLocation</var>.</p></li>
+
+     <li>
+      <p>If either of the following is true:</p>
+
+      <ul>
+       <li><var>lastNode</var> is a <span>host-including inclusive ancestor</span> of the node in
+       which <var>adjustedInsertionLocation</var> finds itself; or</li>
+
+       <li>the node in which <var>adjustedInsertionLocation</var> finds itself is a
+       <code>Document</code> node that already has an element child,</li>
+      </ul>
+
+      <p>then <span data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p>
+
+      <p>Otherwise:</p>
+
+      <ol>
+       <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given
+       <var>lastNode</var>, the node in which <var>adjustedInsertionLocation</var> finds itself,
+       null, and « » does not throw.</p></li>
+
+       <li><p>Insert <var>lastNode</var> at <var>adjustedInsertionLocation</var>.</p></li>
+      </ol>
+     </li>
 
      <li><p><span>Create an element for the token</span> for which <var>formattingElement</var> was created,
      in the <span>HTML namespace</span>, with <var>furthestBlock</var> as the intended parent.</p></li>

--- a/source
+++ b/source
@@ -147353,14 +147353,14 @@ document.body.appendChild(text);
      before, or null if <var>adjustedInsertionLocation</var> is after <var>target</var>'s last
      child.</p></li>
 
-     <li>
-      <p>If <var>lastNode</var>'s <span>parent</span> is non-null, then
-      <span data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p>
+     <li><p>If <var>lastNode</var>'s <span>parent</span> is non-null, then
+     <span data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p></li>
 
-      <p class="note">This can run script, e.g., because it destroys an <code>iframe</code>
-      element's <span>navigable</span>. Such script can change the tree, which is why the conditions
-      below are checked afterwards rather than before.</p>
-     </li>
+     <!-- Removal does not currently run script: destroying an iframe element's navigable does
+          not unload its document, so no pagehide event is fired. Engines do fire pagehide when
+          an iframe is disconnected and we should update the spec to match. The conditions below
+          are therefore checked after the removal rather than before, so that they still hold
+          once removal can run script. -->
 
      <li>
       <p>If any of the following are true:</p>

--- a/source
+++ b/source
@@ -147346,25 +147346,43 @@ document.body.appendChild(text);
      <li><p>Let <var>adjustedInsertionLocation</var> be the <span>adjusted insertion location</span>
      given <var>insertionLocation</var>.</p></li>
 
+     <li><p>Let <var>target</var> be the node in which <var>adjustedInsertionLocation</var> finds
+     itself.</p></li>
+
+     <li><p>Let <var>refNode</var> be the node <var>adjustedInsertionLocation</var> is immediately
+     before, or null if <var>adjustedInsertionLocation</var> is after <var>target</var>'s last
+     child.</p></li>
+
      <li>
-      <p>If either of the following is true:</p>
+      <p>If <var>lastNode</var>'s <span>parent</span> is non-null, then
+      <span data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p>
+
+      <p class="note">This can run script, e.g., because it destroys an <code>iframe</code>
+      element's <span>navigable</span>. Such script can change the tree, which is why the conditions
+      below are checked afterwards rather than before.</p>
+     </li>
+
+     <li>
+      <p>If any of the following are true:</p>
 
       <ul>
-       <li><var>lastNode</var> is a <span>host-including inclusive ancestor</span> of the node in
-       which <var>adjustedInsertionLocation</var> finds itself; or</li>
+       <li><var>lastNode</var>'s <span>parent</span> is non-null;</li>
 
-       <li>the node in which <var>adjustedInsertionLocation</var> finds itself is a
-       <code>Document</code> node that already has an element child,</li>
+       <li><var>lastNode</var> is a <span>host-including inclusive ancestor</span> of
+       <var>target</var>;</li>
+
+       <li><var>target</var> is a <code>Document</code> node that already has an element child;
+       or</li>
+
+       <li><var>refNode</var> is non-null and its <span>parent</span> is
+       not <var>target</var>,</li>
       </ul>
 
-      <p>then <span data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p>
-
-      <p>Otherwise:</p>
+      <p>then <var>lastNode</var> is dropped on the floor. Otherwise:</p>
 
       <ol>
        <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given
-       <var>lastNode</var>, the node in which <var>adjustedInsertionLocation</var> finds itself,
-       null, and « » does not throw.</p></li>
+       <var>lastNode</var>, <var>target</var>, <var>refNode</var>, and « » does not throw.</p></li>
 
        <li><p>Insert <var>lastNode</var> at <var>adjustedInsertionLocation</var>.</p></li>
       </ol>

--- a/source
+++ b/source
@@ -147353,14 +147353,13 @@ document.body.appendChild(text);
      before, or null if <var>adjustedInsertionLocation</var> is after <var>target</var>'s last
      child.</p></li>
 
-     <li><p>If <var>lastNode</var>'s <span>parent</span> is non-null, then
-     <span data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p></li>
-
-     <!-- Removal does not currently run script: destroying an iframe element's navigable does
-          not unload its document, so no pagehide event is fired. Engines do fire pagehide when
-          an iframe is disconnected and we should update the spec to match. The conditions below
-          are therefore checked after the removal rather than before, so that they still hold
-          once removal can run script. -->
+     <li><p>If <var>lastNode</var>'s <span>parent</span> is non-null, then <span
+     data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p></li>
+     <!-- XXX Removal does not currently run script: destroying an iframe element's navigable does
+          not unload its document, so no pagehide event is fired. Engines do fire pagehide when an
+          iframe is disconnected and we should update the spec to match. The conditions below are
+          therefore checked after the removal rather than before, so that they still hold once
+          removal can run script. -->
 
      <li>
       <p>If any of the following are true:</p>


### PR DESCRIPTION
Drop a node the adoption agency cannot reinsert

The adoption agency algorithm's "Insert lastNode ... at the adjusted insertion
location" step moves an already-inserted node. Script running during parsing can
reparent that node first, so the move would either form a cycle — including one
that crosses a shadow root or a template's contents, i.e. where lastNode is a
host-including inclusive ancestor of the target — or target a Document that
already has an element child. The step used a low-level insertion with no
validity check, so such a move built a cyclic or otherwise invalid tree.

Tests: https://github.com/web-platform-tests/wpt/pull/61398

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61398 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-( 
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2064077
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=319780
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12709/infrastructure.html" title="Last updated on Aug 20, 2026, 8:38 AM UTC (16b0955)">/infrastructure.html</a>  ( <a href="https://whatpr.org/html/12709/8d14932...16b0955/infrastructure.html" title="Last updated on Aug 20, 2026, 8:38 AM UTC (16b0955)">diff</a> )
<a href="https://whatpr.org/html/12709/parsing.html" title="Last updated on Aug 20, 2026, 8:38 AM UTC (16b0955)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12709/8d14932...16b0955/parsing.html" title="Last updated on Aug 20, 2026, 8:38 AM UTC (16b0955)">diff</a> )