### PR TITLE
Clarify tokenizer and tree construction interaction

### DIFF
--- a/source
+++ b/source
@@ -32671,7 +32671,7 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
   data-x="">auto,</code>" (<span>ASCII case-insensitive</span>).</p>
 
   <p class="note">If the <code>img</code> element that initiated the image loading (with the
-  <span>update the image data</span> or <span data-x="img-environment-changes">react to environment
+  <span>source/</span> or <span data-x="img-environment-changes">react to environment
   changes</span> algorithms) <span>allows auto-sizes</span> and is <span>being rendered</span>,
   then <code data-x="valdef-sizes-auto">auto</code> is the <span>concrete object size</span> width.
   Otherwise, the <code data-x="valdef-sizes-auto">auto</code> value is ignored and the next
@@ -141630,6 +141630,11 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   scripts executing and using the <span>dynamic markup insertion</span> APIs to insert characters
   into the stream being tokenized.)</p>
 
+  <p class="note">The tokenizer and tree construction stage are interleaved. When a token is emitted,
+  it is immediately processed by the tree construction stage, but the tree construction stage can
+  also ask the tokenizer for the next token to be processed. In this context, the <i>next token</i>
+  is the token that is about to be processed by the tree construction dispatcher.</p>
+
   <p class="note">Creating a token and emitting it are distinct actions. It is possible for a token
   to be created but implicitly abandoned (never emitted), e.g. if the file ends unexpectedly while
   processing the characters that are being parsed into a start tag token.</p>
@@ -144336,7 +144341,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <div algorithm>
   <p>The <dfn>next token</dfn> is the token that is about to be processed by the <span>tree
-  construction dispatcher</span> (even if the token is subsequently just ignored).</p>
+  construction dispatcher</span> (even if the token is subsequently just ignored). This is a
+  lookahead concept used by the tree construction stage while the tokenizer continues to provide
+  tokens as needed.</p>
   </div>
 
   <div algorithm>


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …
- [ ] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs:
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Wattsi server error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 3, 2026, 1:28 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Wattsi Server](https://github.com/domenic/wattsi-server) - Wattsi Server is the web service used to build the WHATWG HTML spec.

:link: [Related URL](https://build.whatwg.org/wattsi)

**Error output:**

```
Parsing MDN data...
Parsing...
Generating HTML variant...
Error: missing <dfn> for topic "source/" explicitly from <span> element containing "source/"; previous heading contents are "4.8.4.2.2 Sizes attributes"
Error count: 1
Saving index-html
Splitting...
Saving index.html
Saving introduction.html
Saving infrastructure.html
Saving common-microsyntaxes.html
Saving urls-and-fetching.html
Saving common-dom-interfaces.html
Saving structured-data.html
Saving dom.html
Saving semantics.html
Saving sections.html
Saving grouping-content.html
Saving text-level-semantics.html
Saving links.html
Saving edits.html
Saving embedded-content.html
Saving images.html
Saving iframe-embed-object.html
Saving media.html
Saving image-maps.html
Saving embedded-content-other.html
Saving tables.html
Saving forms.html
Saving input.html
Saving form-elements.html
Saving form-control-infrastructure.html
Saving interactive-elements.html
Saving scripting.html
Saving canvas.html
Saving custom-elements.html
Saving semantics-other.html
Saving microdata.html
Saving interaction.html
Saving dnd.html
Saving popover.html
Saving browsers.html
Saving nav-history-apis.html
Saving document-sequences.html
Saving browsing-the-web.html
Saving document-lifecycle.html
Saving speculative-loading.html
Saving webappapis.html
Saving dynamic-markup-insertion.html
Saving timers-and-user-prompts.html
Saving system-state.html
Saving imagebitmap-and-animations.html
Saving comms.html
Saving server-sent-events.html
Saving web-messaging.html
Saving workers.html
Saving worklets.html
Saving webstorage.html
Saving syntax.html
Saving parsing.html
Saving named-characters.html
Saving xhtml.html
Saving rendering.html
Saving obsolete.html
Saving iana.html
Saving indices.html
Saving references.html
Saving acknowledgements.html
Generating DEV variant...
Splitting...
Saving index.html
Saving introduction.html
Saving infrastructure.html
Saving common-microsyntaxes.html
Saving urls-and-fetching.html
Saving common-dom-interfaces.html
Saving structured-data.html
Saving dom.html
Saving semantics.html
Saving sections.html
Saving grouping-content.html
Saving text-level-semantics.html
Saving links.html
Saving edits.html
Saving embedded-content.html
Saving images.html
Saving iframe-embed-object.html
Saving media.html
Saving image-maps.html
Saving embedded-content-other.html
Saving tables.html
Saving forms.html
Saving input.html
Saving form-elements.html
Saving form-control-infrastructure.html
Saving interactive-elements.html
Saving scripting.html
Saving canvas.html
Saving custom-elements.html
Saving semantics-other.html
Saving microdata.html
Saving interaction.html
Saving dnd.html
Saving popover.html
Saving browsers.html
Saving nav-history-apis.html
Saving document-sequences.html
Saving browsing-the-web.html
Saving document-lifecycle.html
Saving speculative-loading.html
Saving webappapis.html
Saving dynamic-markup-insertion.html
Saving timers-and-user-prompts.html
Saving system-state.html
Saving imagebitmap-and-animations.html
Saving comms.html
Saving server-sent-events.html
Saving web-messaging.html
Saving workers.html
Saving worklets.html
Saving webstorage.html
Saving syntax.html
Saving named-characters.html
Saving xhtml.html
Saving obsolete.html
Saving indices.html
Saving references.html
Saving acknowledgements.html
Generating SNAP variant...
Error: missing <dfn> for topic "source/" explicitly from <span> element containing "source/"; previous heading contents are "4.8.4.2.2 Sizes attributes"
Error count: 1
Saving index-snap

```

_This seems to be an issue with the [Wattsi Server](https://github.com/domenic/wattsi-server) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Wattsi Server](https://github.com/domenic/wattsi-server/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Wattsi Server, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/html%2312746.)._

</details>
