### PR TITLE
Honor a template's insertion target when foster parenting

### DIFF
--- a/source
+++ b/source
@@ -144608,8 +144608,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   <h5>Creating and inserting nodes</h5>
 
   <p>An <dfn>insertion location</dfn> is a <span>tuple</span> consisting of a <dfn
-  data-x="insertion-location-target-parent">target parent</dfn> (a <code>Node</code>), and a <dfn
-  data-x="insertion-location-ref-child">reference child</dfn> (a <code>Node</code> or null).</p>
+  data-x="insertion-location-target-parent">target parent</dfn> (a <code>Node</code>) and a <dfn
+  data-x="insertion-location-reference-child">reference child</dfn> (a <code>Node</code> or
+  null).</p>
 
   <p>While the parser is processing a token, it can enable or disable <dfn data-x="foster
   parent">foster parenting</dfn>. This affects the following algorithm.</p>
@@ -144833,7 +144834,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    a node</span> given <var>overrideTarget</var>.</p></li>
 
    <li><p>If <var>adjustedInsertionLocation</var>'s <span
-   data-x="insertion-location-target-parent">target target</span> is the first element in the
+   data-x="insertion-location-target-parent">target parent</span> is the first element in the
    <span>stack of open elements</span> and the parser's <span>root insertion target</span> is
    non-null, then set the <var>adjustedInsertionLocation</var> to the parser's
    <span>root insertion target</span>.</p></li>

--- a/source
+++ b/source
@@ -141774,7 +141774,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <h5>Other parsing state flags</h5>
 
-  <p>The <dfn>root insertion target</dfn>, which is null or a <code>DocumentFragment</code>
+  <p>The <dfn>root insertion target</dfn>, which is null or an <span>insertion location</span>
   (initially null).</p>
 
   <p>A boolean <dfn>allow declarative shadow roots</dfn> (initially false).</p>
@@ -144608,7 +144608,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   <h5>Creating and inserting nodes</h5>
 
   <p>An <dfn>insertion location</dfn> is a <span>tuple</span> consisting of a <dfn
-  data-x="insertion-location-parent">parent</dfn> (a <code>Node</code>), and a <dfn
+  data-x="insertion-location-target-parent">target parent</dfn> (a <code>Node</code>), and a <dfn
   data-x="insertion-location-ref-child">reference child</dfn> (a <code>Node</code> or null).</p>
 
   <p>While the parser is processing a token, it can enable or disable <dfn data-x="foster
@@ -144858,15 +144858,17 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <ol>
    <li><p>Let <var>overrideTarget</var> be null if <var>insertionLocation</var> is null;
-   otherwise <var>insertionLocation</var>[0].</p></li>
+   otherwise <var>insertionLocation</var>'s <span
+   data-x="insertion-location-target-parent">target parent</span>.</p></li>
 
    <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting
    a node</span> given <var>overrideTarget</var>.</p></li>
 
-   <li><p>If <var>adjustedInsertionLocation</var>[0] is the first element in the <span>stack of open
-   elements</span> and the parser's <span>root insertion target</span> is non-null, then set the
-   <var>adjustedInsertionLocation</var> to (the parser's <span>root insertion target</span>,
-   null).</p></li>
+   <li><p>If <var>adjustedInsertionLocation</var>'s <span
+   data-x="insertion-location-target-parent">target target</span> is the first element in the
+   <span>stack of open elements</span> and the parser's <span>root insertion target</span> is
+   non-null, then set the <var>adjustedInsertionLocation</var> to the parser's
+   <span>root insertion target</span>.</p></li>
 
    <li><p>Return <var>adjustedInsertionLocation</var>.</p></li>
   </ol>
@@ -144937,7 +144939,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
    <li><p>Let <var>element</var> be the result of <span data-x="create an element for the
    token">creating an element for the token</span> given <var>token</var>, <var>namespace</var>,
-   and <var>adjustedInsertionLocation</var>[0].</p></li>
+   and <var>adjustedInsertionLocation</var>'s <span
+   data-x="insertion-location-target-parent">target parent</span>.</p></li>
 
    <li><p>If <var>onlyAddToElementStack</var> is false, then run <span>insert an element at the
    adjusted insertion location</span> with <var>element</var> and
@@ -150227,7 +150230,8 @@ console.assert(container.firstChild instanceof SuperP);
    a document fragment</span> given <var>target</var>'s <span>node
    document</span>.</p></li>
 
-   <li><p>Set the parser's <span>root insertion target</span> to <var>fragment</var>.</p></li>
+   <li><p>Set the parser's <span>root insertion target</span> to (<var>fragment</var>,
+   null).</p></li>
 
    <li><p>If <var data-x="concept-frag-parse-context">context</var> is a <code>template</code>
    element, then push "<span data-x="insertion mode: in template">in template</span>" onto the

--- a/source
+++ b/source
@@ -144635,34 +144635,23 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
     <p class="note">Foster parenting happens when content is misnested in tables.</p>
 
     <ol>
-     <li><p>Let <var>lastTemplate</var> be the last <code>template</code> element in the
-     <span>stack of open elements</span>, or null if there is no such element.</p></li>
+     <li><p>Let <var>lastTemplateOrTable</var> be the last <code>template</code> or
+     <code>table</code> element in the <span>stack of open elements</span> if there is one;
+     otherwise null.</p></li>
 
-     <li><p>Let <var>lastTable</var> be the last <code>table</code> element in the <span>stack of
-     open elements</span>, or null if there is no such element.</p></li>
-
-     <li><p>If <var>lastTemplate</var> is not null and either <var>lastTable</var> is null or
-     <var>lastTemplate</var> is lower (more recently added) than <var>lastTable</var> in the
-     <span>stack of open elements</span>, then set <var>targetParent</var> to
-     <var>lastTemplate</var>.</p></li>
-
-     <li><p>Otherwise, if <var>lastTable</var> is null, <!-- lastTemplate is then null as well,
-     since we didn't hit the previous step --> then return (the first element in the <span>stack of
-     open elements</span> (the <code>html</code> element), null).
+     <li><p>If <var>lastTemplateOrTable</var> is null, then return (the first element in the
+     <span>stack of open elements</span> (the <code>html</code> element), null).
      (<span>fragment case</span>)</p></li>
 
-     <!-- if we get here, we know lastTable is not null, and if lastTemplate is not null, it's older
-     than lastTable. -->
+     <li><p>If <var>lastTemplateOrTable</var> is a <code>template</code> element, then set
+     <var>targetParent</var> to <var>lastTemplateOrTable</var>.</p></li>
 
-     <li><p>Otherwise, if <var>lastTable</var>'s <span>parent</span> is not null, then set
-     <var>targetParent</var> to <var>lastTable</var>'s <span>parent</span> and set
-     <var>referenceChild</var> to <var>lastTable</var>.</p></li>
-
-     <!-- if we get here, we know lastTable is not null, but it has no parent, and if lastTemplate
-     is not null, it's older than lastTable. -->
+     <li><p>Otherwise, if <var>lastTemplateOrTable</var>'s <span>parent</span> is not null, then set
+     <var>targetParent</var> to <var>lastTemplateOrTable</var>'s <span>parent</span> and set
+     <var>referenceChild</var> to <var>lastTemplateOrTable</var>.</p></li>
 
      <li><p>Otherwise, set <var>targetParent</var> to the element immediately above
-     <var>lastTable</var> in the <span>stack of open elements</span>.</p></li>
+     <var>lastTemplateOrTable</var> in the <span>stack of open elements</span>.</p></li>
     </ol>
 
     <p class="note">These steps are involved in part because it's possible for elements, the

--- a/source
+++ b/source
@@ -144651,8 +144651,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
        <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, or there is one, but <var>last template</var> is lower
        (more recently added) than <var>last table</var> in the <span>stack of open
-       elements</span>, then let <var>adjusted insertion location</var> be (<var>last
-       template</var>'s <span>template contents</span>, null), and abort these steps.</p></li>
+       elements</span>, then return (<var>last template</var>'s <span>template contents</span>,
+       null).</p></li>
 
        <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
        template, since we didn't hit the previous step --> then let <var>adjusted insertion

--- a/source
+++ b/source
@@ -144616,12 +144616,12 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   parent">foster parenting</dfn>. This affects the following algorithm.</p>
 
   <div algorithm>
-  <p>The <dfn>appropriate place for inserting a node</dfn>, optionally using a particular
-  <i>override target</i>, is the <span>insertion location</span> returned by running the following
-  steps:</p>
+  <p>To find the <dfn>appropriate place for inserting a node</dfn>, given an optional
+  <code>Node</code> <var>overrideTarget</var> (default null), perform the following steps. They
+  return an <span>insertion location</span>.</p>
 
   <ol>
-   <li><p>Let <var>targetParent</var> be <i>override target</i> if it was given; otherwise the
+   <li><p>Let <var>targetParent</var> be <var>overrideTarget</var> if it is not null; otherwise the
    <span>current node</span>.</p></li>
 
    <li>
@@ -144633,39 +144633,32 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
     <p class="note">Foster parenting happens when content is misnested in tables.</p>
 
     <ol>
-     <li><p>Let <var>last template</var> be the last <code>template</code> element in the
-     <span>stack of open elements</span>, if any.</p></li>
+     <li><p>Let <var>lastTemplate</var> be the last <code>template</code> element in the
+     <span>stack of open elements</span>, or null if there is no such element.</p></li>
 
-     <li><p>Let <var>last table</var> be the last <code>table</code> element in the
-     <span>stack of open elements</span>, if any.</p></li>
+     <li><p>Let <var>lastTable</var> be the last <code>table</code> element in the <span>stack of
+     open elements</span>, or null if there is no such element.</p></li>
 
-     <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, or
-     there is one, but <var>last template</var> is lower (more recently added) than
-     <var>last table</var> in the <span>stack of open elements</span>, then set
-     <var>targetParent</var> to <var>last template</var>.</p></li>
+     <li><p>If <var>lastTemplate</var> is not null and either <var>lastTable</var> is null or
+     <var>lastTemplate</var> is lower (more recently added) than <var>lastTable</var> in the
+     <span>stack of open elements</span>, then set <var>targetParent</var> to
+     <var>lastTemplate</var>.</p></li>
 
-     <li>
-      <p>Otherwise:</p>
+     <li><p>Otherwise, if <var>lastTable</var> is null, <!-- lastTemplate is then null as well, since
+     we didn't hit the previous step --> then return (the first element in the <span>stack of open
+     elements</span> (the <code>html</code> element), null). (<span>fragment case</span>)</p></li>
 
-      <ol>
-       <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
-       template, since we didn't hit the previous step --> then return (the first element in the
-       <span>stack of open elements</span> (the <code>html</code> element), null).
-       (<span>fragment case</span>)</p></li>
+     <!-- if we get here, we know lastTable is not null, and if lastTemplate is not null, it's older
+     than lastTable. -->
 
-       <!-- if we get here, we know there's a last table, and if there's a last template, it's older
-       than the last table. -->
+     <li><p>Otherwise, if <var>lastTable</var>'s <span>parent</span> is not null, then return
+     (<var>lastTable</var>'s <span>parent</span>, <var>lastTable</var>).</p></li>
 
-       <li><p>If <var>last table</var>'s <span>parent</span> is not null, then return
-       (<var>last table</var>'s <span>parent</span>, <var>last table</var>).</p></li>
+     <!-- if we get here, we know lastTable is not null, but it has no parent, and if lastTemplate
+     is not null, it's older than lastTable. -->
 
-       <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
-       last template, it's older than the last table. -->
-
-       <li><p>Set <var>targetParent</var> to the element immediately above <var>last table</var> in
-       the <span>stack of open elements</span>.</p></li>
-      </ol>
-     </li>
+     <li><p>Otherwise, set <var>targetParent</var> to the element immediately above
+     <var>lastTable</var> in the <span>stack of open elements</span>.</p></li>
     </ol>
 
     <p class="note">These steps are involved in part because it's possible for elements, the

--- a/source
+++ b/source
@@ -144607,12 +144607,17 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <h5>Creating and inserting nodes</h5>
 
+  <p>An <dfn>insertion location</dfn> is a <span>tuple</span> consisting of a <dfn
+  data-x="insertion-location-parent">parent</dfn> (a <code>Node</code>), and a <dfn
+  data-x="insertion-location-ref-child">reference child</dfn> (a <code>Node</code> or null).</p>
+
   <p>While the parser is processing a token, it can enable or disable <dfn data-x="foster
   parent">foster parenting</dfn>. This affects the following algorithm.</p>
 
   <div algorithm>
   <p>The <dfn>appropriate place for inserting a node</dfn>, optionally using a particular
-  <i>override target</i>, is the position in a node returned by running the following steps:</p>
+  <i>override target</i>, is the <span>insertion location</span> returned by running the following
+  steps:</p>
 
   <ol>
    <li>
@@ -144639,35 +144644,36 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
       <ol>
        <li><p>Let <var>last template</var> be the last <code>template</code> element in the
-       <span>stack of open elements</span>, if any.</p>
+       <span>stack of open elements</span>, if any.</p></li>
 
        <li><p>Let <var>last table</var> be the last <code>table</code> element in the
-       <span>stack of open elements</span>, if any.</p>
+       <span>stack of open elements</span>, if any.</p></li>
 
        <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, or there is one, but <var>last template</var> is lower
        (more recently added) than <var>last table</var> in the <span>stack of open
-       elements</span>, then let <var>adjusted insertion location</var> be inside <var>last template</var>'s <span>template contents</span>, after its last child (if any),
-       and abort these steps.</p></li>
+       elements</span>, then let <var>adjusted insertion location</var> be (<var>last
+       template</var>'s <span>template contents</span>, null), and abort these steps.</p></li>
 
        <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
        template, since we didn't hit the previous step --> then let <var>adjusted insertion
-       location</var> be inside the first element in the <span>stack of open elements</span> (the
-       <code>html</code> element), after its last child (if any), and abort these steps.
-       (<span>fragment case</span>)</p>
+       location</var> be (the first element in the <span>stack of open elements</span> (the
+       <code>html</code> element), null), and abort these steps.
+       (<span>fragment case</span>)</p></li>
 
        <!-- if we get here, we know there's a last table, and if there's a last template, it's older
        than the last table. -->
 
-       <li><p>If <var>last table</var> has a parent node, then let <var>adjusted insertion location</var> be inside <var>last table</var>'s parent
-       node, immediately before <var>last table</var>, and abort these steps.</p></li>
+       <li><p>If <var>last table</var> has a parent node, then let
+       <var>adjusted insertion location</var> be (<var>last table</var>'s <span>parent</span>,
+       <var>last table</var>), and abort these steps.</p></li>
 
        <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
        last template, it's older than the last table. -->
 
        <li><p>Let <var>previous element</var> be the element immediately above <var>last table</var> in the <span>stack of open elements</span>.</p></li>
 
-       <li><p>Let <var>adjusted insertion location</var> be inside <var>previous
-       element</var>, after its last child (if any).</p></li>
+       <li><p>Let <var>adjusted insertion location</var> be (<var>previous element</var>,
+       null).</p></li>
       </ol>
 
       <p class="note">These steps are involved in part because it's possible for elements, the
@@ -144679,46 +144685,45 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <dt>Otherwise</dt>
 
      <dd>
-      <p>Let <var>adjusted insertion location</var> be inside <var>target</var>,
-      after its last child (if any).</p>
+      <p>Let <var>adjusted insertion location</var> be (<var>target</var>, null).</p>
      </dd>
     </dl>
    </li>
 
+   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be
+   <var>adjusted insertion location</var>.</p></li>
+
    <li>
-    <p>If <var>adjusted insertion location</var> is inside a <code>template</code> element:</p>
+    <p>If <var>targetParent</var> is a <code>template</code> element:</p>
 
     <ol>
-     <li><p>Let <var>template</var> be that element.</p></li>
-
-     <li><p>Let <var>target</var> be <var>template</var>'s <span>insertion target</span>.</p></li>
+     <li><p>Let <var>target</var> be <var>targetParent</var>'s <span>insertion target</span>.</p></li>
 
      <li>
       <p>If <var>target</var> is not null:</p>
 
       <ol>
        <li>
-        <p>If <var>template</var>'s <span>insertion end marker</span> is not null and its
+        <p>If <var>targetParent</var>'s <span>insertion end marker</span> is not null and its
         <span>parent</span> is <var>target</var>, then set <var>adjusted insertion location</var> to
-        inside <var>target</var>, before <var>template</var>'s <span>insertion end
-        marker</span>.</p>
+        (<var>target</var>, <var>targetParent</var>'s <span>insertion end marker</span>).</p>
 
         <p class="note">If the end marker has been removed or moved to another node, nodes are
         instead appended to <var>target</var> in the following step.</p>
        </li>
 
-       <li><p>Otherwise, set <var>adjusted insertion location</var> to inside <var>target</var>,
-       after its last child (if any).</p></li>
+       <li><p>Otherwise, set <var>adjusted insertion location</var> to (<var>target</var>,
+       null).</p></li>
       </ol>
      </li>
 
-     <li><p>Otherwise, set <var>adjusted insertion location</var> to inside <var>template</var>'s
-     <span>template contents</span>, after its last child (if any).</p></li>
+     <li><p>Otherwise, set <var>adjusted insertion location</var> to (<var>targetParent</var>'s
+     <span>template contents</span>, null).</p></li>
     </ol>
    </li>
 
    <li>
-    <p>Return the <var>adjusted insertion location</var>.</p>
+    <p>Return <var>adjusted insertion location</var>.</p>
    </li>
   </ol>
   </div>
@@ -144848,22 +144853,22 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   </div>
 
   <div algorithm>
-  <p>To compute the <dfn>adjusted insertion location</dfn> with an optional insertion location
-  <var>insertionLocation</var> (default null):</p>
+  <p>To compute the <dfn>adjusted insertion location</dfn> with an optional <span>insertion
+  location</span> <var>insertionLocation</var> (default null):</p>
 
   <ol>
    <li><p>Let <var>overrideTarget</var> be null if <var>insertionLocation</var> is null;
-   otherwise the node in which <var>insertionLocation</var> finds itself.</p></li>
+   otherwise <var>insertionLocation</var>[0].</p></li>
 
    <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting
    a node</span> given <var>overrideTarget</var>.</p></li>
 
-   <li><p>If the node in which the <var>adjustedInsertionLocation</var> finds itself is the first
-   element in the <span>stack of open elements</span> and the parser's <span>root insertion
-   target</span> is non-null, then set the <var>adjustedInsertionLocation</var> to the parser's
-   <span>root insertion target</span>, after its last child (if any).</p></li>
+   <li><p>If <var>adjustedInsertionLocation</var>[0] is the first element in the <span>stack of open
+   elements</span> and the parser's <span>root insertion target</span> is non-null, then set the
+   <var>adjustedInsertionLocation</var> to (the parser's <span>root insertion target</span>,
+   null).</p></li>
 
-   <li><p>Return the <var>adjustedInsertionLocation</var>.</p></li>
+   <li><p>Return <var>adjustedInsertionLocation</var>.</p></li>
   </ol>
   </div>
 
@@ -144871,15 +144876,15 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <div algorithm>
   <p>To <dfn>insert an element at the adjusted insertion location</dfn> with an element
-  <var>element</var> and an optional insertion location <var>insertionLocation</var> (default
-  null):</p>
+  <var>element</var> and an optional <span>insertion location</span> <var>insertionLocation</var>
+  (default null):</p>
 
   <ol>
    <li><p>Set <var>insertionLocation</var> to the <span>adjusted insertion location</span> given
    <var>insertionLocation</var>.</p></li>
 
-   <li><p>Let <var>target</var> be the node in which <var>insertionLocation</var> finds
-   itself.</p></li>
+   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be
+   <var>insertionLocation</var>.</p></li>
 
    <li>
     <p>If any of the following are true:</p>
@@ -144888,22 +144893,26 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <li><var>element</var>'s <span>parent</span> is non-null;</li>
 
      <li><var>element</var> is a <span>host-including inclusive ancestor</span> of
-     <var>target</var>; or</li>
+     <var>targetParent</var>; or</li>
 
-     <li><var>target</var> is a <code>Document</code> node that already has an element child,</li>
+     <li><var>targetParent</var> is a <code>Document</code> node that already has an element
+     child,</li>
     </ul>
 
     <p>then return.</p>
    </li>
 
    <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given <var>element</var>,
-   <var>target</var>, null, and « » does not throw.</p></li>
+   <var>targetParent</var>, <var>referenceChild</var>, and « » does not throw.</p></li>
 
    <li><p>If the parser was not created as part of the <span>HTML fragment parsing
    algorithm</span>, then push a new <span>element queue</span> onto <var>element</var>'s
    <span>relevant agent</span>'s <span>custom element reactions stack</span>.</p></li>
 
-   <li><p>Insert <var>element</var> at <var>insertionLocation</var>.</p></li>
+   <li><p>If <var>referenceChild</var> is null, then <span data-x="concept-node-append">append</span>
+   <var>element</var> to <var>targetParent</var>; otherwise <span
+   data-x="concept-node-insert">insert</span> <var>element</var> into <var>targetParent</var> before
+   <var>referenceChild</var>.</p></li>
 
    <li><p>If the parser was not created as part of the <span>HTML fragment parsing
    algorithm</span>, then pop the <span>element queue</span> from <var>element</var>'s
@@ -144928,10 +144937,11 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
    <li><p>Let <var>element</var> be the result of <span data-x="create an element for the
    token">creating an element for the token</span> given <var>token</var>, <var>namespace</var>,
-   and the node in which the <var>adjustedInsertionLocation</var> finds itself.</p></li>
+   and <var>adjustedInsertionLocation</var>[0].</p></li>
 
    <li><p>If <var>onlyAddToElementStack</var> is false, then run <span>insert an element at the
-   adjusted insertion location</span> with <var>element</var>.</p></li>
+   adjusted insertion location</span> with <var>element</var> and
+   <var>adjustedInsertionLocation</var>.</p></li>
 
    <li><p>Push <var>element</var> onto the <span>stack of open elements</span> so that it is the new
    <span>current node</span>.</p></li>
@@ -145062,24 +145072,30 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <li><p>Let <var>data</var> be the characters passed to the algorithm, or, if no characters were
    explicitly specified, the character of the character token being processed.</p></li>
 
-   <li><p>Let <var>insertionLocation</var> be the <span>adjusted insertion location</span>.</p></li>
+   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be the <span>adjusted insertion
+   location</span>.</p></li>
 
    <li>
-    <p>If <var>insertionLocation</var> is in a <code>Document</code> node, then return.</p>
+    <p>If <var>targetParent</var> is a <code>Document</code> node, then return.</p>
 
     <p class="note">The DOM will not let <code>Document</code> nodes have <code>Text</code> node
     children, so they are dropped on the floor.</p>
    </li>
 
+   <li><p>Let <var>previousSibling</var> be <var>referenceChild</var>'s <span>previous sibling</span> if
+   <var>referenceChild</var> is non-null; otherwise <var>targetParent</var>'s <span>last
+   child</span>.</p></li>
+
    <li>
-    <p>If there is a <code>Text</code> node immediately before <var>insertionLocation</var>, then
-    append <var>data</var> to that <code>Text</code> node's <span
-    data-x="concept-cd-data">data</span>.</p>
+    <p>If <var>previousSibling</var> is a <code>Text</code> node, then append <var>data</var> to
+    <var>previousSibling</var>'s <span data-x="concept-cd-data">data</span>.</p>
 
     <p>Otherwise, let <var>text</var> be the result of <span data-x="create a text node">creating a
-    text node</span> given the <span>node document</span> of the node in which
-    <var>insertionLocation</var> finds itself and <var>data</var>, and insert <var>text</var> at
-    <var>insertionLocation</var>.</p>
+    text node</span> given <var>targetParent</var>'s <span>node document</span> and <var>data</var>,
+    and, if <var>referenceChild</var> is null, <span data-x="concept-node-append">append</span>
+    <var>text</var> to <var>targetParent</var>; otherwise <span
+    data-x="concept-node-insert">insert</span> <var>text</var> into <var>targetParent</var> before
+    <var>referenceChild</var>.</p>
    </li>
   </ol>
   </div>
@@ -145130,27 +145146,30 @@ document.body.appendChild(text);
 
   <div algorithm>
   <p>When the steps below require the user agent to <dfn>insert a comment</dfn> while processing a
-  comment token, with an optional insertion location <var>insertionLocation</var> (default null),
-  the user agent must run the following steps:</p>
+  comment token, with an optional <span>insertion location</span> <var>insertionLocation</var>
+  (default null), the user agent must run the following steps:</p>
 
   <ol>
    <li><p>Let <var>data</var> be the data given in the comment token being
    processed.</p></li>
 
-   <li><p>Set <var>insertionLocation</var> to the <span>adjusted insertion location</span> given
-   <var>insertionLocation</var>.</p></li>
+   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be the <span>adjusted insertion
+   location</span> given <var>insertionLocation</var>.</p></li>
 
    <li><p>Let <var>comment</var> be the result of <span data-x="create a comment node">creating a
-   comment node</span> given the <span>node document</span> of the node in which the
-   <var>insertionLocation</var> finds itself and <var>data</var>.</p>
+   comment node</span> given <var>targetParent</var>'s <span>node document</span> and
+   <var>data</var>.</p></li>
 
-   <li><p>Insert <var>comment</var> at <var>insertionLocation</var>.</p></li>
+   <li><p>If <var>referenceChild</var> is null, then <span data-x="concept-node-append">append</span>
+   <var>comment</var> to <var>targetParent</var>; otherwise <span
+   data-x="concept-node-insert">insert</span> <var>comment</var> into <var>targetParent</var> before
+   <var>referenceChild</var>.</p></li>
   </ol>
   </div>
 
   <div algorithm>
   <p>When the steps below require the user agent to <dfn>insert a processing instruction</dfn> while
-  processing a processing instruction token, with an optional insertion location
+  processing a processing instruction token, with an optional <span>insertion location</span>
   <var>insertionLocation</var> (default null), the user agent must run the following steps:</p>
 
   <ol>
@@ -145160,15 +145179,17 @@ document.body.appendChild(text);
    <li><p>Let <var>data</var> be the data given in the processing instruction token being
    processed.</p></li>
 
-   <li><p>Set <var>insertionLocation</var> to the <span>adjusted insertion location</span> given
-   <var>insertionLocation</var>.</p></li>
+   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be the <span>adjusted insertion
+   location</span> given <var>insertionLocation</var>.</p></li>
 
    <li><p>Let <var>pi</var> be the result of <span data-x="create a processing instruction
-   node">creating a processing instruction node</span> given the <span>node document</span> of the
-   node in which the <var>insertionLocation</var> finds itself, <var>target</var>, and
-   <var>data</var>.</p>
+   node">creating a processing instruction node</span> given <var>targetParent</var>'s <span>node
+   document</span>, <var>target</var>, and <var>data</var>.</p></li>
 
-   <li><p>Insert <var>pi</var> at <var>insertionLocation</var>.</p></li>
+   <li><p>If <var>referenceChild</var> is null, then <span data-x="concept-node-append">append</span>
+   <var>pi</var> to <var>targetParent</var>; otherwise <span
+   data-x="concept-node-insert">insert</span> <var>pi</var> into <var>targetParent</var> before
+   <var>referenceChild</var>.</p></li>
   </ol>
   </div>
 
@@ -145672,8 +145693,8 @@ document.body.appendChild(text);
      scripts inserted via <code data-x="dom-document-write">document.write()</code> under slow
      network conditions, or when the page has already taken a long time to load.)</p></li>
 
-     <li><p>Insert the newly created element at the <span>adjusted insertion location</span> given
-     <var>adjustedInsertionLocation</var>.</p></li>
+     <li><p><span>Insert an element at the adjusted insertion location</span> with the
+     newly created element and <var>adjustedInsertionLocation</var>.</p></li>
 
      <li><p>Push the element onto the <span>stack of open elements</span> so that it is the new
      <span>current node</span>.</p></li>
@@ -147349,18 +147370,10 @@ document.body.appendChild(text);
       </ol>
      </li>
 
-     <li><p>Let <var>insertionLocation</var> be <var>commonAncestor</var>, after its last child, if
-     any.</p></li>
-
      <li><p>Let <var>adjustedInsertionLocation</var> be the <span>adjusted insertion location</span>
-     given <var>insertionLocation</var>.</p></li>
+     given (<var>commonAncestor</var>, null).</p></li>
 
-     <li><p>Let <var>target</var> be the node in which <var>adjustedInsertionLocation</var> finds
-     itself.</p></li>
-
-     <li><p>Let <var>refNode</var> be the node <var>adjustedInsertionLocation</var> is immediately
-     before, or null if <var>adjustedInsertionLocation</var> is after <var>target</var>'s last
-     child.</p></li>
+     <li><p>Let (<var>target</var>, <var>refNode</var>) be <var>adjustedInsertionLocation</var>.</p></li>
 
      <li><p>If <var>lastNode</var>'s <span>parent</span> is non-null, then <span
      data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p></li>
@@ -147391,7 +147404,10 @@ document.body.appendChild(text);
        <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given
        <var>lastNode</var>, <var>target</var>, <var>refNode</var>, and « » does not throw.</p></li>
 
-       <li><p>Insert <var>lastNode</var> at <var>adjustedInsertionLocation</var>.</p></li>
+       <li><p>If <var>refNode</var> is null, then <span data-x="concept-node-append">append</span>
+       <var>lastNode</var> to <var>target</var>; otherwise <span
+       data-x="concept-node-insert">insert</span> <var>lastNode</var> into <var>target</var> before
+       <var>refNode</var>.</p></li>
       </ol>
      </li>
 
@@ -147401,7 +147417,13 @@ document.body.appendChild(text);
      <li><p>Take all of the child nodes of <var>furthestBlock</var> and append them to the
      element created in the last step.</p></li>
 
-     <li><p>Append that new element to <var>furthestBlock</var>.</p></li>
+     <li><p>Let (<var>furthestBlockTarget</var>, <var>furthestBlockRefNode</var>) be the
+     <span>adjusted insertion location</span> given (<var>furthestBlock</var>, null).</p></li>
+
+     <li><p>If <var>furthestBlockRefNode</var> is null, then <span
+     data-x="concept-node-append">append</span> the element created in the previous steps to
+     <var>furthestBlockTarget</var>; otherwise <span data-x="concept-node-insert">insert</span> the
+     element into <var>furthestBlockTarget</var> before <var>furthestBlockRefNode</var>.</p></li>
 
      <li><p>Remove <var>formattingElement</var> from the <span>list of active formatting
      elements</span>, and insert the new element into the <span>list of active formatting

--- a/source
+++ b/source
@@ -144640,25 +144640,31 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
      <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, or
      there is one, but <var>last template</var> is lower (more recently added) than
-     <var>last table</var> in the <span>stack of open elements</span>, then return
-     (<var>last template</var>'s <span>template contents</span>, null).</p></li>
+     <var>last table</var> in the <span>stack of open elements</span>, then set
+     <var>targetParent</var> to <var>last template</var>.</p></li>
 
-     <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
-     template, since we didn't hit the previous step --> then return (the first element in the
-     <span>stack of open elements</span> (the <code>html</code> element), null).
-     (<span>fragment case</span>)</p></li>
+     <li>
+      <p>Otherwise:</p>
+      
+      <ol>
+       <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
+       template, since we didn't hit the previous step --> then return (the first element in the
+       <span>stack of open elements</span> (the <code>html</code> element), null).
+       (<span>fragment case</span>)</p></li>
 
-     <!-- if we get here, we know there's a last table, and if there's a last template, it's older
-     than the last table. -->
+       <!-- if we get here, we know there's a last table, and if there's a last template, it's older
+       than the last table. -->
 
-     <li><p>If <var>last table</var>'s <span>parent</span> is not null, then return
-     (<var>last table</var>'s <span>parent</span>, <var>last table</var>).</p></li>
+       <li><p>If <var>last table</var>'s <span>parent</span> is not null, then return
+       (<var>last table</var>'s <span>parent</span>, <var>last table</var>).</p></li>
 
-     <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
-     last template, it's older than the last table. -->
+       <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
+       last template, it's older than the last table. -->
 
-     <li><p>Set <var>targetParent</var> to the element immediately above <var>last table</var> in
-     the <span>stack of open elements</span>.</p></li>
+       <li><p>Set <var>targetParent</var> to the element immediately above <var>last table</var> in
+       the <span>stack of open elements</span>.</p></li>
+      </ol>
+     </li>
     </ol>
 
     <p class="note">These steps are involved in part because it's possible for elements, the

--- a/source
+++ b/source
@@ -144638,7 +144638,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <li><p>Let <var>last table</var> be the last <code>table</code> element in the
      <span>stack of open elements</span>, if any.</p></li>
 
-     <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, o
+     <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, or
      there is one, but <var>last template</var> is lower (more recently added) than
      <var>last table</var> in the <span>stack of open elements</span>, then return
      (<var>last template</var>'s <span>template contents</span>, null).</p></li>

--- a/source
+++ b/source
@@ -145216,12 +145216,13 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code> object, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code> object,
+    null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>
@@ -145364,12 +145365,13 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code> object, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code> object,
+    null).</p>
    </dd>
 
    <dt>A character token that is one of U+0009 CHARACTER TABULATION, U+000A LINE FEED (LF), U+000C
@@ -148622,12 +148624,13 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code> object, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code> object,
+    null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>
@@ -148664,12 +148667,13 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code> object, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code> object,
+    null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>

--- a/source
+++ b/source
@@ -144844,11 +144844,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   (default null):</p>
 
   <ol>
-   <li><p>Set <var>insertionLocation</var> to the <span>adjusted insertion location</span> given
-   <var>insertionLocation</var>.</p></li>
-
-   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be
-   <var>insertionLocation</var>.</p></li>
+   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be the <span>adjusted insertion
+   location</span> given <var>insertionLocation</var>.</p></li>
 
    <li>
     <p>If any of the following are true:</p>
@@ -144892,8 +144889,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   <var>namespace</var>, and a boolean <var>onlyAddToElementStack</var>:</p>
 
   <ol>
-   <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting
-   a node</span>.</p></li>
+   <li><p>Let <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting a
+   node</span>.</p></li>
 
    <!-- this insertion stuff should be cleaned up: https://github.com/whatwg/html/issues/1706 -->
 
@@ -145131,7 +145128,7 @@ document.body.appendChild(text);
   <var>insertionLocation</var> (default null), the user agent must run the following steps:</p>
 
   <ol>
-   <li><p>Let <var>target</var> be the target given in the processing instruction token being
+   <li><p>Let <var>piTarget</var> be the target given in the processing instruction token being
    processed.</p></li>
 
    <li><p>Let <var>data</var> be the data given in the processing instruction token being
@@ -145142,7 +145139,7 @@ document.body.appendChild(text);
 
    <li><p>Let <var>pi</var> be the result of <span data-x="create a processing instruction
    node">creating a processing instruction node</span> given <var>targetParent</var>'s <span>node
-   document</span>, <var>target</var>, and <var>data</var>.</p></li>
+   document</span>, <var>piTarget</var>, and <var>data</var>.</p></li>
 
    <li><p><span data-x="concept-node-insert">Insert</span> <var>pi</var> into
    <var>targetParent</var> before <var>referenceChild</var>.</p></li>
@@ -145608,7 +145605,7 @@ document.body.appendChild(text);
     <p>Run these steps:</p>
 
     <ol>
-     <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for
+     <li><p>Let <var>adjustedInsertionLocation</var> be the <span>appropriate place for
      inserting a node</span>.</p></li>
 
      <li><p><span>Create an element for the token</span> in the <span>HTML namespace</span>, with
@@ -145696,7 +145693,7 @@ document.body.appendChild(text);
      <span>stack of template insertion modes</span> so that it is the new <span>current template
      insertion mode</span>.</p></li>
 
-     <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for
+     <li><p>Let <var>adjustedInsertionLocation</var> be the <span>appropriate place for
      inserting a node</span>.</p></li>
 
      <li>
@@ -147324,10 +147321,8 @@ document.body.appendChild(text);
       </ol>
      </li>
 
-     <li><p>Let <var>adjustedInsertionLocation</var> be the <span>adjusted insertion location</span>
-     given (<var>commonAncestor</var>, null).</p></li>
-
-     <li><p>Let (<var>target</var>, <var>refNode</var>) be <var>adjustedInsertionLocation</var>.</p></li>
+     <li><p>Let (<var>target</var>, <var>refNode</var>) be the <span>adjusted insertion
+     location</span> given (<var>commonAncestor</var>, null).</p></li>
 
      <li><p>If <var>lastNode</var>'s <span>parent</span> is non-null, then <span
      data-x="concept-node-remove">remove</span> <var>lastNode</var>.</p></li>

--- a/source
+++ b/source
@@ -144646,9 +144646,10 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <span>stack of open elements</span>, then set <var>targetParent</var> to
      <var>lastTemplate</var>.</p></li>
 
-     <li><p>Otherwise, if <var>lastTable</var> is null, <!-- lastTemplate is then null as well, since
-     we didn't hit the previous step --> then return (the first element in the <span>stack of open
-     elements</span> (the <code>html</code> element), null). (<span>fragment case</span>)</p></li>
+     <li><p>Otherwise, if <var>lastTable</var> is null, <!-- lastTemplate is then null as well,
+     since we didn't hit the previous step --> then return (the first element in the <span>stack of
+     open elements</span> (the <code>html</code> element), null).
+     (<span>fragment case</span>)</p></li>
 
      <!-- if we get here, we know lastTable is not null, and if lastTemplate is not null, it's older
      than lastTable. -->
@@ -144826,8 +144827,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    otherwise <var>insertionLocation</var>'s <span
    data-x="insertion-location-target-parent">target parent</span>.</p></li>
 
-   <li><p>Let <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting
-   a node</span> given <var>overrideTarget</var>.</p></li>
+   <li><p>Let <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting a
+   node</span> given <var>overrideTarget</var>.</p></li>
 
    <li><p>If <var>adjustedInsertionLocation</var>'s <span
    data-x="insertion-location-target-parent">target parent</span> is the first element in the
@@ -145647,8 +145648,8 @@ document.body.appendChild(text);
      scripts inserted via <code data-x="dom-document-write">document.write()</code> under slow
      network conditions, or when the page has already taken a long time to load.)</p></li>
 
-     <li><p><span>Insert an element at the adjusted insertion location</span> with the
-     newly created element and <var>adjustedInsertionLocation</var>.</p></li>
+     <li><p><span>Insert an element at the adjusted insertion location</span> with the newly created
+     element and <var>adjustedInsertionLocation</var>.</p></li>
 
      <li><p>Push the element onto the <span>stack of open elements</span> so that it is the new
      <span>current node</span>.</p></li>

--- a/source
+++ b/source
@@ -144620,12 +144620,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   steps:</p>
 
   <ol>
-   <li>
-    <p>If there was an <i>override target</i> specified, then let <var>targetParent</var> be the
-    <i>override target</i>.</p>
-
-    <p>Otherwise, let <var>targetParent</var> be the <span>current node</span>.</p>
-   </li>
+   <li><p>Let <var>targetParent</var> be <i>override target</i> if it was given; otherwise the
+   <span>current node</span>.</p></li>
 
    <li>
     <p>If <span data-x="foster parent">foster parenting</span> is enabled and

--- a/source
+++ b/source
@@ -147387,13 +147387,7 @@ document.body.appendChild(text);
      <li><p>Take all of the child nodes of <var>furthestBlock</var> and append them to the
      element created in the last step.</p></li>
 
-     <li><p>Let (<var>furthestBlockTarget</var>, <var>furthestBlockRefNode</var>) be the
-     <span>adjusted insertion location</span> given (<var>furthestBlock</var>, null).</p></li>
-
-     <li><p>If <var>furthestBlockRefNode</var> is null, then <span
-     data-x="concept-node-append">append</span> the element created in the previous steps to
-     <var>furthestBlockTarget</var>; otherwise <span data-x="concept-node-insert">insert</span> the
-     element into <var>furthestBlockTarget</var> before <var>furthestBlockRefNode</var>.</p></li>
+     <li><p>Append that new element to <var>furthestBlock</var>.</p></li>
 
      <li><p>Remove <var>formattingElement</var> from the <span>list of active formatting
      elements</span>, and insert the new element into the <span>list of active formatting

--- a/source
+++ b/source
@@ -144621,110 +144621,76 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <ol>
    <li>
-    <p>If there was an <i>override target</i> specified, then let <var>target</var> be the
+    <p>If there was an <i>override target</i> specified, then let <var>targetParent</var> be the
     <i>override target</i>.</p>
 
-    <p>Otherwise, let <var>target</var> be the <span>current node</span>.</p>
+    <p>Otherwise, let <var>targetParent</var> be the <span>current node</span>.</p>
    </li>
 
    <li>
-    <p>Determine the <var>adjusted insertion location</var> using the first matching steps
-    from the following list:</p>
+    <p>If <span data-x="foster parent">foster parenting</span> is enabled and
+    <var>targetParent</var> is a <code>table</code>, <code>tbody</code>, <code>tfoot</code>,
+    <code>thead</code>, or <code>tr</code> element:</p> <!-- same list as handling of characters
+    in "in table" mode -->
 
-    <dl class="switch">
-
-     <dt>If <span data-x="foster parent">foster parenting</span> is enabled and <var>target</var> is a <code>table</code>, <code>tbody</code>, <code>tfoot</code>,
-     <code>thead</code>, or <code>tr</code> element</dt> <!-- same list as handling of characters
-     in "in table" mode -->
-
-     <dd>
-      <p class="note">Foster parenting happens when content is misnested in tables.</p>
-
-      <p>Run these substeps:</p>
-
-      <ol>
-       <li><p>Let <var>last template</var> be the last <code>template</code> element in the
-       <span>stack of open elements</span>, if any.</p></li>
-
-       <li><p>Let <var>last table</var> be the last <code>table</code> element in the
-       <span>stack of open elements</span>, if any.</p></li>
-
-       <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, or there is one, but <var>last template</var> is lower
-       (more recently added) than <var>last table</var> in the <span>stack of open
-       elements</span>, then return (<var>last template</var>'s <span>template contents</span>,
-       null).</p></li>
-
-       <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
-       template, since we didn't hit the previous step --> then let <var>adjusted insertion
-       location</var> be (the first element in the <span>stack of open elements</span> (the
-       <code>html</code> element), null), and abort these steps.
-       (<span>fragment case</span>)</p></li>
-
-       <!-- if we get here, we know there's a last table, and if there's a last template, it's older
-       than the last table. -->
-
-       <li><p>If <var>last table</var> has a parent node, then let
-       <var>adjusted insertion location</var> be (<var>last table</var>'s <span>parent</span>,
-       <var>last table</var>), and abort these steps.</p></li>
-
-       <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
-       last template, it's older than the last table. -->
-
-       <li><p>Let <var>previous element</var> be the element immediately above <var>last table</var> in the <span>stack of open elements</span>.</p></li>
-
-       <li><p>Let <var>adjusted insertion location</var> be (<var>previous element</var>,
-       null).</p></li>
-      </ol>
-
-      <p class="note">These steps are involved in part because it's possible for elements, the
-      <code>table</code> element in this case in particular, to have been moved by a script around
-      in the DOM, or indeed removed from the DOM entirely, after the element was inserted by the
-      parser.</p>
-     </dd>
-
-     <dt>Otherwise</dt>
-
-     <dd>
-      <p>Let <var>adjusted insertion location</var> be (<var>target</var>, null).</p>
-     </dd>
-    </dl>
-   </li>
-
-   <li><p>Let (<var>targetParent</var>, <var>referenceChild</var>) be
-   <var>adjusted insertion location</var>.</p></li>
-
-   <li>
-    <p>If <var>targetParent</var> is a <code>template</code> element:</p>
+    <p class="note">Foster parenting happens when content is misnested in tables.</p>
 
     <ol>
-     <li><p>Let <var>target</var> be <var>targetParent</var>'s <span>insertion target</span>.</p></li>
+     <li><p>Let <var>last template</var> be the last <code>template</code> element in the
+     <span>stack of open elements</span>, if any.</p></li>
 
-     <li>
-      <p>If <var>target</var> is not null:</p>
+     <li><p>Let <var>last table</var> be the last <code>table</code> element in the
+     <span>stack of open elements</span>, if any.</p></li>
 
-      <ol>
-       <li>
-        <p>If <var>targetParent</var>'s <span>insertion end marker</span> is not null and its
-        <span>parent</span> is <var>target</var>, then set <var>adjusted insertion location</var> to
-        (<var>target</var>, <var>targetParent</var>'s <span>insertion end marker</span>).</p>
+     <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>,
+     or there is one, but <var>last template</var> is lower (more recently added) than
+     <var>last table</var> in the <span>stack of open elements</span>, then return
+     (<var>last template</var>'s <span>template contents</span>, null).</p></li>
 
-        <p class="note">If the end marker has been removed or moved to another node, nodes are
-        instead appended to <var>target</var> in the following step.</p>
-       </li>
+     <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
+     template, since we didn't hit the previous step --> then return (the first element in the
+     <span>stack of open elements</span> (the <code>html</code> element), null).
+     (<span>fragment case</span>)</p></li>
 
-       <li><p>Otherwise, set <var>adjusted insertion location</var> to (<var>target</var>,
-       null).</p></li>
-      </ol>
-     </li>
+     <!-- if we get here, we know there's a last table, and if there's a last template, it's older
+     than the last table. -->
 
-     <li><p>Otherwise, set <var>adjusted insertion location</var> to (<var>targetParent</var>'s
-     <span>template contents</span>, null).</p></li>
+     <li><p>If <var>last table</var>'s <span>parent</span> is not null, then return
+     (<var>last table</var>'s <span>parent</span>, <var>last table</var>).</p></li>
+
+     <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
+     last template, it's older than the last table. -->
+
+     <li><p>Set <var>targetParent</var> to the element immediately above <var>last table</var>
+     in the <span>stack of open elements</span>.</p></li>
     </ol>
+
+    <p class="note">These steps are involved in part because it's possible for elements, the
+    <code>table</code> element in this case in particular, to have been moved by a script around
+    in the DOM, or indeed removed from the DOM entirely, after the element was inserted by the
+    parser.</p>
    </li>
+
+   <li><p>If <var>targetParent</var> is not a <code>template</code> element, then return
+   (<var>targetParent</var>, null).</p></li>
+
+   <li><p>Let <var>patchInsertionTarget</var> be <var>targetParent</var>'s
+   <span>insertion target</span>.</p></li>
+
+   <li><p>If <var>patchInsertionTarget</var> is null, then return (<var>targetParent</var>'s
+   <span>template contents</span>, null).</p></li>
 
    <li>
-    <p>Return <var>adjusted insertion location</var>.</p>
+    <p>If <var>targetParent</var>'s <span>insertion end marker</span> is not null and its
+    <span>parent</span> is <var>patchInsertionTarget</var>, then return
+    (<var>patchInsertionTarget</var>, <var>targetParent</var>'s
+    <span>insertion end marker</span>).</p>
+
+    <p class="note">If the end marker has been removed or moved to another node, nodes are
+    instead appended to <var>patchInsertionTarget</var> in the following step.</p>
    </li>
+
+   <li><p>Return (<var>patchInsertionTarget</var>, null).</p></li>
   </ol>
   </div>
 

--- a/source
+++ b/source
@@ -144624,6 +144624,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    <li><p>Let <var>targetParent</var> be <var>overrideTarget</var> if it is not null; otherwise the
    <span>current node</span>.</p></li>
 
+   <li><p>Let <var>referenceChild</var> be null.</p></li>
+
    <li>
     <p>If <span data-x="foster parent">foster parenting</span> is enabled and
     <var>targetParent</var> is a <code>table</code>, <code>tbody</code>, <code>tfoot</code>,
@@ -144651,8 +144653,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <!-- if we get here, we know lastTable is not null, and if lastTemplate is not null, it's older
      than lastTable. -->
 
-     <li><p>Otherwise, if <var>lastTable</var>'s <span>parent</span> is not null, then return
-     (<var>lastTable</var>'s <span>parent</span>, <var>lastTable</var>).</p></li>
+     <li><p>Otherwise, if <var>lastTable</var>'s <span>parent</span> is not null, then set
+     <var>targetParent</var> to <var>lastTable</var>'s <span>parent</span> and set
+     <var>referenceChild</var> to <var>lastTable</var>.</p></li>
 
      <!-- if we get here, we know lastTable is not null, but it has no parent, and if lastTemplate
      is not null, it's older than lastTable. -->
@@ -144668,7 +144671,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    </li>
 
    <li><p>If <var>targetParent</var> is not a <code>template</code> element, then return
-   (<var>targetParent</var>, null).</p></li>
+   (<var>targetParent</var>, <var>referenceChild</var>).</p></li>
 
    <li><p>Let <var>patchInsertionTarget</var> be <var>targetParent</var>'s
    <span>insertion target</span>.</p></li>

--- a/source
+++ b/source
@@ -144911,8 +144911,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    data-x="insertion-location-target-parent">target parent</span>.</p></li>
 
    <li><p>If <var>onlyAddToElementStack</var> is false, then run <span>insert an element at the
-   adjusted insertion location</span> with <var>element</var> and
-   <var>adjustedInsertionLocation</var>.</p></li>
+   adjusted insertion location</span> with <var>element</var>.</p></li>
 
    <li><p>Push <var>element</var> onto the <span>stack of open elements</span> so that it is the new
    <span>current node</span>.</p></li>

--- a/source
+++ b/source
@@ -145240,13 +145240,12 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> as the last child of the <code>Document</code> object.</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> as the last child of the <code>Document</code>
-    object.</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>
@@ -145389,13 +145388,12 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> as the last child of the <code>Document</code> object.</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> as the last child of the <code>Document</code>
-    object.</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A character token that is one of U+0009 CHARACTER TABULATION, U+000A LINE FEED (LF), U+000C
@@ -145408,8 +145406,8 @@ document.body.appendChild(text);
    <dd>
     <p><span>Create an element for the token</span> in the <span>HTML namespace</span>, with the
     <code>Document</code> as the intended parent. <span>Insert an element at the adjusted insertion
-    location</span> with that element and the <code>Document</code>, after its last child (if any).
-    Put this element in the <span>stack of open elements</span>.</p>
+    location</span> with that element and (the <code>Document</code>, null). Put this element in the
+    <span>stack of open elements</span>.</p>
 
     <p>Switch the <span>insertion mode</span> to "<span data-x="insertion mode: before head">before
     head</span>".</p>
@@ -148447,14 +148445,14 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> as the last child of the first element in the <span>stack of
-    open elements</span> (the <code>html</code> element).</p>
+    <p><span>Insert a comment</span> given (the first element in the <span>stack of open
+    elements</span> (the <code>html</code> element), null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> as the last child of the first element in the
-    <span>stack of open elements</span> (the <code>html</code> element).</p>
+    <p><span>Insert a processing instruction</span> given (the first element in the <span>stack of
+    open elements</span> (the <code>html</code> element), null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>
@@ -148652,13 +148650,12 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> as the last child of the <code>Document</code> object.</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> as the last child of the <code>Document</code>
-    object.</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>
@@ -148695,13 +148692,12 @@ document.body.appendChild(text);
 
    <dt>A comment token</dt>
    <dd>
-    <p><span>Insert a comment</span> as the last child of the <code>Document</code> object.</p>
+    <p><span>Insert a comment</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A processing instruction token</dt>
    <dd>
-    <p><span>Insert a processing instruction</span> as the last child of the <code>Document</code>
-    object.</p>
+    <p><span>Insert a processing instruction</span> given (the <code>Document</code>, null).</p>
    </dd>
 
    <dt>A DOCTYPE token</dt>

--- a/source
+++ b/source
@@ -144879,10 +144879,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    algorithm</span>, then push a new <span>element queue</span> onto <var>element</var>'s
    <span>relevant agent</span>'s <span>custom element reactions stack</span>.</p></li>
 
-   <li><p>If <var>referenceChild</var> is null, then <span data-x="concept-node-append">append</span>
-   <var>element</var> to <var>targetParent</var>; otherwise <span
-   data-x="concept-node-insert">insert</span> <var>element</var> into <var>targetParent</var> before
-   <var>referenceChild</var>.</p></li>
+   <li><p><span data-x="concept-node-insert">Insert</span> <var>element</var> into
+   <var>targetParent</var> before <var>referenceChild</var>.</p></li>
 
    <li><p>If the parser was not created as part of the <span>HTML fragment parsing
    algorithm</span>, then pop the <span>element queue</span> from <var>element</var>'s
@@ -145052,9 +145050,9 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
     children, so they are dropped on the floor.</p>
    </li>
 
-   <li><p>Let <var>previousSibling</var> be <var>referenceChild</var>'s <span>previous sibling</span> if
-   <var>referenceChild</var> is non-null; otherwise <var>targetParent</var>'s <span>last
-   child</span>.</p></li>
+   <li><p>Let <var>previousSibling</var> be <var>referenceChild</var>'s <span>previous
+   sibling</span> if <var>referenceChild</var> is non-null; otherwise <var>targetParent</var>'s
+   <span>last child</span>.</p></li>
 
    <li>
     <p>If <var>previousSibling</var> is a <code>Text</code> node, then append <var>data</var> to
@@ -145062,10 +145060,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
     <p>Otherwise, let <var>text</var> be the result of <span data-x="create a text node">creating a
     text node</span> given <var>targetParent</var>'s <span>node document</span> and <var>data</var>,
-    and, if <var>referenceChild</var> is null, <span data-x="concept-node-append">append</span>
-    <var>text</var> to <var>targetParent</var>; otherwise <span
-    data-x="concept-node-insert">insert</span> <var>text</var> into <var>targetParent</var> before
-    <var>referenceChild</var>.</p>
+    and <span data-x="concept-node-insert">insert</span> <var>text</var> into
+    <var>targetParent</var> before <var>referenceChild</var>.</p>
    </li>
   </ol>
   </div>
@@ -145130,10 +145126,8 @@ document.body.appendChild(text);
    comment node</span> given <var>targetParent</var>'s <span>node document</span> and
    <var>data</var>.</p></li>
 
-   <li><p>If <var>referenceChild</var> is null, then <span data-x="concept-node-append">append</span>
-   <var>comment</var> to <var>targetParent</var>; otherwise <span
-   data-x="concept-node-insert">insert</span> <var>comment</var> into <var>targetParent</var> before
-   <var>referenceChild</var>.</p></li>
+   <li><p><span data-x="concept-node-insert">Insert</span> <var>comment</var> into
+   <var>targetParent</var> before <var>referenceChild</var>.</p></li>
   </ol>
   </div>
 
@@ -145156,10 +145150,8 @@ document.body.appendChild(text);
    node">creating a processing instruction node</span> given <var>targetParent</var>'s <span>node
    document</span>, <var>target</var>, and <var>data</var>.</p></li>
 
-   <li><p>If <var>referenceChild</var> is null, then <span data-x="concept-node-append">append</span>
-   <var>pi</var> to <var>targetParent</var>; otherwise <span
-   data-x="concept-node-insert">insert</span> <var>pi</var> into <var>targetParent</var> before
-   <var>referenceChild</var>.</p></li>
+   <li><p><span data-x="concept-node-insert">Insert</span> <var>pi</var> into
+   <var>targetParent</var> before <var>referenceChild</var>.</p></li>
   </ol>
   </div>
 
@@ -147372,10 +147364,8 @@ document.body.appendChild(text);
        <li><p><span>Assert</span>: <span>ensure pre-insert validity</span> given
        <var>lastNode</var>, <var>target</var>, <var>refNode</var>, and « » does not throw.</p></li>
 
-       <li><p>If <var>refNode</var> is null, then <span data-x="concept-node-append">append</span>
-       <var>lastNode</var> to <var>target</var>; otherwise <span
-       data-x="concept-node-insert">insert</span> <var>lastNode</var> into <var>target</var> before
-       <var>refNode</var>.</p></li>
+       <li><p><span data-x="concept-node-insert">Insert</span> <var>lastNode</var> into
+       <var>target</var> before <var>refNode</var>.</p></li>
       </ol>
      </li>
 

--- a/source
+++ b/source
@@ -144645,7 +144645,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
      <li>
       <p>Otherwise:</p>
-      
+
       <ol>
        <li><p>If there is no <var>last table</var>, <!-- there's also implicitly no last
        template, since we didn't hit the previous step --> then return (the first element in the

--- a/source
+++ b/source
@@ -144642,8 +144642,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <li><p>Let <var>last table</var> be the last <code>table</code> element in the
      <span>stack of open elements</span>, if any.</p></li>
 
-     <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>,
-     or there is one, but <var>last template</var> is lower (more recently added) than
+     <li><p>If there is a <var>last template</var> and either there is no <var>last table</var>, o
+     there is one, but <var>last template</var> is lower (more recently added) than
      <var>last table</var> in the <span>stack of open elements</span>, then return
      (<var>last template</var>'s <span>template contents</span>, null).</p></li>
 
@@ -144661,13 +144661,13 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
      <!-- if we get here, we know there's a last table, but it has no parent, and if there's a
      last template, it's older than the last table. -->
 
-     <li><p>Set <var>targetParent</var> to the element immediately above <var>last table</var>
-     in the <span>stack of open elements</span>.</p></li>
+     <li><p>Set <var>targetParent</var> to the element immediately above <var>last table</var> in
+     the <span>stack of open elements</span>.</p></li>
     </ol>
 
     <p class="note">These steps are involved in part because it's possible for elements, the
-    <code>table</code> element in this case in particular, to have been moved by a script around
-    in the DOM, or indeed removed from the DOM entirely, after the element was inserted by the
+    <code>table</code> element in this case in particular, to have been moved by a script around in
+    the DOM, or indeed removed from the DOM entirely, after the element was inserted by the
     parser.</p>
    </li>
 

--- a/source
+++ b/source
@@ -141774,7 +141774,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <h5>Other parsing state flags</h5>
 
-  <p>The <dfn>root insertion target</dfn>, which is null or an <span>insertion location</span>
+  <p>The <dfn>root insertion target</dfn>, which is null or a <code>DocumentFragment</code>
   (initially null).</p>
 
   <p>A boolean <dfn>allow declarative shadow roots</dfn> (initially false).</p>
@@ -144830,14 +144830,14 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
    otherwise <var>insertionLocation</var>'s <span
    data-x="insertion-location-target-parent">target parent</span>.</p></li>
 
-   <li><p>Let the <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting
+   <li><p>Let <var>adjustedInsertionLocation</var> be the <span>appropriate place for inserting
    a node</span> given <var>overrideTarget</var>.</p></li>
 
    <li><p>If <var>adjustedInsertionLocation</var>'s <span
    data-x="insertion-location-target-parent">target parent</span> is the first element in the
    <span>stack of open elements</span> and the parser's <span>root insertion target</span> is
-   non-null, then set the <var>adjustedInsertionLocation</var> to the parser's
-   <span>root insertion target</span>.</p></li>
+   non-null, then set <var>adjustedInsertionLocation</var> to (the parser's <span>root insertion
+   target</span>, null).</p></li>
 
    <li><p>Return <var>adjustedInsertionLocation</var>.</p></li>
   </ol>
@@ -150178,8 +150178,7 @@ console.assert(container.firstChild instanceof SuperP);
    a document fragment</span> given <var>target</var>'s <span>node
    document</span>.</p></li>
 
-   <li><p>Set the parser's <span>root insertion target</span> to (<var>fragment</var>,
-   null).</p></li>
+   <li><p>Set the parser's <span>root insertion target</span> to <var>fragment</var>.</p></li>
 
    <li><p>If <var data-x="concept-frag-parse-context">context</var> is a <code>template</code>
    element, then push "<span data-x="insertion mode: in template">in template</span>" onto the


### PR DESCRIPTION
Foster parenting into the last template element on the stack of open elements went straight to its template contents, ignoring that template's insertion target. That loses content for `<template for>`, whose element is never inserted into the DOM: `<table><template for=p><tr><div>` dropped the div on the floor. It now goes to the insertion target, matching the non-foster-parenting path.

To make that expressible, an insertion location is now a (target parent, reference child) tuple rather than a position described in prose, which also lets "appropriate place for inserting a node" return early instead of assigning and aborting, and removes the "the node in which the insertion location finds itself" idiom throughout.

Tests: https://github.com/web-platform-tests/wpt/pull/62217

Partially addresses #1706.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12831/parsing.html" title="Last updated on Aug 26, 2026, 2:33 PM UTC (b429d15)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12831/ca693db...b429d15/parsing.html" title="Last updated on Aug 26, 2026, 2:33 PM UTC (b429d15)">diff</a> )