### PR TITLE
Drop an element the parser cannot insert

### DIFF
--- a/source
+++ b/source
@@ -144877,11 +144877,26 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <li><p>Set <var>insertionLocation</var> to the <span>adjusted insertion location</span> given
    <var>insertionLocation</var>.</p></li>
 
-   <li><p>If <var>insertionLocation</var> is in a <code>Document</code> node and that
-   <code>Document</code> node has an element child, then return.</p></li>
+   <li><p>Let <var>target</var> be the node in which <var>insertionLocation</var> finds
+   itself.</p></li>
 
-   <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given <var>element</var>, the
-   node in which <var>insertionLocation</var> finds itself, null, and « » does not throw.</p></li>
+   <li>
+    <p>If any of the following are true:</p>
+
+    <ul>
+     <li><var>element</var>'s <span>parent</span> is non-null;</li>
+
+     <li><var>element</var> is a <span>host-including inclusive ancestor</span> of
+     <var>target</var>; or</li>
+
+     <li><var>target</var> is a <code>Document</code> node that already has an element child,</li>
+    </ul>
+
+    <p>then return.</p>
+   </li>
+
+   <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given <var>element</var>,
+   <var>target</var>, null, and « » does not throw.</p></li>
 
    <li><p>If the parser was not created as part of the <span>HTML fragment parsing
    algorithm</span>, then push a new <span>element queue</span> onto <var>element</var>'s


### PR DESCRIPTION
"Insert an element at the adjusted insertion location" asserted that the
insertion was valid, on the grounds that the element was newly created. But
creating an element for the token runs a custom element constructor and can
invoke attributeChangedCallback, both with a reference to the element, so script
can give it a parent, or move the node the adjusted insertion location finds
itself in into the element — including into the element's shadow root, or into
the template contents of a template element inside it.

Tests: https://github.com/web-platform-tests/wpt/pull/62174

Fixes #12494.

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Presumably Gecko & Chromium as this is a severe bug
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62174
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-( 
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2038800
   * WebKit: https://github.com/WebKit/WebKit/pull/72309
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12830/parsing.html" title="Last updated on Aug 24, 2026, 5:15 PM UTC (cf2fdf6)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12830/508a037...cf2fdf6/parsing.html" title="Last updated on Aug 24, 2026, 5:15 PM UTC (cf2fdf6)">diff</a> )