### PR TITLE
Editorial: define fragment context element on HTML parser

### DIFF
--- a/source
+++ b/source
@@ -141378,9 +141378,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    elements</span>.</p></li>
 
    <li><p><i>Loop</i>: If <var>node</var> is the first node in the stack of open elements, then set
-   <var>last</var> to true, and, if the parser was created as part of the <span>HTML fragment
-   parsing algorithm</span> (<span>fragment case</span>), set <var>node</var> to the <var
-   data-x="concept-frag-parse-context">context</var> element passed to that algorithm.</p></li>
+   <var>last</var> to true, and, if the parser has a <span>fragment context element</span>, then set
+   <var>node</var> to that element (<span>fragment case</span>).</p></li>
 
    <li><p>If <var>node</var> is a <code>td</code> or <code>th</code> element and <var>last</var> is
    false, then switch the <span>insertion mode</span> to "<span data-x="insertion mode: in cell">in
@@ -141486,10 +141485,10 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   </div>
 
   <div algorithm>
-  <p>The <dfn>adjusted current node</dfn> is the <i data-x="concept-frag-parse-context">context</i>
-  element if the parser was created as part of the <span>HTML fragment parsing algorithm</span> and
-  the <span>stack of open elements</span> has only one element in it (<span>fragment case</span>);
-  otherwise, the <span>adjusted current node</span> is the <span>current node</span>.</p>
+  <p>The <dfn>adjusted current node</dfn> is the parser's <span>fragment context element</span> if
+  it is non-null and the <span>stack of open elements</span> has only one element in it
+  (<span>fragment case</span>); otherwise, the <span>adjusted current node</span> is the <span>current
+  node</span>.</p>
   </div>
 
   <div algorithm>
@@ -141780,6 +141779,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <p>The <dfn>root insertion target</dfn>, which is null or a <code>DocumentFragment</code>
   (initially null).</p>
+
+  <p>An <code>Element</code>-or-null <dfn>fragment context element</dfn>, initially null.</p>
 
   <p>A boolean <dfn>allow declarative shadow roots</dfn> (initially false).</p>
 
@@ -144594,10 +144595,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   </ul>
   </div>
 
-  <p class="note">If the node in question is the <var ignore
-  data-x="concept-frag-parse-context">context</var> element passed to the <span>HTML fragment
-  parsing algorithm</span>, then the start tag token for that element is the "fake" token created
-  during by that <span>HTML fragment parsing algorithm</span>.</p>
+  <p class="note">If the node in question is the parser's <span>fragment context element</span>, then the
+  start tag token for that element is the "fake" token created when <span
+  data-x="HTML fragment parsing algorithm">parsing HTML fragments</span>.</p>
 
   <hr>
 
@@ -144729,8 +144729,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <var>namespace</var>, <var>localName</var>, and <var>is</var>.</p></li>
 
    <li><p>Let <var>willExecuteScript</var> be true if <var>definition</var> is non-null and the
-   parser was not created as part of the <span>HTML fragment parsing algorithm</span>; otherwise
-   false.</p></li>
+   parser does not have a <span>fragment context element</span>; otherwise false.</p></li>
 
    <li>
     <p>If <var>willExecuteScript</var> is true:</p>
@@ -146847,9 +146846,8 @@ document.body.appendChild(text);
 
    <dt>A start tag whose tag name is "input"</dt>
    <dd>
-    <p>If the parser was created as part of the <span>HTML fragment parsing algorithm</span>
-    (<span>fragment case</span>) and the <span data-x="concept-frag-parse-context">context</span>
-    element passed to that algorithm is a <code>select</code> element:</p>
+    <p>If the parser's <span>fragment context element</span> is a <code>select</code> element
+    (<span>fragment case</span>):</p>
 
     <ol>
      <li><p><span>Parse error</span>.</p></li>
@@ -146979,9 +146977,8 @@ document.body.appendChild(text);
 
    <dt>A start tag whose tag name is "select"</dt>
    <dd>
-    <p>If the parser was created as part of the <span>HTML fragment parsing algorithm</span>
-    (<span>fragment case</span>) and the <span data-x="concept-frag-parse-context">context</span>
-    element passed to that algorithm is a <code>select</code> element:</p>
+    <p>If the parser's <span>fragment context element</span> is a <code>select</code> element
+    (<span>fragment case</span>):</p>
 
     <ol>
      <li><p><span>Parse error</span>.</p></li>
@@ -148450,8 +148447,8 @@ document.body.appendChild(text);
 
    <dt>An end tag whose tag name is "html"</dt>
    <dd>
-    <p>If the parser was created as part of the <span>HTML fragment parsing algorithm</span>, this
-    is a <span>parse error</span>; ignore the token. (<span>fragment case</span>)</p>
+    <p>If the parser has a <span>fragment context element</span>, this is a
+    <span>parse error</span>; ignore the token. (<span>fragment case</span>)</p>
 
     <p>Otherwise, switch the <span>insertion mode</span> to "<span data-x="insertion mode: after
     after body">after after body</span>".</p>
@@ -148519,10 +148516,9 @@ document.body.appendChild(text);
     <p>Otherwise, pop the <span>current node</span> from the <span>stack of open
     elements</span>.</p>
 
-    <p>If the parser was not created as part of the <span>HTML fragment parsing algorithm</span>
-    (<span>fragment case</span>), and the <span>current node</span> is no longer a
-    <code>frameset</code> element, then switch the <span>insertion mode</span> to "<span
-    data-x="insertion mode: after frameset">after frameset</span>".</p>
+    <p>If the parser does not have a <span>fragment context element</span> and the <span>current
+    node</span> is no longer a <code>frameset</code> element, then switch the <span>insertion mode</span>
+    to "<span data-x="insertion mode: after frameset">after frameset</span>".</p>
    </dd>
 
    <dt>A start tag whose tag name is "frame"</dt>
@@ -150076,11 +150072,11 @@ console.assert(container.firstChild instanceof SuperP);
   is the following steps. They return a <code>DocumentFragment</code>.</p>
 
   <p class="note">Parts marked <dfn>fragment case</dfn> in algorithms in the <span>HTML
-  parser</span> section are parts that only occur if the parser was created for the purposes of this
-  algorithm. The algorithms have been annotated with such markings for informational purposes only;
-  such markings have no normative weight. If it is possible for a condition described as a
-  <span>fragment case</span> to occur even when the parser wasn't created for the purposes of
-  handling this algorithm, then that is an error in the specification.</p>
+  parser</span> section are parts that only occur if the parser has a
+  <span>fragment context element</span>. The algorithms have been annotated with such markings for
+  informational purposes only; such markings have no normative weight. If it is possible for a
+  condition described as a <span>fragment case</span> to occur even when the parser does not have a
+  <span>fragment context element</span>, then that is an error in the specification.</p>
 
   <ol>
    <li><p><span>Assert</span>: <var>scriptingMode</var> is either <span
@@ -150110,6 +150106,9 @@ console.assert(container.firstChild instanceof SuperP);
 
    <li><p>Create a new <span>HTML parser</span> whose <span>allow declarative shadow roots</span> is
    <var>allowDeclarativeShadowRoots</var>, and associate it with <var>document</var>.</p></li>
+
+   <li><p>Set the parser's <span>fragment context element</span> to
+   <var data-x="concept-frag-parse-context">context</var>.</p></li>
 
    <li><p>If <var>contextDocument</var>'s <span data-x="concept-n-script">scripting is
    disabled</span>, then set <var>scriptingMode</var> to <span
@@ -150192,8 +150191,8 @@ console.assert(container.firstChild instanceof SuperP);
     <p><span data-x="reset the insertion mode appropriately">Reset the parser's insertion mode
     appropriately</span>.</p>
 
-    <p class="note">The parser will reference the <var
-    data-x="concept-frag-parse-context">context</var> element as part of that algorithm.</p>
+    <p class="note">The parser will reference the parser's <span>fragment context element</span>
+    as part of that algorithm.</p>
    </li>
 
    <li><p>Set the <span>HTML parser</span>'s <span><code>form</code> element pointer</span> to the

--- a/source
+++ b/source
@@ -141378,8 +141378,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    elements</span>.</p></li>
 
    <li><p><i>Loop</i>: If <var>node</var> is the first node in the stack of open elements, then set
-   <var>last</var> to true, and, if the parser has a <span>fragment context element</span>, then set
-   <var>node</var> to that element (<span>fragment case</span>).</p></li>
+   <var>last</var> to true, and, if the parser's <span>fragment context element</span> is non-null,
+   then set <var>node</var> to that element (<span>fragment case</span>).</p></li>
 
    <li><p>If <var>node</var> is a <code>td</code> or <code>th</code> element and <var>last</var> is
    false, then switch the <span>insertion mode</span> to "<span data-x="insertion mode: in cell">in
@@ -141486,9 +141486,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <div algorithm>
   <p>The <dfn>adjusted current node</dfn> is the parser's <span>fragment context element</span> if
-  it is non-null and the <span>stack of open elements</span> has only one element in it
-  (<span>fragment case</span>); otherwise, the <span>adjusted current node</span> is the <span>current
-  node</span>.</p>
+  that element is non-null and the <span>stack of open elements</span> has only one element in it
+  (<span>fragment case</span>); otherwise, the <span>adjusted current node</span> is the
+  <span>current node</span>.</p>
   </div>
 
   <div algorithm>
@@ -144595,9 +144595,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   </ul>
   </div>
 
-  <p class="note">If the node in question is the parser's <span>fragment context element</span>, then the
-  start tag token for that element is the "fake" token created when <span
-  data-x="HTML fragment parsing algorithm">parsing HTML fragments</span>.</p>
+  <p class="note">If the node in question is the parser's <span>fragment context element</span>,
+  then the start tag token for that element is the "fake" token created by the <span>HTML fragment
+  parsing algorithm</span>.</p>
 
   <hr>
 
@@ -144729,7 +144729,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <var>namespace</var>, <var>localName</var>, and <var>is</var>.</p></li>
 
    <li><p>Let <var>willExecuteScript</var> be true if <var>definition</var> is non-null and the
-   parser does not have a <span>fragment context element</span>; otherwise false.</p></li>
+   parser's <span>fragment context element</span> is null; otherwise false.</p></li>
 
    <li>
     <p>If <var>willExecuteScript</var> is true:</p>
@@ -144866,17 +144866,16 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given <var>element</var>,
    <var>targetParent</var>, <var>referenceChild</var>, and « » does not throw.</p></li>
 
-   <li><p>If the parser was not created as part of the <span>HTML fragment parsing
-   algorithm</span>, then push a new <span>element queue</span> onto <var>element</var>'s
-   <span>relevant agent</span>'s <span>custom element reactions stack</span>.</p></li>
+   <li><p>If the parser's <span>fragment context element</span> is null, then push a new
+   <span>element queue</span> onto <var>element</var>'s <span>relevant agent</span>'s <span>custom
+   element reactions stack</span>.</p></li>
 
    <li><p><span data-x="concept-node-insert">Insert</span> <var>element</var> into
    <var>targetParent</var> before <var>referenceChild</var>.</p></li>
 
-   <li><p>If the parser was not created as part of the <span>HTML fragment parsing
-   algorithm</span>, then pop the <span>element queue</span> from <var>element</var>'s
-   <span>relevant agent</span>'s <span>custom element reactions stack</span>, and <span>invoke
-   custom element reactions</span> in that queue.</p></li>
+   <li><p>If the parser's <span>fragment context element</span> is null, then pop the <span>element
+   queue</span> from <var>element</var>'s <span>relevant agent</span>'s <span>custom element
+   reactions stack</span>, and <span>invoke custom element reactions</span> in that queue.</p></li>
   </ol>
   </div>
 
@@ -148447,8 +148446,8 @@ document.body.appendChild(text);
 
    <dt>An end tag whose tag name is "html"</dt>
    <dd>
-    <p>If the parser has a <span>fragment context element</span>, this is a
-    <span>parse error</span>; ignore the token. (<span>fragment case</span>)</p>
+    <p>If the parser's <span>fragment context element</span> is non-null, this is a <span>parse
+    error</span>; ignore the token. (<span>fragment case</span>)</p>
 
     <p>Otherwise, switch the <span>insertion mode</span> to "<span data-x="insertion mode: after
     after body">after after body</span>".</p>
@@ -148516,9 +148515,9 @@ document.body.appendChild(text);
     <p>Otherwise, pop the <span>current node</span> from the <span>stack of open
     elements</span>.</p>
 
-    <p>If the parser does not have a <span>fragment context element</span> and the <span>current
-    node</span> is no longer a <code>frameset</code> element, then switch the <span>insertion mode</span>
-    to "<span data-x="insertion mode: after frameset">after frameset</span>".</p>
+    <p>If the parser's <span>fragment context element</span> is null and the <span>current
+    node</span> is no longer a <code>frameset</code> element, then switch the <span>insertion
+    mode</span> to "<span data-x="insertion mode: after frameset">after frameset</span>".</p>
    </dd>
 
    <dt>A start tag whose tag name is "frame"</dt>
@@ -150072,11 +150071,11 @@ console.assert(container.firstChild instanceof SuperP);
   is the following steps. They return a <code>DocumentFragment</code>.</p>
 
   <p class="note">Parts marked <dfn>fragment case</dfn> in algorithms in the <span>HTML
-  parser</span> section are parts that only occur if the parser has a
-  <span>fragment context element</span>. The algorithms have been annotated with such markings for
+  parser</span> section are parts that only occur if the parser's <span>fragment context
+  element</span> is non-null. The algorithms have been annotated with such markings for
   informational purposes only; such markings have no normative weight. If it is possible for a
-  condition described as a <span>fragment case</span> to occur even when the parser does not have a
-  <span>fragment context element</span>, then that is an error in the specification.</p>
+  condition described as a <span>fragment case</span> to occur even when the parser's <span>fragment
+  context element</span> is null, then that is an error in the specification.</p>
 
   <ol>
    <li><p><span>Assert</span>: <var>scriptingMode</var> is either <span
@@ -150107,8 +150106,8 @@ console.assert(container.firstChild instanceof SuperP);
    <li><p>Create a new <span>HTML parser</span> whose <span>allow declarative shadow roots</span> is
    <var>allowDeclarativeShadowRoots</var>, and associate it with <var>document</var>.</p></li>
 
-   <li><p>Set the parser's <span>fragment context element</span> to
-   <var data-x="concept-frag-parse-context">context</var>.</p></li>
+   <li><p>Set the parser's <span>fragment context element</span> to <var
+   data-x="concept-frag-parse-context">context</var>.</p></li>
 
    <li><p>If <var>contextDocument</var>'s <span data-x="concept-n-script">scripting is
    disabled</span>, then set <var>scriptingMode</var> to <span
@@ -150191,8 +150190,8 @@ console.assert(container.firstChild instanceof SuperP);
     <p><span data-x="reset the insertion mode appropriately">Reset the parser's insertion mode
     appropriately</span>.</p>
 
-    <p class="note">The parser will reference the parser's <span>fragment context element</span>
-    as part of that algorithm.</p>
+    <p class="note">The parser will reference its <span>fragment context element</span> as part of
+    that algorithm.</p>
    </li>
 
    <li><p>Set the <span>HTML parser</span>'s <span><code>form</code> element pointer</span> to the


### PR DESCRIPTION
Instead of repeatedly asking whether the parser "was created as part of the  HTML fragment parsing algorithm", give the HTML parser a fragment context element and test that directly.

This also drops the (fragment case) marker on the "in frameset" end tag branch, since that branch only runs when there is no fragment context element.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12829/parsing.html" title="Last updated on Aug 26, 2026, 6:07 PM UTC (c763e75)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12829/b17ff2b...c763e75/parsing.html" title="Last updated on Aug 26, 2026, 6:07 PM UTC (c763e75)">diff</a> )