### PR TITLE
Remove object/embed exposedness from document named properties

### DIFF
--- a/source
+++ b/source
@@ -12681,28 +12681,18 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
   <div algorithm>
   <p id="dom-document-namedItem-which">The <code>Document</code> interface <span data-x="support
   named properties">supports named properties</span>. The <span>supported property names</span> of a
-  <code>Document</code> object <var>document</var> at any moment consist of the following, in
-  <span>tree order</span> according to the element that contributed them, ignoring later duplicates,
-  and with values from <code data-x="attr-id">id</code> attributes coming before values from <code
-  data-x="">name</code> attributes when the same element contributes both:</p>
+  <code>Document</code> object <var>document</var> at any moment consist of the following, for each
+  element <var>element</var> <span>in a document tree</span> with <var>document</var> as its
+  <span>root</span>, in <span>tree order</span>, ignoring later duplicates:</p>
 
-  <!-- KEEP THIS LIST IN SYNC WITH "NAMED ELEMENTS" DEFINITION BELOW -->
   <ul>
-   <li><p>the value of the <code data-x="">name</code> content attribute for all
-   <code>embed</code>, <code>form</code>, <code>iframe</code>, <code>img</code>, and
-   <code>object</code> elements that have a non-empty <code data-x="">name</code> content attribute
-   and are <span>in a document tree</span> with <var>document</var> as their
-   <span>root</span>;</p></li>
+   <li><p>the value of <var>element</var>'s <code data-x="attr-id">id</code> content attribute, if
+   <var>element</var> is a <span data-x="dom-document-namedItem-filter">named element</span> with
+   that value as its name; and then</p></li>
 
-   <li><p>the value of the <code data-x="attr-id">id</code> content attribute for all
-   <code>object</code> elements that have a non-empty <code data-x="attr-id">id</code> content
-   attribute and are <span>in a document tree</span> with <var>document</var> as their
-   <span>root</span>; and</p></li>
-
-   <li><p>the value of the <code data-x="attr-id">id</code> content attribute for all
-   <code>img</code> elements that have both a non-empty <code data-x="attr-id">id</code> content
-   attribute and a non-empty <code data-x="">name</code> content attribute, and are <span>in a
-   document tree</span> with <var>document</var> as their <span>root</span>.</p></li>
+   <li><p>the value of <var>element</var>'s <code data-x="">name</code> content attribute, if
+   <var>element</var> is a <span data-x="dom-document-namedItem-filter">named element</span> with
+   that value as its name.</p></li>
   </ul>
   </div>
 
@@ -12746,20 +12736,20 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
   </div>
 
   <div algorithm>
-  <p><dfn data-x="dom-document-nameditem-filter">Named elements</dfn> with the name <var>name</var>, for the purposes of the above algorithm, are those that are either:</p>
+  <p>An element is a <dfn data-x="dom-document-nameditem-filter">named element</dfn> with the name
+  <var>name</var> if <var>name</var> is not the empty string and any of the following are true:</p>
 
-  <!-- KEEP THIS LIST IN SYNC WITH SUPPORTED PROPERTY VALUES ABOVE -->
   <ul>
-   <li><code>embed</code>, <code>form</code>, <code>iframe</code>, <code>img</code>, or
-   <code>object</code> elements that have a <code data-x="">name</code> content attribute whose
-   value is <var>name</var>, or</li>
+   <li>it is an <code>embed</code>, <code>form</code>, <code>iframe</code>, <code>img</code>, or
+   <code>object</code> element whose <code data-x="">name</code> content attribute's value is
+   <var>name</var>;</li>
 
-   <li><code>object</code> elements that have an <code data-x="attr-id">id</code> content attribute
-   whose value is <var>name</var>, or</li>
+   <li>it is an <code>object</code> element whose <code data-x="attr-id">id</code> content
+   attribute's value is <var>name</var>; or</li>
 
-   <li><code>img</code> elements that have an <code data-x="attr-id">id</code> content attribute
-   whose value is <var>name</var>, and that have a non-empty <code data-x="">name</code>
-   content attribute present also.</li>
+   <li>it is an <code>img</code> element whose <code data-x="attr-id">id</code> content attribute's
+   value is <var>name</var>, and that has a non-empty <code data-x="">name</code> content attribute
+   present also.</li>
   </ul>
   </div>
 

--- a/source
+++ b/source
@@ -12689,15 +12689,15 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
   <!-- KEEP THIS LIST IN SYNC WITH "NAMED ELEMENTS" DEFINITION BELOW -->
   <ul>
    <li><p>the value of the <code data-x="">name</code> content attribute for all
-   <span>exposed</span> <code>embed</code>, <code>form</code>, <code>iframe</code>,
-   <code>img</code>, and <span>exposed</span> <code>object</code> elements that have a non-empty
-   <code data-x="">name</code> content attribute and are <span>in a document tree</span> with
-   <var>document</var> as their <span>root</span>;</p></li>
+   <code>embed</code>, <code>form</code>, <code>iframe</code>, <code>img</code>, and
+   <code>object</code> elements that have a non-empty <code data-x="">name</code> content attribute
+   and are <span>in a document tree</span> with <var>document</var> as their
+   <span>root</span>;</p></li>
 
    <li><p>the value of the <code data-x="attr-id">id</code> content attribute for all
-   <span>exposed</span> <code>object</code> elements that have a non-empty
-   <code data-x="attr-id">id</code> content attribute and are <span>in a document tree</span> with
-   <var>document</var> as their <span>root</span>; and</p></li>
+   <code>object</code> elements that have a non-empty <code data-x="attr-id">id</code> content
+   attribute and are <span>in a document tree</span> with <var>document</var> as their
+   <span>root</span>; and</p></li>
 
    <li><p>the value of the <code data-x="attr-id">id</code> content attribute for all
    <code>img</code> elements that have both a non-empty <code data-x="attr-id">id</code> content
@@ -12750,24 +12750,17 @@ partial interface <dfn id="document" data-lt="">Document</dfn> {
 
   <!-- KEEP THIS LIST IN SYNC WITH SUPPORTED PROPERTY VALUES ABOVE -->
   <ul>
-   <li><span>Exposed</span> <code>embed</code>, <code>form</code>, <code>iframe</code>,
-   <code>img</code>, or <span>exposed</span> <code>object</code> elements that have a <code
-   data-x="">name</code> content attribute whose value is <var>name</var>, or</li>
+   <li><code>embed</code>, <code>form</code>, <code>iframe</code>, <code>img</code>, or
+   <code>object</code> elements that have a <code data-x="">name</code> content attribute whose
+   value is <var>name</var>, or</li>
 
-   <li><span>Exposed</span> <code>object</code> elements that have an <code
-   data-x="attr-id">id</code> content attribute whose value is <var>name</var>, or</li>
+   <li><code>object</code> elements that have an <code data-x="attr-id">id</code> content attribute
+   whose value is <var>name</var>, or</li>
 
    <li><code>img</code> elements that have an <code data-x="attr-id">id</code> content attribute
    whose value is <var>name</var>, and that have a non-empty <code data-x="">name</code>
    content attribute present also.</li>
   </ul>
-  </div>
-
-  <div algorithm>
-  <p>An <code>embed</code> or <code>object</code> element is said to be <dfn>exposed</dfn> if it has
-  no <span>exposed</span> <code>object</code> ancestor, and, for <code>object</code> elements, is
-  additionally either not showing its <span>fallback content</span> or has no <code>object</code> or
-  <code>embed</code> descendants.</p>
   </div>
 
   </div>


### PR DESCRIPTION
Remove object/embed exposedness from document named properties

The "exposed" concept filtered object and embed elements out of a
Document's supported property names and named property lookup, based on
fallback content state, object and embed descendants, and, recursively,
object ancestors. No implementation matched it: Gecko ignored it
entirely, while Blink and WebKit ignored fallback content state for
lookup and ignored exposedness altogether for supported property names,
so Object.getOwnPropertyNames(document) could report a name that
resolved to undefined.

Follow Gecko and drop the filtering. These are legacy features and
choosing a corrected version of the nesting-based approximation is not
worth the complexity. This removes the only use of "exposed".

Tests: https://github.com/web-platform-tests/wpt/pull/62149

Fixes #12787.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Gecko already behaves this way
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62149 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/551807991
   * Gecko: not needed, already matches
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=322330
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12823/dom.html" title="Last updated on Aug 24, 2026, 2:16 PM UTC (08579a5)">/dom.html</a>  ( <a href="https://whatpr.org/html/12823/508a037...08579a5/dom.html" title="Last updated on Aug 24, 2026, 2:16 PM UTC (08579a5)">diff</a> )