### PR TITLE
Scripting mode should be Normal by default

### DIFF
--- a/source
+++ b/source
@@ -141765,7 +141765,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   <p>A boolean <dfn>allow declarative shadow roots</dfn> (initially false).</p>
 
   <p>The <dfn>scripting mode</dfn>, which is a <span>parser scripting mode</span> (initially
-  <span data-x="scripting-mode-normal">Normal).</p>
+  <span data-x="scripting-mode-normal">Normal</span>).</p>
 
   <p>A <dfn>parser scripting mode</dfn> is one of the following:</p>
 

--- a/source
+++ b/source
@@ -141764,7 +141764,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <p>A boolean <dfn>allow declarative shadow roots</dfn> (initially false).</p>
 
-  <p>The <dfn>scripting mode</dfn>, which is a <span>parser scripting mode</span>.</p>
+  <p>The <dfn>scripting mode</dfn>, which is a <span>parser scripting mode</span> (initially
+  <span data-x="scripting-mode-normal">Normal).</p>
 
   <p>A <dfn>parser scripting mode</dfn> is one of the following:</p>
 

--- a/source
+++ b/source
@@ -141764,8 +141764,11 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <p>A boolean <dfn>allow declarative shadow roots</dfn> (initially false).</p>
 
-  <p>The <dfn>scripting mode</dfn>, which is a <span>parser scripting mode</span> (initially
-  <span data-x="scripting-mode-normal">Normal</span>).</p>
+  <p>The <dfn>scripting mode</dfn>, which is a <span>parser scripting mode</span>. It is initially
+  set to <span data-x="scripting-mode-normal">Normal</span> if <span
+  data-x="concept-n-script">scripting was enabled</span> for the <code>Document</code> with which
+  the parser is associated when the parser was created, and <span
+  data-x="scripting-mode-disabled">Disabled</span> otherwise.</p>
 
   <p>A <dfn>parser scripting mode</dfn> is one of the following:</p>
 


### PR DESCRIPTION
Fixes #12847


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12848/parsing.html" title="Last updated on Aug 26, 2026, 1:51 PM UTC (f962057)">/parsing.html</a>  ( <a href="https://whatpr.org/html/12848/a2d61ec...f962057/parsing.html" title="Last updated on Aug 26, 2026, 1:51 PM UTC (f962057)">diff</a> )