### PR TITLE
Fix grammar in autofill field notes

### DIFF
--- a/source
+++ b/source
@@ -61556,7 +61556,7 @@ form.method === input; // => true</code></pre>
     information about what kind of data the user might be expected to enter. User agents would have
     to use heuristics to decide what autocompletion values to suggest.</p>
 
-    <p>The <span>autofill field</span> listed above indicate that the user agent is allowed to
+    <p>The <span>autofill field</span> listed above indicates that the user agent is allowed to
     provide the user with autocompletion values, and specifies what kind of value is expected. The
     meaning of each such keyword is described in the table below.</p>
 
@@ -61571,7 +61571,7 @@ form.method === input; // => true</code></pre>
    <dt>When wearing the <span>autofill anchor mantle</span>...
 
    <dd>
-    <p>The <span>autofill field</span> listed above indicate that the value of the particular kind
+    <p>The <span>autofill field</span> listed above indicates that the value of the particular kind
     of value specified is that value provided for this element. The meaning of each such keyword is
     described in the table below.</p>
 
@@ -161779,6 +161779,7 @@ INSERT INTERFACES HERE
   Hans S. T&oslash;mmerhalt,
   Hans Stimer,
   Harald Alvestrand,
+  Hashim Khan,
   Hayato Ito,
   何志翔 (HE Zhixiang),
   Henri Sivonen,


### PR DESCRIPTION
## Summary
- Change "indicate" to "indicates" in two autofill field notes so the verb agrees with the singular subject.
- Add my name to the acknowledgments section.

Fixes #9094.

## Test plan
- [ ] Spec preview / HTML build from this PR looks correct around the autofill section
- [ ] Diff limited to the two grammar fixes and acknowledgments entry


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12723/acknowledgements.html" title="Last updated on Jul 27, 2026, 10:23 AM UTC (09f63ed)">/acknowledgements.html</a>  ( <a href="https://whatpr.org/html/12723/24c5e48...09f63ed/acknowledgements.html" title="Last updated on Jul 27, 2026, 10:23 AM UTC (09f63ed)">diff</a> )
<a href="https://whatpr.org/html/12723/form-control-infrastructure.html" title="Last updated on Jul 27, 2026, 10:23 AM UTC (09f63ed)">/form-control-infrastructure.html</a>  ( <a href="https://whatpr.org/html/12723/24c5e48...09f63ed/form-control-infrastructure.html" title="Last updated on Jul 27, 2026, 10:23 AM UTC (09f63ed)">diff</a> )