### PR TITLE
Update to correct number of module types

### DIFF
--- a/source
+++ b/source
@@ -117944,7 +117944,7 @@ document.querySelector("button").addEventListener("click", bound);
   data-x="concept-script">script</span>. It has no additional <span data-x="struct
   item">items</span>.</p>
 
-  <p><span data-x="module script">Module scripts</span> can be classified into four types:</p>
+  <p><span data-x="module script">Module scripts</span> can be classified into five types:</p>
 
   <ul>
    <li>


### PR DESCRIPTION
This change fixes a small typo in the spec. Under https://html.spec.whatwg.org/#script-structs, it says "[Module scripts](https://html.spec.whatwg.org/#module-script) can be classified into **four** types:" and then goes on to list **five** types. This change simply updates "four" to "five".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12849/webappapis.html" title="Last updated on Aug 26, 2026, 3:53 PM UTC (052f43e)">/webappapis.html</a>  ( <a href="https://whatpr.org/html/12849/ac0389a...052f43e/webappapis.html" title="Last updated on Aug 26, 2026, 3:53 PM UTC (052f43e)">diff</a> )