### PR TITLE
Revert part of "Do not allow named window targeting with noopener"

### DIFF
--- a/source
+++ b/source
@@ -106052,9 +106052,9 @@ interface <dfn interface>NotRestoredReasons</dfn> {
    data-x="nav-traversable">traversable navigable</span>.</p></li>
 
    <li><p>Otherwise, if <var>name</var> is not an <span>ASCII case-insensitive</span> match for
-   "<code data-x="">_blank</code>" and <var>noopener</var> is false, then set <var>chosen</var> to
-   the result of <span data-x="find a navigable by target name">finding a navigable by target
-   name</span> given <var>name</var> and <var>currentNavigable</var>.</p></li>
+   "<code data-x="">_blank</code>", then set <var>chosen</var> to the result of <span
+   data-x="find a navigable by target name">finding a navigable by target name</span> given
+   <var>name</var> and <var>currentNavigable</var>.</p></li>
 
    <li>
     <p>If <var>chosen</var> is null, then a new <span>top-level traversable</span> is being


### PR DESCRIPTION
This reverts part of commit dfdafb4b295f053c207cbba6deb136819501a00c,
keeping its editorial restructuring.

The behavior reported in #11291 already followed from the standard as
written. A navigable created by a navigation with noopener set goes into
a new browsing context group, and "find a navigable by target name" is
scoped to the current navigable's traversable and browsing context
group. So following `<a href=example target=example rel=noopener>` twice
creates two top-level traversables regardless, even though each has
"example" as its target name. web-platform-tests covers this at
html/browsers/windows/auxiliary-browsing-contexts/named-lookup-scoped-to-browsing-context-group.html.

Gating the name lookup on noopener was also not correct. #1826 settled
on name targeting taking precedence, as Gecko had to back out the
opposite behavior for noreferrer as web-incompatible (Mozilla bug
1358469) and noreferrer needs to remain a superset of noopener.

Closes #12839.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * All engines support this already
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Existing tests: `html/browsers/the-window-object/window-open-noopener.html`, `html/browsers/windows/noreferrer-window-name.html`, and `html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html`
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12844/document-sequences.html" title="Last updated on Aug 26, 2026, 7:15 AM UTC (93f636b)">/document-sequences.html</a>  ( <a href="https://whatpr.org/html/12844/ca693db...93f636b/document-sequences.html" title="Last updated on Aug 26, 2026, 7:15 AM UTC (93f636b)">diff</a> )