### PR TITLE
Editorial: Define tuple origin domains as hosts

### DIFF
--- a/source
+++ b/source
@@ -93284,7 +93284,7 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
      <li>A <dfn export for="origin" data-x="concept-origin-port">port</dfn> (null or a 16-bit
      unsigned integer).</li>
      <li>A <dfn export for="origin" data-x="concept-origin-domain">domain</dfn> (null or a <span
-     data-x="concept-domain">domain</span>). Null unless stated otherwise.</li>
+     data-x="concept-host">host</span>). Null unless stated otherwise.</li>
     </ul>
    </dd>
   </dl>


### PR DESCRIPTION
It's already treated as a host in the `document.domain` setter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12792/browsers.html" title="Last updated on Aug 17, 2026, 8:14 PM UTC (4fa2d9d)">/browsers.html</a>  ( <a href="https://whatpr.org/html/12792/ac0389a...4fa2d9d/browsers.html" title="Last updated on Aug 17, 2026, 8:14 PM UTC (4fa2d9d)">diff</a> )