### PR TITLE
[forms] Remove anonymous button content-box, and use CSS rather than magic for input / button block axis centering.

### DIFF
--- a/source
+++ b/source
@@ -151952,7 +151952,18 @@ input:is([type=radio i], [type=checkbox i], [type=reset i], [type=button i],
   box-sizing: border-box;
 }
 
-textarea { white-space: pre-wrap; }</code></pre>
+textarea { white-space: pre-wrap; }
+
+input:not([type=file i], [type=range i], [type=checkbox i], [type=radio i]) {
+  align-content: unsafe center;
+}
+
+button,
+::file-selector-button,
+input:is([type=color i], [type=reset i], [type=button i], [type=submit i]) {
+  align-content: center;
+}
+</code></pre>
 
   <p>In <span>quirks mode</span>, the following rules are also <span>expected</span> to apply:</p>
 
@@ -152753,27 +152764,6 @@ input[type=image i][align=bottom i], object[align=bottom i] {
 
    <li><p>For the purpose of the 'normal' keyword of the <span>'align-self'</span> property, act
    as if the element is a replaced element.</p></li>
-
-   <li>
-    <p>If the element is an <code>input</code> element, or if it is a <code>button</code> element
-    and its computed value for <span>'display'</span> is not 'inline-grid', 'grid', 'inline-flex',
-    or 'flex', then the element's box has a child <dfn>anonymous button content box</dfn> with the
-    following behaviors:</p>
-
-    <ul>
-     <li><p>The box is a <span>block-level</span> <span>block container</span> that establishes a
-     new <span>block formatting context</span> (i.e., <span>'display'</span> is
-     'flow-root').</p></li>
-
-     <li><p>If the box does not overflow in the horizontal axis, then it is centered
-     horizontally.</p></li>
-
-     <li><p>If the box does not overflow in the vertical axis, then it is centered
-     vertically.</p></li>
-    </ul>
-
-    <p>Otherwise, there is no <span>anonymous button content box</span>.</p>
-   </li>
   </ul>
   </div>
 
@@ -152782,9 +152772,7 @@ input[type=image i][align=bottom i], object[align=bottom i] {
   <h4>The <code>button</code> element</h4>
 
   <p>The <code>button</code> element, when it generates a <span>CSS box</span>, is
-  <span>expected</span> to depict a button and to use <span>button layout</span> whose
-  <span>anonymous button content box</span>'s contents (if there is an <span>anonymous button
-  content box</span>) are the child boxes the element's box would otherwise have.</p>
+  <span>expected</span> to depict a button and to use <span>button layout</span>.</p>
 
   </div>
 
@@ -153073,10 +153061,10 @@ details[open] > summary:first-of-type {
   the <span data-x="attr-input-type-color">Color</span> state is <span>expected</span> to depict a
   color well, which, when activated, provides the user with a color picker (e.g. a color wheel or
   color palette) from which the color can be changed. The element, when it generates a <span>CSS
-  box</span>, is <span>expected</span> to use <span>button layout</span>, that has no child boxes
-  of the <span>anonymous button content box</span>. The <span>anonymous button content box</span>
-  is <span>expected</span> to have a <span data-x="presentational hints">presentational hint</span>
-  setting the <span>'background-color'</span> property to the element's <span
+  box</span>, is <span>expected</span> to use <span>button layout</span>, that has a single
+  <span>block-level</span> <span>block container</span> child box, which is <span>expected</span> to
+  have a <span data-x="presentational hints">presentational hint</span> setting the
+  <span>'background-color'</span> property to the element's <span
   data-x="concept-fe-value">value</span>.</p>
 
   <p>Predefined suggested values (provided by the <code data-x="attr-input-list">list</code>
@@ -153127,9 +153115,9 @@ details[open] > summary:first-of-type {
   data-x="concept-input-type-file-selected">selected files</span>, if any, followed by a button
   that, when activated, provides the user with a file picker from which the selection can be
   changed. The button is <span>expected</span> to use <span>button layout</span> and match the
-  <span>'::file-selector-button'</span> pseudo-element. The contents of its <span>anonymous button
-  content box</span> are <span>expected</span> to be <span>implementation-defined</span> (and
-  possibly locale-specific) text, for example "Choose file".</p>
+  <span>'::file-selector-button'</span> pseudo-element. Its contents are <span>expected</span>
+  to be <span>implementation-defined</span> (and possibly locale-specific) text, for example
+  "Choose file".</p>
 
   <p>User agents may handle an <code>input</code> element whose
   <code data-x="attr-input-type">type</code> attribute is in the
@@ -153152,9 +153140,9 @@ details[open] > summary:first-of-type {
   the <span data-x="attr-input-type-submit">Submit Button</span>, <span
   data-x="attr-input-type-reset">Reset Button</span>, or <span
   data-x="attr-input-type-button">Button</span> state, when it generates a <span>CSS box</span>, is
-  <span>expected</span> to depict a button and use <span>button layout</span> and the contents of
-  the <span>anonymous button content box</span> are <span>expected</span> to be the text of the
-  element's <code data-x="attr-input-value">value</code> attribute, if any, or text derived from
+  <span>expected</span> to depict a button and use <span>button layout</span> and its contents
+  are <span>expected</span> to be the text of the element's <code
+  data-x="attr-input-value">value</code> attribute, if any, or text derived from
   the element's <code data-x="attr-input-type">type</code> attribute in an
   <span>implementation-defined</span> (and probably locale-specific) fashion, if not.</p>
 
@@ -153688,6 +153676,15 @@ option {
 optgroup {
   display: block;
   font-weight: bolder;
+}</code></pre>
+
+  <p>The following styles are <span>expected</span> to apply to <code>select</code> elements when
+  they are being rendered as a <span>drop-down box</span>:</p>
+
+  <pre><code class="css">@namespace "http://www.w3.org/1999/xhtml";
+
+select {
+  align-content: center;
 }</code></pre>
 
   <p>The following styles are <span>expected</span> to apply to <code>select</code> elements when


### PR DESCRIPTION
This defines the (previously undefined, afaict) unsafe center alignment of text inputs and textarea, and makes the changes discussed by the CSS Working Group in https://github.com/w3c/csswg-drafts/issues/14190.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko
   * [Blink](https://github.com/w3c/csswg-drafts/issues/14190#issuecomment-4994516507)
   * WebKit was supportive during the CSSWG meeting, see [minutes](https://github.com/w3c/csswg-drafts/issues/14190#issuecomment-5190728686).
 - [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://phabricator.services.mozilla.com/D312564
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/545527313
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2055599
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=321599
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12781/rendering.html" title="Last updated on Aug 21, 2026, 10:31 AM UTC (3b6067f)">/rendering.html</a>  ( <a href="https://whatpr.org/html/12781/58eecd0...3b6067f/rendering.html" title="Last updated on Aug 21, 2026, 10:31 AM UTC (3b6067f)">diff</a> )