### PR TITLE
Consult the dimension attributes for width and height when not rendered

### DIFF
--- a/source
+++ b/source
@@ -31600,15 +31600,14 @@ interface <dfn interface>HTMLImageElement</dfn> : <span>HTMLElement</span> {
   <var>image</var>:</p>
 
   <ol>
-   <li><p>If <var>image</var> is <span>being rendered</span>, then return its rendered width and
-   height, in <span data-x="'px'">CSS pixels</span>. <ref>CSS</ref></p></li>
+   <li><p>Let <var>naturalDimensions</var> be null.</p></li>
 
-   <li><p>If <var>image</var> is <i data-x="img-available">available</i> and has
-   <span>density-corrected natural width and height</span>, then return its
-   <span>density-corrected natural width and height</span>, in <span data-x="'px'">CSS
-   pixels</span>.</p></li>
+   <li><p>If <var>image</var> is <i data-x="img-available">available</i>, then set
+   <var>naturalDimensions</var> to <var>image</var>'s <span>density-corrected natural width and
+   height</span>.</p></li>
 
-   <li><p>Return a width of 0 and a height of 0.</p></li>
+   <li><p>Return the result of <span data-x="determine-dimensions">determining the
+   dimensions</span> of <var>image</var> given <var>naturalDimensions</var>.</p></li>
   </ol>
   </div>
 
@@ -45322,7 +45321,51 @@ interface <dfn interface>HTMLAreaElement</dfn> : <span>HTMLElement</span> {
 
   <p class="note">The corresponding IDL attributes for <code data-x="dom-img-height">img</code> and
   <code data-x="dom-input-height">input</code> elements are defined in those respective elements'
-  sections, as they are slightly more specific to those elements' other behaviors.</p>
+  sections, as they are slightly more specific to those elements' other behaviors. Both are defined
+  in terms of the algorithm below.</p>
+
+  <div algorithm>
+  <p>To <dfn data-x="determine-dimensions">determine the dimensions</dfn> of an <code>img</code> or
+  <code>input</code> element <var>element</var> given a struct consisting of a width and a height,
+  or null, <var>naturalDimensions</var>:</p>
+
+  <ol>
+   <li><p>If <var>element</var> is <span>being rendered</span>, then return its rendered width and
+   height, in <span data-x="'px'">CSS pixels</span>. <ref>CSS</ref></p></li>
+
+   <li><p>Let <var>width</var> and <var>height</var> be 0.</p></li>
+
+   <li><p>If <var>naturalDimensions</var> is not null, then set <var>width</var> to
+   <var>naturalDimensions</var>'s width and <var>height</var> to <var>naturalDimensions</var>'s
+   height, in <span data-x="'px'">CSS pixels</span>.</p></li>
+
+   <li>
+    <p>If <var>element</var> has a <code data-x="attr-dim-width">width</code> attribute:</p>
+
+    <ol>
+     <li><p>Let <var>attributeWidth</var> be the result of <span data-x="rules for parsing
+     non-negative integers">parsing that attribute's value</span>.</p></li>
+
+     <li><p>If <var>attributeWidth</var> is not an error, then set <var>width</var> to
+     <var>attributeWidth</var>.</p></li>
+    </ol>
+   </li>
+
+   <li>
+    <p>If <var>element</var> has a <code data-x="attr-dim-height">height</code> attribute:</p>
+
+    <ol>
+     <li><p>Let <var>attributeHeight</var> be the result of <span data-x="rules for parsing
+     non-negative integers">parsing that attribute's value</span>.</p></li>
+
+     <li><p>If <var>attributeHeight</var> is not an error, then set <var>height</var> to
+     <var>attributeHeight</var>.</p></li>
+    </ol>
+   </li>
+
+   <li><p>Return a width of <var>width</var> and a height of <var>height</var>.</p></li>
+  </ol>
+  </div>
 
   </div>
 
@@ -51336,17 +51379,30 @@ interface <dfn interface>HTMLInputElement</dfn> : <span>HTMLElement</span> {
   </div>
 
   <div algorithm>
-  <p>The IDL attributes <dfn attribute for="HTMLInputElement"><code
-  data-x="dom-input-width">width</code></dfn> and <dfn attribute for="HTMLInputElement"><code
-  data-x="dom-input-height">height</code></dfn> must return the rendered width and height of the
-  image, in <span data-x="'px'">CSS pixels</span>, if an image is <span>being rendered</span>; or
-  else the <span data-x="natural dimensions">natural width and height</span> of the image, in
-  <span data-x="'px'">CSS pixels</span>, if an image is <i
-  data-x="input-img-available">available</i> but not <span>being rendered</span>; or else 0,
-  if no image is <i data-x="input-img-available">available</i>. When the <code>input</code>
-  element's <code data-x="attr-input-type">type</code> attribute is not in the <span
-  data-x="attr-input-type-image">Image Button</span> state, then no image is <i
-  data-x="input-img-available">available</i>. <ref>CSS</ref></p>
+  <p>The <dfn attribute for="HTMLInputElement"><code data-x="dom-input-width">width</code></dfn> and
+  <dfn attribute for="HTMLInputElement"><code data-x="dom-input-height">height</code></dfn> getter
+  steps are to return the respective component of the result of determining the <span
+  data-x="input-img-dimensions">dimensions</span> of <span>this</span>.</p>
+  </div>
+
+  <div algorithm>
+  <p>To determine the <dfn data-x="input-img-dimensions">dimensions</dfn> of an <code>input</code>
+  element <var>input</var>:</p>
+
+  <ol>
+   <li><p>If <var>input</var>'s <code data-x="attr-input-type">type</code> attribute is not in the
+   <span data-x="attr-input-type-image">Image Button</span> state, then return a width of 0 and a
+   height of 0. (In that case no image is <i data-x="input-img-available">available</i>.)</p></li>
+
+   <li><p>Let <var>naturalDimensions</var> be null.</p></li>
+
+   <li><p>If an image is <i data-x="input-img-available">available</i>, then set
+   <var>naturalDimensions</var> to the <span data-x="natural dimensions">natural width and
+   height</span> of that image.</p></li>
+
+   <li><p>Return the result of <span data-x="determine-dimensions">determining the
+   dimensions</span> of <var>input</var> given <var>naturalDimensions</var>.</p></li>
+  </ol>
   </div>
 
   <p>The <code data-x="dom-cva-willValidate">willValidate</code>, <code

--- a/source
+++ b/source
@@ -31549,8 +31549,11 @@ interface <dfn interface>HTMLImageElement</dfn> : <span>HTMLElement</span> {
    <dt><code data-x=""><var>image</var>.<span subdfn data-x="dom-img-height">height</span> [ = <var>value</var> ]</code></dt>
 
    <dd>
-    <p>These attributes return the actual rendered dimensions of the image, or 0 if the dimensions
-    are not known.</p>
+    <p>These attributes return the rendered dimensions of the image. When the image is not being
+    rendered, they return the <code data-x="attr-dim-width">width</code> and <code
+    data-x="attr-dim-height">height</code> content attributes' values, defaulting to <code
+    data-x="dom-img-naturalWidth">naturalWidth</code> and <code
+    data-x="dom-img-naturalHeight">naturalHeight</code>.</p>
 
     <p>They can be set, to change the corresponding content attributes.</p>
    </dd>
@@ -45330,14 +45333,15 @@ interface <dfn interface>HTMLAreaElement</dfn> : <span>HTMLElement</span> {
   or null, <var>naturalDimensions</var>:</p>
 
   <ol>
-   <li><p>If <var>element</var> is <span>being rendered</span>, then return its rendered width and
-   height, in <span data-x="'px'">CSS pixels</span>. <ref>CSS</ref></p></li>
+   <li><p>If <var>element</var> is <span>being rendered</span>, then return the width and height of
+   <var>element</var>'s <span>content box</span>, in <span data-x="'px'">CSS pixels</span>.
+   <ref>CSS</ref></p></li>
 
    <li><p>Let <var>width</var> and <var>height</var> be 0.</p></li>
 
    <li><p>If <var>naturalDimensions</var> is not null, then set <var>width</var> to
    <var>naturalDimensions</var>'s width and <var>height</var> to <var>naturalDimensions</var>'s
-   height, in <span data-x="'px'">CSS pixels</span>.</p></li>
+   height.</p></li>
 
    <li>
     <p>If <var>element</var> has a <code data-x="attr-dim-width">width</code> attribute:</p>
@@ -45363,7 +45367,8 @@ interface <dfn interface>HTMLAreaElement</dfn> : <span>HTMLElement</span> {
     </ol>
    </li>
 
-   <li><p>Return a width of <var>width</var> and a height of <var>height</var>.</p></li>
+   <li><p>Return a width of <var>width</var> and a height of <var>height</var>, in <span
+   data-x="'px'">CSS pixels</span>.</p></li>
   </ol>
   </div>
 
@@ -51397,8 +51402,9 @@ interface <dfn interface>HTMLInputElement</dfn> : <span>HTMLElement</span> {
    <li><p>Let <var>naturalDimensions</var> be null.</p></li>
 
    <li><p>If an image is <i data-x="input-img-available">available</i>, then set
-   <var>naturalDimensions</var> to the <span data-x="natural dimensions">natural width and
-   height</span> of that image.</p></li>
+   <var>naturalDimensions</var> to the result of applying the <span>default sizing algorithm</span>
+   with that image's <span data-x="natural dimensions">natural width, natural height, and natural
+   aspect ratio</span>, if any, using a <span>default object size</span> of 300 by 150.</p></li>
 
    <li><p>Return the result of <span data-x="determine-dimensions">determining the
    dimensions</span> of <var>input</var> given <var>naturalDimensions</var>.</p></li>
@@ -54731,8 +54737,10 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
    <dt><code data-x=""><var>image</var>.<span subdfn data-x="dom-input-height">height</span> [ = <var>value</var> ]</code></dt>
 
    <dd>
-    <p>These attributes return the actual rendered dimensions of the image, or 0 if the dimensions
-    are not known.</p>
+    <p>These attributes return the rendered dimensions of the image. When the image is not being
+    rendered, they return the <code data-x="attr-dim-width">width</code> and <code
+    data-x="attr-dim-height">height</code> content attributes' values, defaulting to the image's
+    <span>natural dimensions</span>, if any; otherwise 0.</p>
 
     <p>They can be set, to change the corresponding content attributes.</p>
    </dd>


### PR DESCRIPTION
The width and height IDL attributes of img elements, and of input
elements in the Image Button state, returned the natural dimensions when
the element was not being rendered. All browsers instead return the width
and height content attributes.

Drop the "has density-corrected natural width and height" condition as
4ff60b08499a3009909ff9a0b80ccbf5aa1f8fc4 gave every available image a
300x150 fallback.

All three engines already consult the dimension attributes when the element is not
being rendered, which is what this change specifies; each has gaps in the details.

Tests: https://github.com/web-platform-tests/wpt/pull/61080

Closes #12573.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko: @dholbert asked for this change in [wpt#61080](https://github.com/web-platform-tests/wpt/pull/61080#discussion_r3847354138)
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61080 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/555956978
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2052914 
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=323210
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: none needed
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12840/embedded-content-other.html" title="Last updated on Aug 28, 2026, 11:39 AM UTC (7e57b60)">/embedded-content-other.html</a>  ( <a href="https://whatpr.org/html/12840/a2d61ec...7e57b60/embedded-content-other.html" title="Last updated on Aug 28, 2026, 11:39 AM UTC (7e57b60)">diff</a> )
<a href="https://whatpr.org/html/12840/embedded-content.html" title="Last updated on Aug 28, 2026, 11:39 AM UTC (7e57b60)">/embedded-content.html</a>  ( <a href="https://whatpr.org/html/12840/a2d61ec...7e57b60/embedded-content.html" title="Last updated on Aug 28, 2026, 11:39 AM UTC (7e57b60)">diff</a> )
<a href="https://whatpr.org/html/12840/input.html" title="Last updated on Aug 28, 2026, 11:39 AM UTC (7e57b60)">/input.html</a>  ( <a href="https://whatpr.org/html/12840/a2d61ec...7e57b60/input.html" title="Last updated on Aug 28, 2026, 11:39 AM UTC (7e57b60)">diff</a> )