### PR TITLE
Close unrelated auto popovers when a dialog opens inside a hint popover

### DIFF
--- a/source
+++ b/source
@@ -92531,11 +92531,19 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
    <span data-x="attr-popover-hint-state">Hint</span>, <var>focusPreviousElement</var>, and
    <var>fireEvents</var>.</p></li>
 
-   <li><p>If <var>endpointIsHint</var> is true, then return.</p></li>
+   <li><p>Let <var>autoEndpoint</var> be <var>endpoint</var>.</p></li>
 
-   <li><p>Run <span>hide popover stack until</span> given <var>document</var>, <var>endpoint</var>,
-   <span data-x="attr-popover-auto-state">Auto</span>, <var>focusPreviousElement</var>, and
-   <var>fireEvents</var>.</p></li>
+   <li>
+    <p>If <var>endpointIsHint</var> is true, then set <var>autoEndpoint</var> to
+    <var>document</var>'s <span>hint stack parent</span>.</p>
+
+    <p class="note">This means, if <var>endpoint</var> is a hint popover, auto popovers are closed,
+    except those that are parent to that hint popover.</p>
+   </li>
+
+   <li><p>Run <span>hide popover stack until</span> given <var>document</var>,
+   <var>autoEndpoint</var>, <span data-x="attr-popover-auto-state">Auto</span>,
+   <var>focusPreviousElement</var>, and <var>fireEvents</var>.</p></li>
   </ol>
   </div>
 
@@ -93101,27 +93109,8 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
 
      <li><p>If <var>sameTarget</var> is false, then return.</p></li>
 
-     <li><p>Let <var>endpointIsHint</var> be true if <var>document</var>'s <span>showing hint
-     popover list</span> <span data-x="list contains">contains</span> <var>ancestor</var>; otherwise
-     false.</p></li>
-
-     <li><p>Run <span>hide popover stack until</span> given <var>document</var>,
-     <var>ancestor</var>, <span data-x="attr-popover-hint-state">Hint</span>, false, and
-     true.</p></li>
-
-     <li><p>Let <var>autoEndpoint</var> be <var>ancestor</var>.</p></li>
-
-     <li>
-      <p>If <var>endpointIsHint</var> is true, then set <var>autoEndpoint</var> to
-      <var>document</var>'s <span>hint stack parent</span>.</p>
-
-      <p class="note">This means, if a hint popover is clicked, auto popovers are closed, except
-      those that are parent to the clicked hint popover.</p>
-     </li>
-
-     <li><p>Run <span>hide popover stack until</span> given <var>document</var>,
-     <var>autoEndpoint</var>, <span data-x="attr-popover-auto-state">Auto</span>, false, and
-     true.</p></li>
+     <li><p>Run <span>hide popovers until</span> given <var>document</var>, <var>ancestor</var>,
+     false, and true.</p></li>
     </ol>
    </li>
   </ol>


### PR DESCRIPTION
Commit message:

---

Close unrelated auto popovers when a dialog opens inside a hint popover

The algorithm the show-dialog methods were using was wrong. Light dismiss had the algorithm right. I've updated "hide popovers until" to use the light dismiss behaviour, and now light dismiss uses the "hide popovers until".

---

Fixes #12763.

- [x] At least two implementers are interested (and none opposed):
   * Mozilla
   * Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61795
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/544919867
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2062282
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=321499
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12764/popover.html" title="Last updated on Aug 11, 2026, 9:19 AM UTC (f9376b2)">/popover.html</a>  ( <a href="https://whatpr.org/html/12764/24c5e48...f9376b2/popover.html" title="Last updated on Aug 11, 2026, 9:19 AM UTC (f9376b2)">diff</a> )