### PR TITLE
Remove cross-origin check for simple dialogs

### DIFF
--- a/source
+++ b/source
@@ -35867,16 +35867,6 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
   data-x="attr-iframe-sandbox-allow-popups">allow-popups</code> are specified, as doing so is
   redundant.</p>
 
-  <p class="note">To allow <code data-x="dom-alert">alert()</code>, <code
-  data-x="dom-confirm">confirm()</code>, and <code data-x="dom-prompt">prompt()</code> inside
-  sandboxed content, both the <code data-x="attr-iframe-sandbox-allow-modals">allow-modals</code>
-  and <code data-x="attr-iframe-sandbox-allow-same-origin">allow-same-origin</code> keywords need to
-  be specified, and the loaded URL needs to be <span>same origin</span> with the <span>top-level
-  origin</span>. Without the <code
-  data-x="attr-iframe-sandbox-allow-same-origin">allow-same-origin</code> keyword, the content is
-  always treated as cross-origin, and cross-origin content <span>cannot show simple
-  dialogs</span>.</p>
-
   <p class="warning">Setting both the <code
   data-x="attr-iframe-sandbox-allow-scripts">allow-scripts</code> and <code
   data-x="attr-iframe-sandbox-allow-same-origin">allow-same-origin</code> keywords together when the
@@ -129918,11 +129908,6 @@ function sendData(data) {
    <li><p>If the <span>active sandboxing flag set</span> of <var>window</var>'s <span
    data-x="concept-document-window">associated <code>Document</code></span> has the <span>sandboxed
    modals flag</span> set, then return true.</p></li>
-
-   <li><p>If <var>window</var>'s <span>relevant settings object</span>'s <span
-   data-x="concept-settings-object-origin">origin</span> and <var>window</var>'s <span>relevant
-   settings object</span>'s <span>top-level origin</span> are not <span>same origin-domain</span>,
-   then return true.</p></li>
 
    <li>If <var>window</var>'s <span>relevant agent</span>'s <span
    data-x="concept-agent-event-loop">event loop</span>'s <span>termination nesting level</span> is


### PR DESCRIPTION
This behavior was never shipped, due to compat issues.

This reverts https://github.com/whatwg/html/pull/5407 and https://github.com/whatwg/html/pull/6297.
(effective revert of https://github.com/whatwg/html/commit/5f626a10f73d3e2af5c50d30a8d838f0801c0f8d and https://github.com/whatwg/html/commit/7c8fb864f83341dd55f851d86692d553eb164687, without removing contributor acknowledgement).

Corresponding tests: https://github.com/web-platform-tests/wpt/pull/62019

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12794/iframe-embed-object.html" title="Last updated on Aug 18, 2026, 12:40 PM UTC (3023f14)">/iframe-embed-object.html</a>  ( <a href="https://whatpr.org/html/12794/ac0389a...3023f14/iframe-embed-object.html" title="Last updated on Aug 18, 2026, 12:40 PM UTC (3023f14)">diff</a> )
<a href="https://whatpr.org/html/12794/timers-and-user-prompts.html" title="Last updated on Aug 18, 2026, 12:40 PM UTC (3023f14)">/timers-and-user-prompts.html</a>  ( <a href="https://whatpr.org/html/12794/ac0389a...3023f14/timers-and-user-prompts.html" title="Last updated on Aug 18, 2026, 12:40 PM UTC (3023f14)">diff</a> )