### PR TITLE
Fix focus navigation trap when starting point is inside focused area, but before any other focusable areas.

### DIFF
--- a/source
+++ b/source
@@ -87083,6 +87083,22 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
    algorithm</span> with <var>starting point</var>, <var>direction</var>, and <var>selection
    mechanism</var>.</p></li>
 
+   <li>
+     <p>If <var>candidate</var> is the <span>currently focused area of a top-level
+     traversable</span>, then</p>
+     <p class="note">
+       This occurs for backward sequential focus navigation if <var>starting point</var>
+       is inside the <span>currently focused area of a top-level traversable</span>,
+       and there is no <span>suitable sequentially focusable area</span> before it.
+     </p>
+     <ol>
+       <li><span>Assert</span>: <var>direction</var> is "<code data-x="sequential-focus-backward"
+           >backward</code>" and <var>candidate</var> is not <var>starting point</var>.</li>
+       <li>Set <var>starting point</var> to <var>candidate</var>.</li>
+       <li>Return to the step labeled <i>loop</i>.</li>
+     </ol>
+   </li>
+
    <li><p>If <var>candidate</var> is not null, then run the <span>focusing steps</span> for
    <var>candidate</var> and return.</p></li>
 


### PR DESCRIPTION
Fixes #12514 

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Gecko
   * …
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Tentative tests at [html/interaction/focus/sequential-focus-navigation-starting-point.tentative.html](https://wpt.fyi/results/html/interaction/focus/sequential-focus-navigation-starting-point.tentative.html). I don't think it's possible to make a non-tentative test for this, since the only places in the standard where the starting point is set also run the focusing steps on it. (In practice, all browsers move it on click, which is what the tests uses, but it's not specified.)
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A (sequential focus navigation starting point is not used if there is a focused element)
   * Gecko: (already implementing)
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=316027


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12843/interaction.html" title="Last updated on Aug 25, 2026, 7:23 PM UTC (651732a)">/interaction.html</a>  ( <a href="https://whatpr.org/html/12843/224e47e...651732a/interaction.html" title="Last updated on Aug 25, 2026, 7:23 PM UTC (651732a)">diff</a> )