### PR TITLE
Meta: load standard-mdn-annos.js for the MDN annotation panels

### DIFF
--- a/source
+++ b/source
@@ -63,6 +63,7 @@
   <script w-nodev w-noreview crossorigin src="/html-dfn.js" defer></script>
   <script w-nodev w-noreview crossorigin src="https://html.spec.whatwg.org/var-click-highlighting.js" defer></script>
   <script w-nodev w-noreview w-nosplit crossorigin src="https://resources.whatwg.org/commit-snapshot-shortcut-key.js" defer></script>
+  <script w-noreview crossorigin src="https://resources.whatwg.org/standard-mdn-annos.js" defer></script>
   <header class="head with-buttons" id="head">
    <a href="https://whatwg.org/" class="logo"><img crossorigin width="100" height="100" alt="WHATWG" src="https://resources.whatwg.org/logo.svg" class="darkmode-aware"></a>
    <hgroup w-nodev>


### PR DESCRIPTION
wattsi is moving the MDN compatibility tables out of the markup and into a "data-mdn" attribute per panel, built on first open by this script. Part of whatwg/html#12782.

The inline toggleStatus() stays for now: it is what drives the current <button>-based panels, and it has to keep working until the wattsi change has shipped. Removing it is a follow-up.

---

This is step 2 of https://github.com/whatwg/wattsi/issues/169

Generated by Claude.