### PR TITLE
Only nullify the navigation API state when cross-document

### DIFF
--- a/source
+++ b/source
@@ -111328,18 +111328,26 @@ location.href = '#foo';</code></pre>
      history entry</span> to <var>targetEntry</var>.</p></li>
 
      <li>
-      <p><span>Queue a global task</span> on the <span>navigation and
-      traversal task source</span> of <var>navigable</var>'s <span data-x="nav-window">active
-      window</span> to run these steps:</p>
+      <p>If <var>targetEntry</var>'s <span data-x="she-document">document</span> is not
+      <var>navigable</var>'s <span data-x="nav-document">active document</span>:</p>
 
       <ol>
-       <li><p>Let <var>navigation</var> be <var>navigable</var>'s <span data-x="nav-window">active
-       window</span>'s <span data-x="window-navigation-api">navigation API</span>.</p></li>
+       <li>
+        <p><span>Queue a global task</span> on the <span>navigation and traversal task source</span>
+        given <var>navigable</var>'s <span data-x="nav-window">active window</span> to run these
+        steps:</p>
 
-       <li><p>Set <var>navigation</var>'s <span>ongoing <code
-       data-x="event-navigate">navigate</code> event</span> to null.</p>
+        <ol>
+         <li><p>Let <var>navigation</var> be <var>navigable</var>'s <span data-x="nav-window">active
+         window</span>'s <span data-x="window-navigation-api">navigation API</span>.</p></li>
 
-       <li><p>Set <var>navigation</var>'s <span>ongoing API method tracker</span> to null.</p></li>
+         <li><p>Set <var>navigation</var>'s <span>ongoing <code
+         data-x="event-navigate">navigate</code> event</span> to null.</p></li>
+
+         <li><p>Set <var>navigation</var>'s <span>ongoing API method tracker</span> to
+         null.</p></li>
+        </ol>
+       </li>
       </ol>
 
       <p class="note">This prevents the <code data-x="event-navigateerror">navigateerror</code>

--- a/source
+++ b/source
@@ -111329,8 +111329,8 @@ location.href = '#foo';</code></pre>
 
      <li>
       <p>If <var>targetEntry</var>'s <span data-x="she-document">document</span> is not
-      <var>navigable</var>'s <span data-x="nav-document">active document</span>, then
-      <span>queue a global task</span> on the <span>navigation and traversal task source</span> of
+      <var>navigable</var>'s <span data-x="nav-document">active document</span>, then <span>queue a
+      global task</span> on the <span>navigation and traversal task source</span> of
       <var>navigable</var>'s <span data-x="nav-window">active window</span> to run these steps:</p>
 
       <ol>
@@ -111348,7 +111348,7 @@ location.href = '#foo';</code></pre>
       as a result of a successful cross-document navigation.</p>
      </li>
 
-     <li><p><span>Set the ongoing navigation</span> for <var>navigable</var> to "<code
+     <li><p>Set <var>navigable</var>'s <span>ongoing navigation</span> to "<code
      data-x="">traversal</code>".</p></li>
     </ol>
    </li>
@@ -111716,7 +111716,7 @@ location.href = '#foo';</code></pre>
 
       <ol>
        <li>
-        <p><span>Set the ongoing navigation</span> for <var>navigable</var> to null.</p>
+        <p>Set <var>navigable</var>'s <span>ongoing navigation</span> to null.</p>
 
         <p class="note">This allows new <span data-x="navigate">navigations</span> of
         <var>navigable</var> to start, whereas during the traversal they were blocked.</p>
@@ -111856,7 +111856,7 @@ location.href = '#foo';</code></pre>
      </li>
 
      <li>
-      <p><span>Set the ongoing navigation</span> for <var>navigable</var> to null.</p>
+      <p>Set <var>navigable</var>'s <span>ongoing navigation</span> to null.</p>
 
       <p class="note">This allows new <span data-x="navigate">navigations</span> of
       <var>navigable</var> to start, whereas during the traversal they were blocked.</p>
@@ -111887,7 +111887,7 @@ location.href = '#foo';</code></pre>
 
         <ol>
          <li>
-          <p><span>Set the ongoing navigation</span> for <var>navigable</var> to null.</p>
+          <p>Set <var>navigable</var>'s <span>ongoing navigation</span> to null.</p>
 
           <p class="note">This allows new <span data-x="navigate">navigations</span> of
           <var>navigable</var> to start, whereas during the traversal they were blocked.</p>

--- a/source
+++ b/source
@@ -111329,25 +111329,18 @@ location.href = '#foo';</code></pre>
 
      <li>
       <p>If <var>targetEntry</var>'s <span data-x="she-document">document</span> is not
-      <var>navigable</var>'s <span data-x="nav-document">active document</span>:</p>
+      <var>navigable</var>'s <span data-x="nav-document">active document</span>, then
+      <span>queue a global task</span> on the <span>navigation and traversal task source</span> of
+      <var>navigable</var>'s <span data-x="nav-window">active window</span> to run these steps:</p>
 
       <ol>
-       <li>
-        <p><span>Queue a global task</span> on the <span>navigation and traversal task source</span>
-        given <var>navigable</var>'s <span data-x="nav-window">active window</span> to run these
-        steps:</p>
+       <li><p>Let <var>navigation</var> be <var>navigable</var>'s <span data-x="nav-window">active
+       window</span>'s <span data-x="window-navigation-api">navigation API</span>.</p></li>
 
-        <ol>
-         <li><p>Let <var>navigation</var> be <var>navigable</var>'s <span data-x="nav-window">active
-         window</span>'s <span data-x="window-navigation-api">navigation API</span>.</p></li>
+       <li><p>Set <var>navigation</var>'s <span>ongoing <code
+       data-x="event-navigate">navigate</code> event</span> to null.</p></li>
 
-         <li><p>Set <var>navigation</var>'s <span>ongoing <code
-         data-x="event-navigate">navigate</code> event</span> to null.</p></li>
-
-         <li><p>Set <var>navigation</var>'s <span>ongoing API method tracker</span> to
-         null.</p></li>
-        </ol>
-       </li>
+       <li><p>Set <var>navigation</var>'s <span>ongoing API method tracker</span> to null.</p></li>
       </ol>
 
       <p class="note">This prevents the <code data-x="event-navigateerror">navigateerror</code>


### PR DESCRIPTION
`traversal` is used for same-document traverse navigations, as well as *any* cross-document navigation.

Nullifying the ongoing navigate event + method tracker should only take place when it's an actual cross-doc navigation.

This "ongoing navigation" change should change the state without aborting the current navigation.

Closes #12832

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12838/browsing-the-web.html" title="Last updated on Aug 26, 2026, 3:44 PM UTC (2f166cb)">/browsing-the-web.html</a>  ( <a href="https://whatpr.org/html/12838/a2d61ec...2f166cb/browsing-the-web.html" title="Last updated on Aug 26, 2026, 3:44 PM UTC (2f166cb)">diff</a> )