### PR TITLE
Remove stale null module references from #10327

### DIFF
--- a/source
+++ b/source
@@ -118859,7 +118859,7 @@ document.querySelector("button").addEventListener("click", bound);
    data-x="concept-settings-object-module-map">module map</span>.</p></li>
 
    <li><p>If <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] is a
-   <span>module script</span> or null, run <var>onComplete</var> given
+   <span>module script</span>, run <var>onComplete</var> given
    <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)], and return.</p></li>
 
    <li><p>If <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] is a <span>list</span>,
@@ -121962,8 +121962,8 @@ dictionary <dfn dictionary>PromiseRejectionEventInit</dfn> : <span>EventInit</sp
   The <span>URL record</span> is the <span data-x="concept-request-url">request URL</span> at which
   the module was fetched, and the <span>string</span> indicates the type of the module (e.g. "<code
   data-x="">javascript-or-wasm</code>"). The <span>module map</span>'s values are either a <span>module
-  script</span>, null (used to represent a mismatched <span>MIME type</span>), or a
-  <span>list</span> of algorithms (that are waiting for the fetch to complete).</span> <span
+  script</span> or a <span>list</span> of algorithms (that are waiting for the fetch to
+  complete).</span> <span
   data-x="module map">Module maps</span> are used to ensure that imported module scripts are only
   fetched, parsed, and evaluated once per <code>Document</code> or <a
   href="#workers">worker</a>.</p>

--- a/source
+++ b/source
@@ -118858,9 +118858,9 @@ document.querySelector("button").addEventListener("click", bound);
    <li><p>Let <var>moduleMap</var> be <var>settingsObject</var>'s <span
    data-x="concept-settings-object-module-map">module map</span>.</p></li>
 
-   <li><p>If <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] is a
-   <span>module script</span>, run <var>onComplete</var> given
-   <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)], and return.</p></li>
+   <li><p>If <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] is a <span>module
+   script</span>, run <var>onComplete</var> given <var>moduleMap</var>[(<var>url</var>,
+   <var>moduleType</var>)], and return.</p></li>
 
    <li><p>If <var>moduleMap</var>[(<var>url</var>, <var>moduleType</var>)] is a <span>list</span>,
    <span data-x="list append">append</span> <var>onComplete</var> to
@@ -121961,11 +121961,10 @@ dictionary <dfn dictionary>PromiseRejectionEventInit</dfn> : <span>EventInit</sp
   data-x="tuple">tuples</span> consisting of a <span>URL record</span> and a <span>string</span>.
   The <span>URL record</span> is the <span data-x="concept-request-url">request URL</span> at which
   the module was fetched, and the <span>string</span> indicates the type of the module (e.g. "<code
-  data-x="">javascript-or-wasm</code>"). The <span>module map</span>'s values are either a <span>module
-  script</span> or a <span>list</span> of algorithms (that are waiting for the fetch to
-  complete).</span> <span
-  data-x="module map">Module maps</span> are used to ensure that imported module scripts are only
-  fetched, parsed, and evaluated once per <code>Document</code> or <a
+  data-x="">javascript-or-wasm</code>"). The <span>module map</span>'s values are either a
+  <span>module script</span> or a <span>list</span> of algorithms (that are waiting for the fetch to
+  complete).</span> <span data-x="module map">Module maps</span> are used to ensure that imported
+  module scripts are only fetched, parsed, and evaluated once per <code>Document</code> or <a
   href="#workers">worker</a>.</p>
 
   <div class="example">


### PR DESCRIPTION
As pointed out in https://github.com/whatwg/html/pull/10327/changes#r3662863532, #10327 left a couple of stale references to null values in the module map. This PR cleans those up.

As this is not a behavior change, I'm skipping the checkboxes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12725/webappapis.html" title="Last updated on Aug 21, 2026, 1:06 PM UTC (0c8fb68)">/webappapis.html</a>  ( <a href="https://whatpr.org/html/12725/24c5e48...0c8fb68/webappapis.html" title="Last updated on Aug 21, 2026, 1:06 PM UTC (0c8fb68)">diff</a> )