### PR TITLE
Use System colors for links

### DIFF
--- a/source
+++ b/source
@@ -150717,8 +150717,8 @@ ruby { display: ruby; }
 rt { display: ruby-text; }
 
 :link { color: LinkText; }
-:visited { color: #551A8B; }
-:link:active, :visited:active { color: #FF0000; }
+:visited { color: VisitedText; }
+:link:active, :visited:active { color: ActiveText; }
 :link, :visited { text-decoration: underline; cursor: pointer; }
 
 :focus-visible { outline: auto; }

--- a/source
+++ b/source
@@ -150716,7 +150716,7 @@ sub, sup { line-height: normal; font-size: smaller; }
 ruby { display: ruby; }
 rt { display: ruby-text; }
 
-:link { color: #0000EE; }
+:link { color: LinkText; }
 :visited { color: #551A8B; }
 :link:active, :visited:active { color: #FF0000; }
 :link, :visited { text-decoration: underline; cursor: pointer; }


### PR DESCRIPTION
[`/css/css-color/system-color-consistency.html`](https://wpt.fyi/results/css/css-color/system-color-consistency.html?label=experimental&label=master&aligned) ensures
that system colors and the resolved `color` properties have the same value. When updating Servo to support dark mode, using the specified value for links isn't necessarily compatible in dark or light mode.

In other parts of the specification, the system colors are used to denote
the values, leaving it up to user agents to determine what the value should be. In fact, Edge currently fails this test and chooses a different value for LinkText in light mode. In dark mode, Edge passes the test.

Therefore, to align with user agent choice and ensure that system
colors are consistent with resolved colors, use system colors for links.

- [ ] At least two implementers are interested (and none opposed):
   * Gecko (already implemented)
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/css/css-color/system-color-consistency.html?label=experimental&label=master&aligned
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: N/A
   * WebKit: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12761/rendering.html" title="Last updated on Aug 11, 2026, 2:38 PM UTC (a98d2bc)">/rendering.html</a>  ( <a href="https://whatpr.org/html/12761/24c5e48...a98d2bc/rendering.html" title="Last updated on Aug 11, 2026, 2:38 PM UTC (a98d2bc)">diff</a> )