### PR TITLE
Correct reflection definition for commandForElement and popoverTargetElement

### DIFF
--- a/source
+++ b/source
@@ -56647,7 +56647,7 @@ interface <dfn interface>HTMLButtonElement</dfn> : <span>HTMLElement</span> {
   [<span>HTMLConstructor</span>] constructor();
 
   [<span>CEReactions</span>, <span data-x="xattr-ReflectSetter">ReflectSetter</span>] attribute DOMString <span data-x="dom-button-command">command</span>;
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute Element? <dfn attribute for="HTMLButtonElement" data-x="dom-button-commandForElement">commandForElement</dfn>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>="<span data-x="attr-button-commandfor">commandfor</span>"] attribute Element? <dfn attribute for="HTMLButtonElement" data-x="dom-button-commandForElement">commandForElement</dfn>;
   [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute boolean <dfn attribute for="HTMLButtonElement" data-x="dom-button-disabled">disabled</dfn>;
   readonly attribute <span>HTMLFormElement</span>? <span data-x="dom-fae-form">form</span>;
   [<span>CEReactions</span>, <span data-x="xattr-ReflectSetter">ReflectSetter</span>] attribute USVString <span data-x="dom-fs-formAction">formAction</span>;
@@ -92988,7 +92988,7 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
 
   <span data-x="concept-element-dom">DOM interface</span>:
   <pre><code class="idl">interface mixin <dfn interface>PopoverTargetAttributes</dfn> {
-  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>] attribute Element? <dfn attribute for="HTMLElement" data-x="dom-popoverTargetElement">popoverTargetElement</dfn>;
+  [<span>CEReactions</span>, <span data-x="xattr-Reflect">Reflect</span>="<span data-x="attr-popovertarget">popovertarget</span>"] attribute Element? <dfn attribute for="HTMLElement" data-x="dom-popoverTargetElement">popoverTargetElement</dfn>;
   [<span>CEReactions</span>] attribute DOMString <span data-x="dom-popoverTargetAction">popoverTargetAction</span>;
 };</code></pre>
 


### PR DESCRIPTION
Correct reflection definition for commandForElement and popoverTargetElement

This fixes the spec to match actual implementations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Wattsi server error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 21, 2026, 12:36 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Wattsi Server](https://github.com/domenic/wattsi-server) - Wattsi Server is the web service used to build the WHATWG HTML spec.

:link: [Related URL](https://build.whatwg.org/wattsi)

**Error output:**

```
      <!DOCTYPE html>
      <html>
      <head>
          <meta name="viewport" content="width=device-width, initial-scale=1">
          <meta name="robots" content="noindex">
          <style>body,html{height:100%;margin:0}body{display:flex;align-items:center;justify-content:center;flex-direction:column;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}p{text-align:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;color:#000;font-size:14px;margin-top:-50px}p.code{font-size:24px;font-weight:500;border-bottom:1px solid #e0e1e2;padding:0 20px 15px}p.text{margin:0}a,a:visited{color:#aaa}</style>
      </head>
      <body>
      <p class="code">
        Error code: 503      </p>
      <p class="text">
        Well, This is unexpected. An Error has occurred, and we are working to fix the problem! We will be up and running shortly. Try refreshing the page or try again in a few minutes.
      </p>
        <div style="display:none;">
          <h1>
    upstream_reset_before_response_started{connection_termination} (503 UC)      </h1>
          <p data-translate="connection_timed_out">App Platform failed to forward this request to the application.</p>
      </div>
      </body>
      </html>
    
```

_This seems to be an issue with the [Wattsi Server](https://github.com/domenic/wattsi-server) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Wattsi Server](https://github.com/domenic/wattsi-server/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Wattsi Server, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/html%2312762.)._

</details>
