### PR TITLE
Meta: drop the now-unused toggleStatus()

### DIFF
--- a/source
+++ b/source
@@ -63,6 +63,7 @@
   <script w-nodev w-noreview crossorigin src="/html-dfn.js" defer></script>
   <script w-nodev w-noreview crossorigin src="https://html.spec.whatwg.org/var-click-highlighting.js" defer></script>
   <script w-nodev w-noreview w-nosplit crossorigin src="https://resources.whatwg.org/commit-snapshot-shortcut-key.js" defer></script>
+  <script w-noreview crossorigin src="https://resources.whatwg.org/standard-mdn-annos.js" defer></script>
   <header class="head with-buttons" id="head">
    <a href="https://whatwg.org/" class="logo"><img crossorigin width="100" height="100" alt="WHATWG" src="https://resources.whatwg.org/logo.svg" class="darkmode-aware"></a>
    <hgroup w-nodev>

--- a/source
+++ b/source
@@ -40,9 +40,6 @@
   <link w-dev rel="stylesheet" crossorigin href="/dev/styles.css">
   <link w-nodev rel="stylesheet" crossorigin href="https://html.spec.whatwg.org/styles.css">
   <script>
-   function toggleStatus(div) {
-     div.parentNode.classList.toggle('wrapped');
-   }
    function setLinkFragment(link) {
      link.hash = location.hash;
    }


### PR DESCRIPTION
MDN annotation panels are `<details>` now, so nothing calls this. Note that
archived commit snapshots have their own copy baked in and are unaffected.

DO NOT LAND until the wattsi change that emits `<details>` panels has shipped
and html.spec.whatwg.org has been rebuilt with it; until then this function
is what makes the panels open.

---

This is step 4 of https://github.com/whatwg/wattsi/issues/169

Generated by Claude.