### PR TITLE
window.open() with noopener should not always return null

### DIFF
--- a/source
+++ b/source
@@ -97238,8 +97238,12 @@ dictionary <dfn dictionary>WindowPostMessageOptions</dfn> : <span>StructuredSeri
     </ol>
    </li>
 
-   <li><p>If <var>noopener</var> is true or <var>windowType</var> is "<code data-x="">new with no
-   opener</code>", then return null.</p></li>
+   <li><p>If <var>windowType</var> is "<code data-x="">new with no opener</code>", then return
+   null.</p></li>
+
+   <li><p>If <var>noopener</var> is true and <var>target</var> is not an <span>ASCII
+   case-insensitive</span> match for "<code data-x="">_self</code>", "<code
+   data-x="">_parent</code>", or "<code data-x="">_top</code>", then return null.</p></li>
 
    <li><p>Return <var>targetNavigable</var>'s <span data-x="nav-wp">active
    <code>WindowProxy</code></span>.</p></li>


### PR DESCRIPTION
The window open steps returned null whenever noopener was true, but for
the _self, _parent, and _top target names that is meaningless and not
aligned with most implementations.

Tests: https://github.com/web-platform-tests/wpt/pull/62213

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium: already returns the existing window for all three names
   * Gecko: already returns the existing window for all three names
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62213 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: https://github.com/WebKit/WebKit/pull/72495
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12845/nav-history-apis.html" title="Last updated on Aug 26, 2026, 12:19 PM UTC (b47da48)">/nav-history-apis.html</a>  ( <a href="https://whatpr.org/html/12845/ca693db...b47da48/nav-history-apis.html" title="Last updated on Aug 26, 2026, 12:19 PM UTC (b47da48)">diff</a> )