### PR TITLE
Specify MouseEvent in select event.button check

### DIFF
--- a/source
+++ b/source
@@ -57400,8 +57400,8 @@ interface <dfn interface>HTMLSelectElement</dfn> : <span>HTMLElement</span> {
   <ol>
    <li><p>If <var>event</var>'s <span>canceled flag</span> is set, then return.</p></li>
 
-   <li><p>If <var>event</var>'s <code data-x="dom-MouseEvent-button">button</code> attribute is not
-   1, then return.</p></li>
+   <li><p>If <var>event</var> is a <code>MouseEvent</code> and <var>event</var>'s <code
+   data-x="dom-MouseEvent-button">button</code> attribute is not 1, then return.</p></li>
 
    <li><p>Run the <span>show popover</span> algorithm given <var>select</var>'s <span>select
    popover</span>, false, and <var>select</var>.</p></li>

--- a/source
+++ b/source
@@ -57347,7 +57347,7 @@ interface <dfn interface>HTMLSelectElement</dfn> : <span>HTMLElement</span> {
    then return.</p></li>
 
    <li><p>If <var>event</var> is a <code>MouseEvent</code> and <var>event</var>'s <code
-   data-x="dom-MouseEvent-button">button</code> attribute is not 1, then return.</p></li>
+   data-x="dom-MouseEvent-button">button</code> attribute is not 0, then return.</p></li>
 
    <li><p>Set <var>option</var>'s <span data-x="concept-option-selectedness">selectedness</span> to
    true.</p></li>
@@ -57401,7 +57401,7 @@ interface <dfn interface>HTMLSelectElement</dfn> : <span>HTMLElement</span> {
    <li><p>If <var>event</var>'s <span>canceled flag</span> is set, then return.</p></li>
 
    <li><p>If <var>event</var> is a <code>MouseEvent</code> and <var>event</var>'s <code
-   data-x="dom-MouseEvent-button">button</code> attribute is not 1, then return.</p></li>
+   data-x="dom-MouseEvent-button">button</code> attribute is not 0, then return.</p></li>
 
    <li><p>Run the <span>show popover</span> algorithm given <var>select</var>'s <span>select
    popover</span>, false, and <var>select</var>.</p></li>


### PR DESCRIPTION
This event.button check was added to make sure that right clicking a select doesn't open its picker, but since the same algorithm handles keyboard events it should be specific about looking at event.button only on mouse events.

This PR also corrects the number being looked at from 1 to 0 for event.button

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62184
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Already implemented
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2067310
   * WebKit: Already implemented
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: not needed
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: not needed
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12733/form-elements.html" title="Last updated on Aug 27, 2026, 11:23 PM UTC (a6aaad0)">/form-elements.html</a>  ( <a href="https://whatpr.org/html/12733/24c5e48...a6aaad0/form-elements.html" title="Last updated on Aug 27, 2026, 11:23 PM UTC (a6aaad0)">diff</a> )