### PR TITLE
Pass a new "hasPlannedNavigationForWebDriver" flag to the "WebDriver BiDi navigable created" event.

### DIFF
--- a/source
+++ b/source
@@ -35492,22 +35492,15 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
    </li>
 
    <li>
-    <p>If all of the following are true:</p>
+    <p><span>Create a new child navigable</span> given <var>insertedNode</var> and
+    <var>hasImmediateNavigationForWebDriver</var>.</p>
 
-    <ul class="brief">
-     <li><p><var>hasImmediateNavigationForWebDriver</var> is true;</p></li>
-
-     <li><p>the <span>will lazy load element steps</span> given <var>insertedNode</var> return true;
-     and</p></li>
-
-     <li><p><var>insertedNode</var> does not <span>intersect the viewport</span>,</p></li>
-    </ul>
-
-    <p>then set <var>hasImmediateNavigationForWebDriver</var> to false.</p>
+    <p class="note">A lazy-loaded <code>iframe</code> does not start its navigation as part of
+    <span>process the <code>iframe</code> attributes</span>; it registers with the <span>lazy load
+    intersection observer</span> instead. <var>hasImmediateNavigationForWebDriver</var> is still
+    true for such an <code>iframe</code>, as a navigation is pending, but that navigation will not
+    resume unless the <code>iframe</code> comes near the <span>viewport</span>.</p>
    </li>
-
-   <li><p><span>Create a new child navigable</span> given <var>insertedNode</var> and
-   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
 
    <li><p><span>Process the <code>iframe</code> attributes</span> for <var>insertedNode</var>, with
    <i data-x="process-iframe-initial-insertion">initialInsertion</i> set to true.</p></li>

--- a/source
+++ b/source
@@ -27270,8 +27270,9 @@ document.body.appendChild(wbr);</code></pre>
 
    <li><p>If <var>urlRecord</var> is failure, then return.</p></li>
 
-   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>urlRecord</var> does not <span
-   data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+   <li><p>Let <var>hasPlannedNavigationForWebDriver</var> be true if <var>urlRecord</var> does not
+   <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise
+   false.</p></li>
 
    <li><p>Let <var>noopener</var> be the result of <span data-x="get an element's noopener">getting
    an element's noopener</span> with <var>subject</var>, <var>urlRecord</var>, and
@@ -27280,7 +27281,7 @@ document.body.appendChild(wbr);</code></pre>
    <li><p>Let <var>targetNavigable</var> be the first return value of applying <span>the rules for
    choosing a navigable</span> given <var>targetAttributeValue</var>, <var>subject</var>'s
    <span>node navigable</span>, <var>noopener</var>, and
-   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
+   <var>hasPlannedNavigationForWebDriver</var>.</p></li>
 
    <li><p>If <var>targetNavigable</var> is null, then return.</p></li>
 
@@ -35476,7 +35477,7 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
    directive</span> given the attribute's value and <var>insertedNode</var>'s
    <span><code>iframe</code> sandboxing flag set</span>.</p></li>
 
-   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true.</p></li>
+   <li><p>Let <var>hasPlannedNavigationForWebDriver</var> be true.</p></li>
 
    <li>
     <p>If <var>insertedNode</var> does not have a <code
@@ -35487,19 +35488,20 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
      <code>frame</code></span> given <var>insertedNode</var>.</p></li>
 
      <li><p>If <var>url</var> is null or <var>url</var> <span>matches
-     <code>about:blank</code></span>, then set <var>hasImmediateNavigationForWebDriver</var> to false.</p></li>
+     <code>about:blank</code></span>, then set <var>hasPlannedNavigationForWebDriver</var> to
+     false.</p></li>
     </ol>
    </li>
 
    <li>
     <p><span>Create a new child navigable</span> given <var>insertedNode</var> and
-    <var>hasImmediateNavigationForWebDriver</var>.</p>
+    <var>hasPlannedNavigationForWebDriver</var>.</p>
 
     <p class="note">A lazy-loaded <code>iframe</code> does not start its navigation as part of
     <span>process the <code>iframe</code> attributes</span>; it registers with the <span>lazy load
-    intersection observer</span> instead. <var>hasImmediateNavigationForWebDriver</var> is still
-    true for such an <code>iframe</code>, as a navigation is pending, but that navigation will not
-    resume unless the <code>iframe</code> comes near the <span>viewport</span>.</p>
+    intersection observer</span> instead. <var>hasPlannedNavigationForWebDriver</var> is still true
+    for such an <code>iframe</code>, as a navigation is pending, but that navigation will not resume
+    unless the <code>iframe</code> comes near the <span>viewport</span>.</p>
    </li>
 
    <li><p><span>Process the <code>iframe</code> attributes</span> for <var>insertedNode</var>, with
@@ -36959,19 +36961,19 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
         <p>Let <var>response</var> be the <span data-x="concept-response">response</span> from
         <span data-x="concept-fetch">fetch</span>.</p>
 
-        <p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>response</var>'s <span
+        <p>Let <var>hasPlannedNavigationForWebDriver</var> be true if <var>response</var>'s <span
         data-x="concept-response-url">URL</span> does not <span data-x="matches about:blank">match
         <code>about:blank</code></span>; otherwise false.</p>
 
         <p>If the <code>object</code> element's <span>content navigable</span> is null, then
         <span>create a new child navigable</span> given the element and
-        <var>hasImmediateNavigationForWebDriver</var>.</p>
+        <var>hasPlannedNavigationForWebDriver</var>.</p>
 
-        <p>If <var>hasImmediateNavigationForWebDriver</var> is true, then
-        <span>navigate</span><!-- DONAV object --> the element's <span>content navigable</span> to
-        <var>response</var>'s <span data-x="concept-response-url">URL</span> using the element's
-        <span>node document</span>, with <i data-x="navigation-hh">historyHandling</i> set to
-        "<code data-x="NavigationHistoryBehavior-replace">replace</code>".</p>
+        <p>If <var>hasPlannedNavigationForWebDriver</var> is true, then <span>navigate</span><!--
+        DONAV object --> the element's <span>content navigable</span> to <var>response</var>'s <span
+        data-x="concept-response-url">URL</span> using the element's <span>node document</span>,
+        with <i data-x="navigation-hh">historyHandling</i> set to "<code
+        data-x="NavigationHistoryBehavior-replace">replace</code>".</p>
 
         <p class="note">The <code data-x="attr-object-data">data</code> attribute of the
         <code>object</code> element doesn't get updated if the <span>content navigable</span> gets
@@ -64620,8 +64622,9 @@ fur
 
    <li><p>If <var>parsed action</var> is failure, then return.</p></li>
 
-   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>parsed action</var> does not <span
-   data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+   <li><p>Let <var>hasPlannedNavigationForWebDriver</var> be true if <var>parsed action</var> does
+   not <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise
+   false.</p></li>
 
    <li><p>Let <var>scheme</var> be the <span data-x="concept-url-scheme">scheme</span> of
    <var>parsed action</var>.</p></li>
@@ -64646,7 +64649,7 @@ fur
 
    <li><p>Let <var>targetNavigable</var> be the first return value of applying <span>the rules for
    choosing a navigable</span> given <var>target</var>, <var>form</var>'s <span>node
-   navigable</span>, <var>noopener</var>, and <var>hasImmediateNavigationForWebDriver</var>.</p></li>
+   navigable</span>, <var>noopener</var>, and <var>hasPlannedNavigationForWebDriver</var>.</p></li>
 
    <li><p>If <var>targetNavigable</var> is null, then return.</p></li>
 
@@ -97326,15 +97329,15 @@ dictionary <dfn dictionary>WindowPostMessageOptions</dfn> : <span>StructuredSeri
    <li><p>If <var>noreferrer</var> is true, then set <var>noopener</var> to true and set
    <var>referrerPolicy</var> to "<code data-x="">no-referrer</code>".</p></li>
 
-   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>urlRecord</var> is non-null and does
-   not <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise
-   false.</p></li>
+   <li><p>Let <var>hasPlannedNavigationForWebDriver</var> be true if <var>urlRecord</var> is
+   non-null and does not <span data-x="matches about:blank">match <code>about:blank</code></span>;
+   otherwise false.</p></li>
 
    <li>
     <p>Let <var>targetNavigable</var> and <var>windowType</var> be the result of applying <span>the
     rules for choosing a navigable</span> given <var>target</var>, <var>sourceDocument</var>'s
     <span>node navigable</span>, <var>noopener</var>, and
-    <var>hasImmediateNavigationForWebDriver</var>.</p>
+    <var>hasPlannedNavigationForWebDriver</var>.</p>
 
     <p class="example">If there is a user agent that supports control-clicking a link to open it in
     a new tab, and the user control-clicks on an element whose <code
@@ -105311,9 +105314,9 @@ interface <dfn interface>NotRestoredReasons</dfn> {
 
   <div algorithm>
   <p>To <dfn data-x="creating a new top-level traversable">create a new top-level traversable</dfn>
-  given a <span>browsing context</span>-or-null <var>opener</var>, a string
-  <var>targetName</var>, a boolean <var>hasImmediateNavigationForWebDriver</var>, and an optional
-  <span>navigable</span> <var>openerNavigableForWebDriver</var>:</p>
+  given a <span>browsing context</span>-or-null <var>opener</var>, a string <var>targetName</var>, a
+  boolean <var>hasPlannedNavigationForWebDriver</var>, and an optional <span>navigable</span>
+  <var>openerNavigableForWebDriver</var>:</p>
 
   <ol>
    <li><p>Let <var>document</var> be null.</p></li>
@@ -105369,7 +105372,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
    <span>top-level traversable set</span>.</p></li>
 
    <li><p>Invoke <span>WebDriver BiDi navigable created</span> with <var>traversable</var>,
-   <var>hasImmediateNavigationForWebDriver</var>, and <var>openerNavigableForWebDriver</var>.</p></li>
+   <var>hasPlannedNavigationForWebDriver</var>, and <var>openerNavigableForWebDriver</var>.</p></li>
 
    <li><p>Return <var>traversable</var>.</p></li>
   </ol>
@@ -105381,12 +105384,13 @@ interface <dfn interface>NotRestoredReasons</dfn> {
   <var>initialNavigationPostResource</var> (default null):</p>
 
   <ol>
-   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>initialNavigationURL</var> does not
-   <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+   <li><p>Let <var>hasPlannedNavigationForWebDriver</var> be true if <var>initialNavigationURL</var>
+   does not <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise
+   false.</p></li>
 
    <li><p>Let <var>traversable</var> be the result of <span>creating a new top-level
    traversable</span> given null, the empty string, and
-   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
+   <var>hasPlannedNavigationForWebDriver</var>.</p></li>
 
    <li>
     <p><span>Navigate</span> <var>traversable</var> to <var>initialNavigationURL</var> using
@@ -105500,7 +105504,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
 
   <div algorithm>
   <p id="creating-a-new-nested-browsing-context">To <dfn>create a new child navigable</dfn>, given
-  an element <var>element</var> and a boolean <var>hasImmediateNavigationForWebDriver</var>:</p>
+  an element <var>element</var> and a boolean <var>hasPlannedNavigationForWebDriver</var>:</p>
 
   <ol>
    <li><p>Let <var>parentNavigable</var> be <var>element</var>'s <span>node
@@ -105588,7 +105592,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
    </li>
 
    <li><p>Invoke <span>WebDriver BiDi navigable created</span> with <var>navigable</var> and
-   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
+   <var>hasPlannedNavigationForWebDriver</var>.</p></li>
   </ol>
   </div>
 
@@ -106192,10 +106196,10 @@ interface <dfn interface>NotRestoredReasons</dfn> {
   </div>
 
   <div algorithm>
-  <p id="the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name"><dfn>The rules
-  for choosing a navigable</dfn>, given a string <var>name</var>, a <span>navigable</span>
+  <p id="the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name"><dfn>The rules for
+  choosing a navigable</dfn>, given a string <var>name</var>, a <span>navigable</span>
   <var>currentNavigable</var>, a boolean <var>noopener</var>, and a boolean
-  <var>hasImmediateNavigationForWebDriver</var> are as follows:</p>
+  <var>hasPlannedNavigationForWebDriver</var> are as follows:</p>
 
   <ol>
    <li><p>Let <var>chosen</var> be null.</p></li>
@@ -106278,10 +106282,9 @@ interface <dfn interface>NotRestoredReasons</dfn> {
        <li><p>If <var>name</var> is not an <span>ASCII case-insensitive</span> match for "<code
        data-x="">_blank</code>", then set <var>targetName</var> to <var>name</var>.</p></li>
 
-       <li id="noopener"><p>If <var>noopener</var> is true, then set <var>chosen</var> to the
-       result of <span>creating a new top-level traversable</span> given null,
-       <var>targetName</var>, <var>hasImmediateNavigationForWebDriver</var>, and
-       <var>currentNavigable</var>.</p></li>
+       <li id="noopener"><p>If <var>noopener</var> is true, then set <var>chosen</var> to the result
+       of <span>creating a new top-level traversable</span> given null, <var>targetName</var>,
+       <var>hasPlannedNavigationForWebDriver</var>, and <var>currentNavigable</var>.</p></li>
 
        <li>
         <p>Otherwise:</p>
@@ -106289,8 +106292,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
         <ol>
          <li><p>Set <var>chosen</var> to the result of <span>creating a new top-level
          traversable</span> given <var>currentNavigable</var>'s <span data-x="nav-bc">active
-         browsing context</span>, <var>targetName</var>, <var>hasImmediateNavigationForWebDriver</var>, and
-         <var>currentNavigable</var>.</p></li>
+         browsing context</span>, <var>targetName</var>,
+         <var>hasPlannedNavigationForWebDriver</var>, and <var>currentNavigable</var>.</p></li>
 
          <li><p>If <var>sandboxingFlagSet</var>'s <span>sandboxed navigation browsing context
          flag</span> is set, then set <var>chosen</var>'s <span data-x="nav-bc">active browsing
@@ -155303,11 +155306,12 @@ interface <dfn interface>HTMLFrameSetElement</dfn> : <span>HTMLElement</span> {
    <li><p>Let <var>url</var> be the result of <span>getting the URL for an <code>iframe</code> or
    <code>frame</code></span> given <var>insertedNode</var>.</p></li>
 
-   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>url</var> is non-null and does not
-   <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+   <li><p>Let <var>hasPlannedNavigationForWebDriver</var> be true if <var>url</var> is non-null and
+   does not <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise
+   false.</p></li>
 
    <li><p><span>Create a new child navigable</span> given <var>insertedNode</var> and
-   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
+   <var>hasPlannedNavigationForWebDriver</var>.</p></li>
 
    <li><p><span>Process the <code>frame</code> attributes</span> for <var>insertedNode</var>, with
    <i data-x="process-frame-initial-insertion">initialInsertion</i> set to true.</p></li>

--- a/source
+++ b/source
@@ -27270,13 +27270,17 @@ document.body.appendChild(wbr);</code></pre>
 
    <li><p>If <var>urlRecord</var> is failure, then return.</p></li>
 
+   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>urlRecord</var> does not <span
+   data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+
    <li><p>Let <var>noopener</var> be the result of <span data-x="get an element's noopener">getting
    an element's noopener</span> with <var>subject</var>, <var>urlRecord</var>, and
    <var>targetAttributeValue</var>.</p></li>
 
    <li><p>Let <var>targetNavigable</var> be the first return value of applying <span>the rules for
    choosing a navigable</span> given <var>targetAttributeValue</var>, <var>subject</var>'s
-   <span>node navigable</span>, and <var>noopener</var>.</p></li>
+   <span>node navigable</span>, <var>noopener</var>, and
+   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
 
    <li><p>If <var>targetNavigable</var> is null, then return.</p></li>
 
@@ -35472,7 +35476,38 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
    directive</span> given the attribute's value and <var>insertedNode</var>'s
    <span><code>iframe</code> sandboxing flag set</span>.</p></li>
 
-   <li><p><span>Create a new child navigable</span> for <var>insertedNode</var>.</p></li>
+   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true.</p></li>
+
+   <li>
+    <p>If <var>insertedNode</var> does not have a <code
+    data-x="attr-iframe-srcdoc">srcdoc</code> attribute, then:</p>
+
+    <ol>
+     <li><p>Let <var>url</var> be the result of <span>getting the URL for an <code>iframe</code> or
+     <code>frame</code></span> given <var>insertedNode</var>.</p></li>
+
+     <li><p>If <var>url</var> is null or <var>url</var> <span>matches
+     <code>about:blank</code></span>, then set <var>hasImmediateNavigationForWebDriver</var> to false.</p></li>
+    </ol>
+   </li>
+
+   <li>
+    <p>If all of the following are true:</p>
+
+    <ul class="brief">
+     <li><p><var>hasImmediateNavigationForWebDriver</var> is true;</p></li>
+
+     <li><p>the <span>will lazy load element steps</span> given <var>insertedNode</var> return true;
+     and</p></li>
+
+     <li><p><var>insertedNode</var> does not <span>intersect the viewport</span>,</p></li>
+    </ul>
+
+    <p>then set <var>hasImmediateNavigationForWebDriver</var> to false.</p>
+   </li>
+
+   <li><p><span>Create a new child navigable</span> given <var>insertedNode</var> and
+   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
 
    <li><p><span>Process the <code>iframe</code> attributes</span> for <var>insertedNode</var>, with
    <i data-x="process-iframe-initial-insertion">initialInsertion</i> set to true.</p></li>
@@ -35606,9 +35641,8 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
-  <p id="otherwise-steps-for-iframe-or-frame-elements">The <dfn>shared attribute processing steps
-  for <code>iframe</code> and <code>frame</code> elements</dfn>, given an element
-  <var>element</var> and a boolean <var>initialInsertion</var>, are:</p>
+  <p>To <dfn data-x="getting the URL for an iframe or frame">get the URL for an
+  <code>iframe</code> or <code>frame</code></dfn> given an element <var>element</var>:</p>
 
   <ol>
    <li><p>Let <var>url</var> be the <span>URL record</span> <code>about:blank</code>.</p></li>
@@ -35633,6 +35667,21 @@ interface <dfn interface>HTMLIFrameElement</dfn> : <span>HTMLElement</span> {
    fragments">exclude fragments</i> set to true, then return null.</p></li>
    <!-- https://www.hixie.ch/tests/adhoc/html/frames/iframes/ 008.html and 009.html -->
    <!-- https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=1969 -->
+
+   <li><p>Return <var>url</var>.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p id="otherwise-steps-for-iframe-or-frame-elements">The <dfn>shared attribute processing steps
+  for <code>iframe</code> and <code>frame</code> elements</dfn>, given an element
+  <var>element</var> and a boolean <var>initialInsertion</var>, are:</p>
+
+  <ol>
+   <li><p>Let <var>url</var> be the result of <span>getting the URL for an <code>iframe</code> or
+   <code>frame</code></span> given <var>element</var>.</p></li>
+
+   <li><p>If <var>url</var> is null, then return null.</p></li>
 
    <li>
     <p>If <var>url</var> <span>matches <code>about:blank</code></span> and
@@ -36418,7 +36467,7 @@ interface <dfn interface>HTMLEmbedElement</dfn> : <span>HTMLElement</span> {
          <dd>
           <ol>
            <li><p>If <var>element</var>'s <span>content navigable</span> is null, then
-           <span>create a new child navigable</span> for <var>element</var>.</p></li>
+           <span>create a new child navigable</span> given <var>element</var> and true.</p></li>
            <!-- https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=2291 - dynamic changes
                 to 'name' don't do anything -->
 
@@ -36914,14 +36963,18 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
        does not start with "<code data-x="">image/</code>"</dt>
 
        <dd>
-        <p>If the <code>object</code> element's <span>content navigable</span> is null, then
-        <span>create a new child navigable</span> for the element.</p>
-
         <p>Let <var>response</var> be the <span data-x="concept-response">response</span> from
         <span data-x="concept-fetch">fetch</span>.</p>
 
-        <p>If <var>response</var>'s <span data-x="concept-response-url">URL</span> does not <span
-        data-x="matches about:blank">match <code>about:blank</code></span>, then
+        <p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>response</var>'s <span
+        data-x="concept-response-url">URL</span> does not <span data-x="matches about:blank">match
+        <code>about:blank</code></span>; otherwise false.</p>
+
+        <p>If the <code>object</code> element's <span>content navigable</span> is null, then
+        <span>create a new child navigable</span> given the element and
+        <var>hasImmediateNavigationForWebDriver</var>.</p>
+
+        <p>If <var>hasImmediateNavigationForWebDriver</var> is true, then
         <span>navigate</span><!-- DONAV object --> the element's <span>content navigable</span> to
         <var>response</var>'s <span data-x="concept-response-url">URL</span> using the element's
         <span>node document</span>, with <i data-x="navigation-hh">historyHandling</i> set to
@@ -64574,6 +64627,9 @@ fur
 
    <li><p>If <var>parsed action</var> is failure, then return.</p></li>
 
+   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>parsed action</var> does not <span
+   data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+
    <li><p>Let <var>scheme</var> be the <span data-x="concept-url-scheme">scheme</span> of
    <var>parsed action</var>.</p></li>
 
@@ -64597,7 +64653,7 @@ fur
 
    <li><p>Let <var>targetNavigable</var> be the first return value of applying <span>the rules for
    choosing a navigable</span> given <var>target</var>, <var>form</var>'s <span>node
-   navigable</span>, and <var>noopener</var>.</p></li>
+   navigable</span>, <var>noopener</var>, and <var>hasImmediateNavigationForWebDriver</var>.</p></li>
 
    <li><p>If <var>targetNavigable</var> is null, then return.</p></li>
 
@@ -97277,10 +97333,15 @@ dictionary <dfn dictionary>WindowPostMessageOptions</dfn> : <span>StructuredSeri
    <li><p>If <var>noreferrer</var> is true, then set <var>noopener</var> to true and set
    <var>referrerPolicy</var> to "<code data-x="">no-referrer</code>".</p></li>
 
+   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>urlRecord</var> is non-null and does
+   not <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise
+   false.</p></li>
+
    <li>
     <p>Let <var>targetNavigable</var> and <var>windowType</var> be the result of applying <span>the
     rules for choosing a navigable</span> given <var>target</var>, <var>sourceDocument</var>'s
-    <span>node navigable</span>, and <var>noopener</var>.</p>
+    <span>node navigable</span>, <var>noopener</var>, and
+    <var>hasImmediateNavigationForWebDriver</var>.</p>
 
     <p class="example">If there is a user agent that supports control-clicking a link to open it in
     a new tab, and the user control-clicks on an element whose <code
@@ -105258,8 +105319,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
   <div algorithm>
   <p>To <dfn data-x="creating a new top-level traversable">create a new top-level traversable</dfn>
   given a <span>browsing context</span>-or-null <var>opener</var>, a string
-  <var>targetName</var>, and an optional <span>navigable</span>
-  <var>openerNavigableForWebDriver</var>:</p>
+  <var>targetName</var>, a boolean <var>hasImmediateNavigationForWebDriver</var>, and an optional
+  <span>navigable</span> <var>openerNavigableForWebDriver</var>:</p>
 
   <ol>
    <li><p>Let <var>document</var> be null.</p></li>
@@ -105314,8 +105375,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
    <li><p><span data-x="list append">Append</span> <var>traversable</var> to the user agent's
    <span>top-level traversable set</span>.</p></li>
 
-   <li><p>Invoke <span>WebDriver BiDi navigable created</span> with <var>traversable</var>
-   and <var>openerNavigableForWebDriver</var>.</p></li>
+   <li><p>Invoke <span>WebDriver BiDi navigable created</span> with <var>traversable</var>,
+   <var>hasImmediateNavigationForWebDriver</var>, and <var>openerNavigableForWebDriver</var>.</p></li>
 
    <li><p>Return <var>traversable</var>.</p></li>
   </ol>
@@ -105327,8 +105388,12 @@ interface <dfn interface>NotRestoredReasons</dfn> {
   <var>initialNavigationPostResource</var> (default null):</p>
 
   <ol>
+   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>initialNavigationURL</var> does not
+   <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+
    <li><p>Let <var>traversable</var> be the result of <span>creating a new top-level
-   traversable</span> given null and the empty string.</p></li>
+   traversable</span> given null, the empty string, and
+   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
 
    <li>
     <p><span>Navigate</span> <var>traversable</var> to <var>initialNavigationURL</var> using
@@ -105442,7 +105507,7 @@ interface <dfn interface>NotRestoredReasons</dfn> {
 
   <div algorithm>
   <p id="creating-a-new-nested-browsing-context">To <dfn>create a new child navigable</dfn>, given
-  an element <var>element</var>:</p>
+  an element <var>element</var> and a boolean <var>hasImmediateNavigationForWebDriver</var>:</p>
 
   <ol>
    <li><p>Let <var>parentNavigable</var> be <var>element</var>'s <span>node
@@ -105529,7 +105594,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
     </ol>
    </li>
 
-   <li><p>Invoke <span>WebDriver BiDi navigable created</span> with <var>traversable</var>.</p></li>
+   <li><p>Invoke <span>WebDriver BiDi navigable created</span> with <var>navigable</var> and
+   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
   </ol>
   </div>
 
@@ -106135,7 +106201,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
   <div algorithm>
   <p id="the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name"><dfn>The rules
   for choosing a navigable</dfn>, given a string <var>name</var>, a <span>navigable</span>
-  <var>currentNavigable</var>, and a boolean <var>noopener</var> are as follows:</p>
+  <var>currentNavigable</var>, a boolean <var>noopener</var>, and a boolean
+  <var>hasImmediateNavigationForWebDriver</var> are as follows:</p>
 
   <ol>
    <li><p>Let <var>chosen</var> be null.</p></li>
@@ -106220,7 +106287,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
 
        <li id="noopener"><p>If <var>noopener</var> is true, then set <var>chosen</var> to the
        result of <span>creating a new top-level traversable</span> given null,
-       <var>targetName</var>, and <var>currentNavigable</var>.</p></li>
+       <var>targetName</var>, <var>hasImmediateNavigationForWebDriver</var>, and
+       <var>currentNavigable</var>.</p></li>
 
        <li>
         <p>Otherwise:</p>
@@ -106228,7 +106296,8 @@ interface <dfn interface>NotRestoredReasons</dfn> {
         <ol>
          <li><p>Set <var>chosen</var> to the result of <span>creating a new top-level
          traversable</span> given <var>currentNavigable</var>'s <span data-x="nav-bc">active
-         browsing context</span>, <var>targetName</var>, and <var>currentNavigable</var>.</p></li>
+         browsing context</span>, <var>targetName</var>, <var>hasImmediateNavigationForWebDriver</var>, and
+         <var>currentNavigable</var>.</p></li>
 
          <li><p>If <var>sandboxingFlagSet</var>'s <span>sandboxed navigation browsing context
          flag</span> is set, then set <var>chosen</var>'s <span data-x="nav-bc">active browsing
@@ -155238,7 +155307,14 @@ interface <dfn interface>HTMLFrameSetElement</dfn> : <span>HTMLElement</span> {
    <li><p>If <var>insertedNode</var>'s <span>root</span>'s <span
    data-x="concept-document-bc">browsing context</span> is null, then return.</p></li>
 
-   <li><p><span>Create a new child navigable</span> for <var>insertedNode</var>.</p></li>
+   <li><p>Let <var>url</var> be the result of <span>getting the URL for an <code>iframe</code> or
+   <code>frame</code></span> given <var>insertedNode</var>.</p></li>
+
+   <li><p>Let <var>hasImmediateNavigationForWebDriver</var> be true if <var>url</var> is non-null and does not
+   <span data-x="matches about:blank">match <code>about:blank</code></span>; otherwise false.</p></li>
+
+   <li><p><span>Create a new child navigable</span> given <var>insertedNode</var> and
+   <var>hasImmediateNavigationForWebDriver</var>.</p></li>
 
    <li><p><span>Process the <code>frame</code> attributes</span> for <var>insertedNode</var>, with
    <i data-x="process-frame-initial-insertion">initialInsertion</i> set to true.</p></li>


### PR DESCRIPTION
Create a new `hasPlannedNavigationForWebDriver` flag to indicate if a navigable is planning to perform a navigation beyond "about:blank" and the client will have to wait for load events to make sure that the navigable is ready to be interacted with or for a navigation to be failed/aborted.

It's going to be consumed here: https://github.com/w3c/webdriver-bidi/pull/1151.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko
   * Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62524
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2070248
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Wattsi server error :boom: ###

[PR Preview](https://github.com/specinfra/pr-preview#pr-preview) failed to build. _(Last tried on Sep 11, 2026, 1:07 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Wattsi Server](https://github.com/domenic/wattsi-server) - Wattsi Server is the web service used to build the WHATWG HTML spec.

:link: [Related URL](https://build.whatwg.org/wattsi)

**Error output:**

```
      <!DOCTYPE html>
      <html>
      <head>
          <meta name="viewport" content="width=device-width, initial-scale=1">
          <meta name="robots" content="noindex">
          <style>body,html{height:100%;margin:0}body{display:flex;align-items:center;justify-content:center;flex-direction:column;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}p{text-align:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;color:#000;font-size:14px;margin-top:-50px}p.code{font-size:24px;font-weight:500;border-bottom:1px solid #e0e1e2;padding:0 20px 15px}p.text{margin:0}a,a:visited{color:#aaa}</style>
      </head>
      <body>
      <p class="code">
        Error code: 503      </p>
      <p class="text">
        Well, This is unexpected. An Error has occurred, and we are working to fix the problem! We will be up and running shortly. Try refreshing the page or try again in a few minutes.
      </p>
        <div style="display:none;">
          <h1>
    upstream_reset_before_response_started{connection_termination} (503 UC)      </h1>
          <p data-translate="connection_timed_out">App Platform failed to forward this request to the application.</p>
      </div>
      </body>
      </html>
    
```

_This seems to be an issue with the [Wattsi Server](https://github.com/domenic/wattsi-server) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Wattsi Server](https://github.com/domenic/wattsi-server/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Wattsi Server, you can [file an issue with PR Preview](https://github.com/specinfra/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/html%2312833.)._

</details>
