### PR TITLE
Meta: lazy-load the spec's own images and iframes

### DIFF
--- a/source
+++ b/source
@@ -24595,8 +24595,7 @@ this specification: the &lt;abbr>WHATWG&lt;/abbr> and the
 
    <p>This might be rendered as:</p>
 
-   <p><img loading="lazy" src="/images/sample-ruby-ja.png" width="171" height="78"
-           alt="The two main ideographs, each with its annotation in hiragana rendered in a smaller font above it."></p>
+   <p><img loading="lazy" src="/images/sample-ruby-ja.png" width="171" height="78" alt="The two main ideographs, each with its annotation in hiragana rendered in a smaller font above it."></p>
 
   </div>
 
@@ -24611,8 +24610,7 @@ this specification: the &lt;abbr>WHATWG&lt;/abbr> and the
 
    <p>This might be rendered as:</p>
 
-   <p><img loading="lazy" src="/images/sample-ruby-bopomofo.png" width="78" height="100"
-           alt="The two main ideographs, each with its bopomofo annotation rendered in a smaller font next to it."></p>
+   <p><img loading="lazy" src="/images/sample-ruby-bopomofo.png" width="78" height="100" alt="The two main ideographs, each with its bopomofo annotation rendered in a smaller font next to it."></p>
 
   </div>
 
@@ -24627,8 +24625,7 @@ this specification: the &lt;abbr>WHATWG&lt;/abbr> and the
 
    <p>This might be rendered as:</p>
 
-   <p><img loading="lazy" src="/images/sample-ruby-pinyin.png" width="173" height="79"
-           alt="The two main ideographs, each with its pinyin annotation rendered in a smaller font above it."></p>
+   <p><img loading="lazy" src="/images/sample-ruby-pinyin.png" width="173" height="79" alt="The two main ideographs, each with its pinyin annotation rendered in a smaller font above it."></p>
 
   </div>
 
@@ -53408,8 +53405,7 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
 
    <p>A user agent could display in a variety of ways, for instance:</p>
 
-   <p><img loading="lazy" src="/images/sample-range-2a.png" width="231" height="57"
-           alt="As a dial."></p>
+   <p><img loading="lazy" src="/images/sample-range-2a.png" width="231" height="57" alt="As a dial."></p>
 
    <p>Or, alternatively, for instance:</p>
 
@@ -62743,16 +62739,13 @@ MIT Room 32-G524
 
      <p>This might render as follows:</p>
 
-     <p><img loading="lazy" src="/images/select-country-1.png" width="232" height="172"
-             alt="A drop-down control with a long alphabetical list of countries."></p>
+     <p><img loading="lazy" src="/images/select-country-1.png" width="232" height="172" alt="A drop-down control with a long alphabetical list of countries."></p>
 
      <p>Suppose that on the first visit to this page, the user selects "Zambia". On the second visit,
      the user agent could duplicate the entry for Zambia at the top of the list, so that the interface
      instead looks like this:</p>
 
-     <p><img loading="lazy" src="/images/select-country-2.png" width="232" height="172"
-             alt="The same drop-down control with the alphabetical list of countries, but with
-             Zambia as an entry at the top."></p>
+     <p><img loading="lazy" src="/images/select-country-2.png" width="232" height="172" alt="The same drop-down control with the alphabetical list of countries, but with Zambia as an entry at the top."></p>
 
     </div>
 
@@ -75186,11 +75179,7 @@ try {
    <dd>
     <p>Draws the given image onto the canvas. The arguments are interpreted as follows:</p>
 
-    <p><img loading="lazy" src="/images/drawImage.png" width="356" height="356"
-    alt="The sx and sy parameters give the x and y coordinates of the source rectangle; the sw and
-    sh arguments give the width and height of the source rectangle; the dx and dy give the x and y
-    coordinates of the destination rectangle; and the dw and dh arguments give the width and height
-    of the destination rectangle."></p>
+    <p><img loading="lazy" src="/images/drawImage.png" width="356" height="356" alt="The sx and sy parameters give the x and y coordinates of the source rectangle; the sw and sh arguments give the width and height of the source rectangle; the dx and dy give the x and y coordinates of the destination rectangle; and the dw and dh arguments give the width and height of the destination rectangle."></p>
 
     <p>If the image isn't yet fully decoded, then nothing is drawn. If the image is a canvas with no
     data, throws an <span>"<code>InvalidStateError</code>"</span> <code>DOMException</code>.</p>
@@ -153346,16 +153335,16 @@ progress { appearance: auto; }</code></pre>
 
   <!-- https://software.hixie.ch/utilities/js/canvas/?c.clearRect(0%2C%200%2C%20640%2C%20480)%3B%0Ac.save()%3B%0Atry%20%7B%0A%20%20c.fillStyle%20%3D%20%27black%27%3B%0A%20%20c.font%20%3D%20%278px%20sans-serif%27%3B%0A%20%20c.fillText(%27Horizontal%20ltr%27%2C%2030%2C105)%3B%0A%20%20c.fillText(%27Horizontal%20rtl%27%2C125%2C105)%3B%0A%20%20c.fillText(%27Vertical%20ltr%27%2C%20192%2C105)%3B%0A%20%20c.fillText(%27Vertical%20rtl%27%2C%20233%2C105)%3B%0A%20%20c.font%20%3D%20%27700%2010px%20sans-serif%27%3B%0A%20%20c.fillText(%27Progress%20Bars%27%2C%2013%2C30)%3B%0A%20%20c.font%20%3D%20%27100%2010px%20sans-serif%27%3B%0A%20%20c.fillText(%27(80%25)%27%2C%2037%2C45)%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(10%2C0%2C80%2C0)%3B%0A%20%20g.addColorStop(0%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.8%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.9%2C%20%27%23FFFF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(10%2C80%2C80%2C15)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(105%2C0%2C175%2C0)%3B%0A%20%20g.addColorStop(0%2C%20%27%23FFFF00%27)%3B%0A%20%20g.addColorStop(0.2%2C%20%27%23FFFF00%27)%3B%0A%20%20g.addColorStop(0.4%2C%20%27%2300FF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(105%2C80%2C80%2C15)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(0%2C80%2C0%2C20)%3B%0A%20%20g.addColorStop(0%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.75%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.85%2C%20%27%23FFFF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(203%2C15%2C15%2C80)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(0%2C80%2C0%2C20)%3B%0A%20%20g.addColorStop(0%2C%20%27%23FFFF00%27)%3B%0A%20%20g.addColorStop(0.15%2C%20%27%2300FF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(242%2C15%2C15%2C80)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%7D%20finally%20%7B%0A%20%20c.restore()%3B%0A%7D%0A -->
 
-  <p> <img loading="lazy" src="/images/sample-progress.png" alt="" width=276 height=115
-  class="extra"> When this
-  element has a <span>horizontal writing mode</span>, the element is <span>expected</span> to be
-  depicted as a horizontal progress bar. The start is on the right and the end is on the left if
-  the <span>'direction'</span> property on this element has a <span>computed value</span> of 'rtl',
-  and with the start on the left and the end on the right otherwise. When this element has a
-  <span>vertical writing mode</span>, it is <span>expected</span> to be depicted as a vertical
-  progress bar. The start is on the bottom and the end is on the top if the
-  <span>'direction'</span> property on this element has a <span>computed value</span> of 'rtl', and
-  with the start on the top and the end on the bottom otherwise.</p>
+  <p><img loading="lazy" src="/images/sample-progress.png" alt="" width=276 height=115 class="extra">
+  When this element has a <span>horizontal writing mode</span>, the element is
+  <span>expected</span> to be depicted as a horizontal progress bar. The start is on the right and
+  the end is on the left if the <span>'direction'</span> property on this element has a
+  <span>computed value</span> of 'rtl', and with the start on the left and the end on the right
+  otherwise. When this element has a <span>vertical writing mode</span>, it is
+  <span>expected</span> to be depicted as a vertical progress bar. The start is on the bottom and
+  the end is on the top if the <span>'direction'</span> property on this element has a
+  <span>computed value</span> of 'rtl', and with the start on the top and the end on the bottom
+  otherwise.</p>
 
   <p>User agents are <span>expected</span> to use a presentation consistent with platform
   conventions for progress bars. In particular, user agents are <span>expected</span> to use

--- a/source
+++ b/source
@@ -76237,8 +76237,7 @@ console.log(pixels.data[2]);
    <p>The 2D rendering context for <code>canvas</code> is often used for sprite-based games. The
    following example demonstrates this:</p>
 
-   <iframe loading="lazy" src="/demos/canvas/blue-robot/index-idle.html" width="396"
-           height="216"></iframe>
+   <iframe loading="lazy" src="/demos/canvas/blue-robot/index-idle.html" width="396" height="216"></iframe>
 
    <p>Here is the source for this example:</p>
 

--- a/source
+++ b/source
@@ -13590,7 +13590,7 @@ console.assert(image.height === 200);</code></pre>
 
   <p>These categories are related as follows:</p>
 
-  <p><iframe width="1000" height="288" src="/images/content-venn.svg"></iframe></p>
+  <p><iframe loading="lazy" width="1000" height="288" src="/images/content-venn.svg"></iframe></p>
 
   <p>Sectioning content, heading content, phrasing content, embedded content, and interactive
   content are all types of flow content. Metadata is sometimes flow content. Metadata and
@@ -15291,7 +15291,7 @@ Transport Protocol">HTTP&lt;/abbr> today.&lt;/p></code></pre> <!-- DO NOT REWRAP
    namely to align the text to the <i>start edge</i> of the paragraph, the resulting rendering could
    be as follows:</p>
 
-   <p><img src="/images/im.png" alt="Each paragraph rendered as a separate block, with the paragraphs left-aligned except the second paragraph and the last one, which would be right aligned, with the usernames ('Student' and 'Teacher' in this example) flush right, with a colon to their left, and the text first to the left of that." width=366 height=157></p>
+   <p><img loading="lazy" src="/images/im.png" alt="Each paragraph rendered as a separate block, with the paragraphs left-aligned except the second paragraph and the last one, which would be right aligned, with the usernames ('Student' and 'Teacher' in this example) flush right, with a colon to their left, and the text first to the left of that." width=366 height=157></p>
 
    <p>As noted earlier, the <code data-x="attr-dir-auto">auto</code> value is not a panacea. The
    final paragraph in this example is misinterpreted as being right-to-left text, since it begins
@@ -20836,7 +20836,7 @@ interface <dfn interface>HTMLHeadingElement</dfn> : <span>HTMLElement</span> {
 
    <p>A rendered view of the <span>outline</span> might look like:</p>
 
-   <p><img src="/images/outline.svg" width="465" height="120" alt="Top-level section with the heading &quot;HTML: Living Standard&quot; and two subsections; &quot;Table of contents&quot; and &quot;First section&quot;." class="darkmode-aware"></p>
+   <p><img loading="lazy" src="/images/outline.svg" width="465" height="120" alt="Top-level section with the heading &quot;HTML: Living Standard&quot; and two subsections; &quot;Table of contents&quot; and &quot;First section&quot;." class="darkmode-aware"></p>
   </div>
 
   <div class="example">
@@ -24595,7 +24595,7 @@ this specification: the &lt;abbr>WHATWG&lt;/abbr> and the
 
    <p>This might be rendered as:</p>
 
-   <p><img src="/images/sample-ruby-ja.png" width="171" height="78"
+   <p><img loading="lazy" src="/images/sample-ruby-ja.png" width="171" height="78"
            alt="The two main ideographs, each with its annotation in hiragana rendered in a smaller font above it."></p>
 
   </div>
@@ -24611,7 +24611,7 @@ this specification: the &lt;abbr>WHATWG&lt;/abbr> and the
 
    <p>This might be rendered as:</p>
 
-   <p><img src="/images/sample-ruby-bopomofo.png" width="78" height="100"
+   <p><img loading="lazy" src="/images/sample-ruby-bopomofo.png" width="78" height="100"
            alt="The two main ideographs, each with its bopomofo annotation rendered in a smaller font next to it."></p>
 
   </div>
@@ -24627,7 +24627,7 @@ this specification: the &lt;abbr>WHATWG&lt;/abbr> and the
 
    <p>This might be rendered as:</p>
 
-   <p><img src="/images/sample-ruby-pinyin.png" width="173" height="79"
+   <p><img loading="lazy" src="/images/sample-ruby-pinyin.png" width="173" height="79"
            alt="The two main ideographs, each with its pinyin annotation rendered in a smaller font above it."></p>
 
   </div>
@@ -25923,12 +25923,12 @@ wormhole connection.&lt;/mark>&lt;/p></code></pre>
 &lt;/ul></code></pre>
 
    <figure>
-    <img src="/images/sample-bdi.png" alt="">
+    <img loading="lazy" src="/images/sample-bdi.png" width="220" height="75" alt="">
     <figcaption>When using the <code>bdi</code> element, the username acts as expected.</figcaption>
    </figure>
 
    <figure>
-    <img src="/images/sample-not-bdi.png" alt="">
+    <img loading="lazy" src="/images/sample-not-bdi.png" width="220" height="75" alt="">
     <figcaption>If the <code>bdi</code> element were to be replaced by a <code>b</code> element, the username would confuse the bidirectional algorithm and the third bullet would end up saying "User 3 :", followed by the Arabic name (right-to-left), followed by "posts" and a period.</figcaption>
    </figure>
 
@@ -29042,7 +29042,7 @@ document.body.appendChild(wbr);</code></pre>
 
    <p>Assume that the module graph for the application is as follows:</p>
 
-   <img src="/images/ircfog-modules.svg" width="301" height="151" alt="The module graph is rooted at app.mjs, which depends on irc.mjs and fog-machine.mjs. In turn, irc.mjs depends on helpers.mjs." class="darkmode-aware">
+   <img loading="lazy" src="/images/ircfog-modules.svg" width="301" height="151" alt="The module graph is rooted at app.mjs, which depends on irc.mjs and fog-machine.mjs. In turn, irc.mjs depends on helpers.mjs." class="darkmode-aware">
 
    <p>Here we see the application developer has used <code
    data-x="rel-modulepreload">modulepreload</code> to declare all of the modules in their module graph,
@@ -43548,7 +43548,7 @@ interface <dfn interface>TextTrackCue</dfn> : <span>EventTarget</span> {
   score. Suppose a robotics competition was being streamed live. The image could be overlaid with
   the scores, as follows:</p>
 
-  <p><iframe src="data:text/html;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Cstyle%3E%0A%20body%2C%20html%20%7B%20margin%3A%200%3B%20padding%3A%200%3B%20overflow%3A%20hidden%3B%20%7D%0A%20div%20%7B%20width%3A%20600px%3B%20height%3A%20400px%3B%20position%3A%20relative%3B%20%7D%0A%20p%20%7B%20position%3A%20absolute%3B%20top%3A%200%3B%20margin%3A%200.25em%3B%20font%3A%20small-caps%20900%202em%20sans-serif%3B%20text-shadow%3A%20white%200%200%204px%3B%20%7D%0A%20span%20%7B%20display%3A%20block%3B%20%7D%0A%20.left%20%7B%20color%3A%20red%3B%20left%3A%200%3B%20text-align%3A%20left%3B%20%7D%0A%20.right%20%7B%20color%3A%20blue%3B%20right%3A%200%3B%20text-align%3A%20right%3B%20%7D%0A%20.middle%20%7B%20color%3A%20white%3B%20top%3A%20auto%3B%20bottom%3A%200%3B%20left%3A%200%3B%20right%3A%200%3B%20text-align%3A%20center%3B%20text-shadow%3A%20black%200%200%204px%3B%20%7D%0A%20.middle%20span%20%7B%20display%3A%20inline-block%3B%20margin%3A%200%201em%3B%20font-size%3A%200.75em%3B%20text-transform%3A%20uppercase%3B%20%7D%0A%3C%2Fstyle%3E%0A%3Cdiv%3E%0A%20%3Cimg%20src%3D%22https%3A%2F%2Fhtml.spec.whatwg.org%2Fimages%2Frobots.jpeg%22%3E%0A%20%3Cp%20class%3D%22score%20left%22%3E%3Cspan%3ERed%20Alliance%3C%2Fspan%3E%20%3Cspan%3E78%3C%2Fspan%3E%3C%2Fp%3E%0A%20%3Cp%20class%3D%22score%20right%22%3E%3Cspan%3EBlue%20Alliance%3C%2Fspan%3E%20%3Cspan%3E66%3C%2Fspan%3E%3C%2Fp%3E%0A%20%3Cp%20class%3D%22score%20middle%22%3E%3Cspan%3EQual%20Match%2037%3C%2Fspan%3E%20%3Cspan%3EFriday%2014%3A21%3C%2Fspan%3E%0A%3C%2Fdiv%3E" width="600" height="400"></iframe>
+  <p><iframe loading="lazy" src="data:text/html;charset=utf-8,%3C!DOCTYPE%20html%3E%0A%3Cstyle%3E%0A%20body%2C%20html%20%7B%20margin%3A%200%3B%20padding%3A%200%3B%20overflow%3A%20hidden%3B%20%7D%0A%20div%20%7B%20width%3A%20600px%3B%20height%3A%20400px%3B%20position%3A%20relative%3B%20%7D%0A%20p%20%7B%20position%3A%20absolute%3B%20top%3A%200%3B%20margin%3A%200.25em%3B%20font%3A%20small-caps%20900%202em%20sans-serif%3B%20text-shadow%3A%20white%200%200%204px%3B%20%7D%0A%20span%20%7B%20display%3A%20block%3B%20%7D%0A%20.left%20%7B%20color%3A%20red%3B%20left%3A%200%3B%20text-align%3A%20left%3B%20%7D%0A%20.right%20%7B%20color%3A%20blue%3B%20right%3A%200%3B%20text-align%3A%20right%3B%20%7D%0A%20.middle%20%7B%20color%3A%20white%3B%20top%3A%20auto%3B%20bottom%3A%200%3B%20left%3A%200%3B%20right%3A%200%3B%20text-align%3A%20center%3B%20text-shadow%3A%20black%200%200%204px%3B%20%7D%0A%20.middle%20span%20%7B%20display%3A%20inline-block%3B%20margin%3A%200%201em%3B%20font-size%3A%200.75em%3B%20text-transform%3A%20uppercase%3B%20%7D%0A%3C%2Fstyle%3E%0A%3Cdiv%3E%0A%20%3Cimg%20src%3D%22https%3A%2F%2Fhtml.spec.whatwg.org%2Fimages%2Frobots.jpeg%22%3E%0A%20%3Cp%20class%3D%22score%20left%22%3E%3Cspan%3ERed%20Alliance%3C%2Fspan%3E%20%3Cspan%3E78%3C%2Fspan%3E%3C%2Fp%3E%0A%20%3Cp%20class%3D%22score%20right%22%3E%3Cspan%3EBlue%20Alliance%3C%2Fspan%3E%20%3Cspan%3E66%3C%2Fspan%3E%3C%2Fp%3E%0A%20%3Cp%20class%3D%22score%20middle%22%3E%3Cspan%3EQual%20Match%2037%3C%2Fspan%3E%20%3Cspan%3EFriday%2014%3A21%3C%2Fspan%3E%0A%3C%2Fdiv%3E" width="600" height="400"></iframe>
 
   <p>In order to make the score display render correctly whenever the user seeks to an arbitrary
   point in the video, the metadata text track cues need to be as long as is appropriate for the
@@ -44923,7 +44923,7 @@ interface <dfn interface>HTMLAreaElement</dfn> : <span>HTMLElement</span> {
 
    <p>Consider an image that looks as follows:</p>
 
-   <p><img src="/images/sample-usemap.png" width="600" height="150" alt="A line with four shapes in it, equally spaced: a red hollow box, a green circle, a blue triangle, and a yellow four-pointed star."></p>
+   <p><img loading="lazy" src="/images/sample-usemap.png" width="600" height="150" alt="A line with four shapes in it, equally spaced: a red hollow box, a green circle, a blue triangle, and a yellow four-pointed star."></p>
 
    <p>If we wanted just the colored areas to be clickable, we could do it as follows:</p>
 
@@ -46947,7 +46947,7 @@ interface <dfn interface>HTMLTableCellElement</dfn> : <span>HTMLElement</span> {
    <p>The remaining headers apply just to the cells to the right of them.</p>
 
    <!-- image source: https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=151 -->
-   <img src="/images/table-scope-diagram.png" width="459" height="256" alt=""><!-- (alt is empty because the diagram is completely described by the previous paragraphs) -->
+   <img loading="lazy" src="/images/table-scope-diagram.png" width="459" height="256" alt=""><!-- (alt is empty because the diagram is completely described by the previous paragraphs) -->
 
   </div>
 
@@ -51837,7 +51837,7 @@ interface <dfn interface>HTMLInputElement</dfn> : <span>HTMLElement</span> {
    data-x="">https://streams.spec.whatwg.org/</code> in the recent past, then the rendering might look
    like this:</p>
 
-   <p><img src="/images/sample-url.svg" width="480" height="150" alt="A text box with an icon on the left followed by the text &quot;spec.w&quot; and a cursor, with a drop down button on the right hand side; with, below, a drop down box containing a list of six URLs on the left, with the first four having grayed out labels on the right; and a scrollbar to the right of the drop down box, indicating further values are available." class="darkmode-aware"></p>
+   <p><img loading="lazy" src="/images/sample-url.svg" width="480" height="150" alt="A text box with an icon on the left followed by the text &quot;spec.w&quot; and a cursor, with a drop down button on the right hand side; with, below, a drop down box containing a list of six URLs on the left, with the first four having grayed out labels on the right; and a scrollbar to the right of the drop down box, indicating further values are available." class="darkmode-aware"></p>
 
    <p>The first four URLs in this sample consist of the four URLs in the author-specified list that
    match the text the user has entered, sorted in some <span>implementation-defined</span> manner
@@ -53387,7 +53387,7 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
 
    <p>...might render as:</p>
 
-   <p><img src="/images/sample-range.png" width="49" height="75" alt="A vertical slider control whose primary color is black and whose background color is beige, with the slider having five tick marks, one long one at each extremity, and three short ones clustered around the midpoint.">
+   <p><img loading="lazy" src="/images/sample-range.png" width="49" height="75" alt="A vertical slider control whose primary color is black and whose background color is beige, with the slider having five tick marks, one long one at each extremity, and three short ones clustered around the midpoint.">
 
    <p>Note how the UA determined the orientation of the control from the ratio of the
    style-sheet-specified height and width properties. The colors were similarly derived from the
@@ -53408,11 +53408,12 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
 
    <p>A user agent could display in a variety of ways, for instance:</p>
 
-   <p><img src="/images/sample-range-2a.png" width="231" height="57" alt="As a dial."></p>
+   <p><img loading="lazy" src="/images/sample-range-2a.png" width="231" height="57"
+           alt="As a dial."></p>
 
    <p>Or, alternatively, for instance:</p>
 
-   <p><img src="/images/sample-range-2b.png" width="445" height="56" alt="As a long horizontal slider with tick marks."></p>
+   <p><img loading="lazy" src="/images/sample-range-2b.png" width="445" height="56" alt="As a long horizontal slider with tick marks."></p>
 
    <p>The user agent could pick which one to display based on the dimensions given in the style
    sheet. This would allow it to maintain the same resolution for the tick marks, despite the
@@ -53432,7 +53433,7 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
 
    <p>With styles that make the control draw vertically, it might look as follows:</p>
 
-   <p><img src="/images/sample-range-labels.png" width="103" height="164" alt="A vertical slider control with two tick marks, one near the top labeled 'High', and one near the bottom labeled 'Low'.">
+   <p><img loading="lazy" src="/images/sample-range-labels.png" width="103" height="164" alt="A vertical slider control with two tick marks, one near the top labeled 'High', and one near the bottom labeled 'Low'.">
 
   </div>
 
@@ -55231,7 +55232,7 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
    HTML, since the image is redundant with the previous paragraph. In particular, just describing
    the image would be especially bad for accessibility as it would be disorienting, there having
    been no mention that an image is present. -->
-   <p><img src="/images/sample-email-1.svg" width="330" height="100" alt="" class="darkmode-aware"></p>
+   <p><img loading="lazy" src="/images/sample-email-1.svg" width="330" height="100" alt="" class="darkmode-aware"></p>
 
    <p>The page could also link in the user's contacts database from the site:</p>
 
@@ -55252,7 +55253,7 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
    <!-- As above, having a non-empty alt="" attribute on the following image would be dumb, which is
    why it's left blank. The pertinent parts of the image are already described in the prose, and the
    non-pertinent parts aren't relevant to users who can't see the image, obviously. -->
-   <p><img src="/images/sample-email-2.svg" width="330" height="140" alt="" class="darkmode-aware"></p>
+   <p><img loading="lazy" src="/images/sample-email-2.svg" width="330" height="140" alt="" class="darkmode-aware"></p>
 
   </div>
 
@@ -55698,7 +55699,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
    data-x="concept-option-label">label</span> and <span data-x="concept-option-value">value</span>
    would be shown:</p>
 
-   <p><img src="/images/sample-datalist.svg" width="280" height="150" alt="A text box with a drop down button on the right hand side; with, below, a drop down box containing a list of the six values the left and the six labels on the right." class="darkmode-aware"></p>
+   <p><img loading="lazy" src="/images/sample-datalist.svg" width="280" height="150" alt="A text box with a drop down button on the right hand side; with, below, a drop down box containing a list of the six values the left and the six labels on the right." class="darkmode-aware"></p>
 
    <p>Then, typing "<kbd>arrow</kbd>" or "<kbd>=></kbd>" would filter the list to the entries with
    labels "arrow function" and "async arrow function". Typing "<kbd>generator</kbd>" or
@@ -59955,7 +59956,7 @@ and a height of &lt;meter value=2>2cm&lt;/meter>.&lt;/p> &lt;!-- <strong>BAD!</s
  &lt;/li>
 &lt;/ul></code></pre>
    <p>Might be rendered as follows:</p>
-   <p><img src="/images/sample-meter.png" width="332" height="178" alt="With the &lt;meter> elements rendered as inline green bars of varying lengths."></p>
+   <p><img loading="lazy" src="/images/sample-meter.png" width="332" height="178" alt="With the &lt;meter> elements rendered as inline green bars of varying lengths."></p>
   </div>
 
   <p>User agents <span w-nodev>may</span> combine the value of the <code
@@ -62742,13 +62743,16 @@ MIT Room 32-G524
 
      <p>This might render as follows:</p>
 
-     <p><img src="/images/select-country-1.png" alt="A drop-down control with a long alphabetical list of countries."></p>
+     <p><img loading="lazy" src="/images/select-country-1.png" width="232" height="172"
+             alt="A drop-down control with a long alphabetical list of countries."></p>
 
      <p>Suppose that on the first visit to this page, the user selects "Zambia". On the second visit,
      the user agent could duplicate the entry for Zambia at the top of the list, so that the interface
      instead looks like this:</p>
 
-     <p><img src="/images/select-country-2.png" alt="The same drop-down control with the alphabetical list of countries, but with Zambia as an entry at the top."></p>
+     <p><img loading="lazy" src="/images/select-country-2.png" width="232" height="172"
+             alt="The same drop-down control with the alphabetical list of countries, but with
+             Zambia as an entry at the top."></p>
 
     </div>
 
@@ -65630,7 +65634,7 @@ interface <dfn interface>HTMLDetailsElement</dfn> : <span>HTMLElement</span> {
    to collapse a set of fields down to a small set of headings, with the ability to open each
    one.</p>
 
-   <p class="details-example"><img src="/images/sample-details-1.png" width="345" height="611" alt=""><img src="/images/sample-details-2.png" width="345" height="666" alt=""></p>
+   <p class="details-example"><img loading="lazy" src="/images/sample-details-1.png" width="345" height="611" alt=""><img loading="lazy" src="/images/sample-details-2.png" width="345" height="666" alt=""></p>
 
    <p>In these examples, the summary really just summarizes what the controls can change, and not
    the actual values, which is less than ideal.</p>
@@ -67444,7 +67448,7 @@ interface <dfn interface>HTMLScriptElement</dfn> : <span>HTMLElement</span> {
 
   <p>This is all summarized in the following schematic diagram:</p>
 
-  <p><img src="/images/asyncdefer.svg" style="width: 80%; min-width: 820px;" alt="With &lt;script&gt;, parsing is interrupted by fetching and execution. With &lt;script defer&gt;, fetching is parallel to parsing and execution takes place after all parsing has finished. And with &lt;script async&gt;, fetching is parallel to parsing but once it finishes parsing is interrupted to execute the script. The story for &lt;script type=&quot;module&quot;&gt; is similar to &lt;script defer&gt;, but the dependencies will be fetched as well, and the story for &lt;script type=&quot;module&quot; async&gt; is similar to &lt;script async&gt; with the extra dependency fetching." class="darkmode-aware"></p>
+  <p><img loading="lazy" src="/images/asyncdefer.svg" width="820" height="200" style="width: 80%; min-width: 820px; height: auto;" alt="With &lt;script&gt;, parsing is interrupted by fetching and execution. With &lt;script defer&gt;, fetching is parallel to parsing and execution takes place after all parsing has finished. And with &lt;script async&gt;, fetching is parallel to parsing but once it finishes parsing is interrupted to execute the script. The story for &lt;script type=&quot;module&quot;&gt; is similar to &lt;script defer&gt;, but the dependencies will be fetched as well, and the story for &lt;script type=&quot;module&quot; async&gt; is similar to &lt;script async&gt; with the extra dependency fetching." class="darkmode-aware"></p>
 
   <p class="note" w-nodev>The exact processing details for these attributes are, for mostly
   historical reasons, somewhat non-trivial, involving a number of aspects of HTML. The
@@ -72140,7 +72144,7 @@ worker.postMessage(offscreenCanvas, [offscreenCanvas]);</code></pre>
   attribute's allowed keywords correspond to alignment points in the
   font:</p>
 
-  <p><img src="/images/baselines.png" width="738" height="300" alt="The em-over baseline is roughly at the top of the glyphs in a font, the hanging baseline is where some glyphs like &#x0906; are anchored, the middle is half-way between the em-over and em-under baselines, the alphabetic baseline is where characters like &#x00C1;, &#x00FF;, &#x0066;, and &#x03A9; are anchored, the ideographic-under baseline is where glyphs like &#x79C1; and &#x9054; are anchored, and the em-under baseline is roughly at the bottom of the glyphs in a font. The top and bottom of the bounding box can be far from these baselines, due to glyphs extending far outside em-over and em-under baselines."></p>
+  <p><img loading="lazy" src="/images/baselines.png" width="738" height="300" alt="The em-over baseline is roughly at the top of the glyphs in a font, the hanging baseline is where some glyphs like &#x0906; are anchored, the middle is half-way between the em-over and em-under baselines, the alphabetic baseline is where characters like &#x00C1;, &#x00FF;, &#x0066;, and &#x03A9; are anchored, the ideographic-under baseline is where glyphs like &#x79C1; and &#x9054; are anchored, and the em-under baseline is roughly at the bottom of the glyphs in a font. The top and bottom of the bounding box can be far from these baselines, due to glyphs extending far outside em-over and em-under baselines."></p>
 
   <p>The keywords map to these alignment points as follows:</p>
 
@@ -72591,9 +72595,9 @@ worker.postMessage(offscreenCanvas, [offscreenCanvas]);</code></pre>
     <figure class="diagrams">
      <!-- if anyone wants to try writing alternative text for these,
      be my guest. I can't work out how to describe them. -->
-     <img src="/images/arcTo1.png" alt="" width="357" height="254">
-     <img src="/images/arcTo2.png" alt="" width="468" height="310">
-     <img src="/images/arcTo3.png" alt="" width="513" height="233">
+     <img loading="lazy" src="/images/arcTo1.png" alt="" width="357" height="254">
+     <img loading="lazy" src="/images/arcTo2.png" alt="" width="468" height="310">
+     <img loading="lazy" src="/images/arcTo3.png" alt="" width="513" height="233">
     </figure>
 
 <!--
@@ -72749,7 +72753,7 @@ try {
 
     <figure class="diagrams">
      <!-- if anyone wants to try writing alternative text for this, be my guest. I can't work out how to describe it. -->
-     <img src="/images/arc1.png" alt="" width="590" height="255">
+     <img loading="lazy" src="/images/arc1.png" alt="" width="590" height="255">
     </figure>
 
 <!--
@@ -75182,11 +75186,11 @@ try {
    <dd>
     <p>Draws the given image onto the canvas. The arguments are interpreted as follows:</p>
 
-    <p><img src="/images/drawImage.png" width="356" height="356" alt="The sx and sy parameters give
-    the x and y coordinates of the source rectangle; the sw and sh arguments give the width and
-    height of the source rectangle; the dx and dy give the x and y coordinates of the destination
-    rectangle; and the dw and dh arguments give the width and height of the destination
-    rectangle."></p>
+    <p><img loading="lazy" src="/images/drawImage.png" width="356" height="356"
+    alt="The sx and sy parameters give the x and y coordinates of the source rectangle; the sw and
+    sh arguments give the width and height of the source rectangle; the dx and dy give the x and y
+    coordinates of the destination rectangle; and the dw and dh arguments give the width and height
+    of the destination rectangle."></p>
 
     <p>If the image isn't yet fully decoded, then nothing is drawn. If the image is a canvas with no
     data, throws an <span>"<code>InvalidStateError</code>"</span> <code>DOMException</code>.</p>
@@ -76244,7 +76248,8 @@ console.log(pixels.data[2]);
    <p>The 2D rendering context for <code>canvas</code> is often used for sprite-based games. The
    following example demonstrates this:</p>
 
-   <iframe src="/demos/canvas/blue-robot/index-idle.html" width="396" height="216"></iframe>
+   <iframe loading="lazy" src="/demos/canvas/blue-robot/index-idle.html" width="396"
+           height="216"></iframe>
 
    <p>Here is the source for this example:</p>
 
@@ -77345,37 +77350,37 @@ interface <dfn interface>OffscreenCanvasRenderingContext2D</dfn> {
       <td>255, 127, 0, 255
       <td>255, 127, 0, 255
       <td>Completely-opaque orange
-      <td><img src="/images/premultiplied-example-1.png" width="96" height="96" alt="An opaque orange circle sits atop a background">
+      <td><img loading="lazy" src="/images/premultiplied-example-1.png" width="96" height="96" alt="An opaque orange circle sits atop a background">
      <tr>
       <td>rgba(255, 255, 0, 0.5)
       <td>127, 127, 0, 127
       <td>255, 255, 0, 127
       <td>Halfway-opaque yellow
-      <td><img src="/images/premultiplied-example-2.png" width="96" height="96" alt="A yellow circle, halfway transparent, sits atop a background">
+      <td><img loading="lazy" src="/images/premultiplied-example-2.png" width="96" height="96" alt="A yellow circle, halfway transparent, sits atop a background">
      <tr>
       <td>Unrepresentable
       <td>255, 127, 0, 127
       <td>Unrepresentable
       <td>Additive halfway-opaque orange
-      <td><img src="/images/premultiplied-example-3.png" width="96" height="96" alt="An orange circle somewhat brightens the background that it sits atop">
+      <td><img loading="lazy" src="/images/premultiplied-example-3.png" width="96" height="96" alt="An orange circle somewhat brightens the background that it sits atop">
      <tr>
       <td>Unrepresentable
       <td>255, 127, 0, 0
       <td>Unrepresentable
       <td>Additive fully-transparent orange
-      <td><img src="/images/premultiplied-example-4.png" width="96" height="96" alt="An orange circle completely brightens the background that it sits atop">
+      <td><img loading="lazy" src="/images/premultiplied-example-4.png" width="96" height="96" alt="An orange circle completely brightens the background that it sits atop">
      <tr>
       <td>rgba(255, 127, 0, 0)
       <td>0, 0, 0, 0
       <td>255, 127, 0, 0
       <td>Fully-transparent ("invisible") orange
-      <td><img src="/images/premultiplied-example-5.png" width="96" height="96" alt="An empty background with nothing atop it">
+      <td><img loading="lazy" src="/images/premultiplied-example-5.png" width="96" height="96" alt="An empty background with nothing atop it">
      <tr>
       <td>rgba(0, 127, 255, 0)
       <td>0, 0, 0, 0
       <td>255, 127, 0, 0
       <td>Fully-transparent ("invisible") turquoise
-      <td><img src="/images/premultiplied-example-5.png" width="96" height="96" alt="An empty background with nothing atop it">
+      <td><img loading="lazy" src="/images/premultiplied-example-5.png" width="96" height="96" alt="An empty background with nothing atop it">
    </table>
   </div>
 
@@ -79284,7 +79289,7 @@ customElements.define("x-foo", class extends HTMLElement {
 
   <p>This is all summarized in the following schematic diagram:</p>
 
-  <p><img src="/images/custom-element-reactions.svg" style="width: 80%; max-width: 580px;" alt="A custom element reactions stack consists of a stack of element queues. Zooming in on a particular queue, we see that it contains a number of elements (in our example, &lt;x-a&gt;, then &lt;x-b&gt;, then &lt;x-c&gt;). Any particular element in the queue then has a custom element reaction queue. Zooming in on the custom element reaction queue, we see that it contains a variety of queued-up reactions (in our example, upgrade, then attribute changed, then another attribute changed, then connected)." class="darkmode-aware"></p>
+  <p><img loading="lazy" src="/images/custom-element-reactions.svg" width="580" height="390" style="width: 80%; max-width: 580px; height: auto;" alt="A custom element reactions stack consists of a stack of element queues. Zooming in on a particular queue, we see that it contains a number of elements (in our example, &lt;x-a&gt;, then &lt;x-b&gt;, then &lt;x-c&gt;). Any particular element in the queue then has a custom element reaction queue. Zooming in on the custom element reaction queue, we see that it contains a variety of queued-up reactions (in our example, upgrade, then attribute changed, then another attribute changed, then connected)." class="darkmode-aware"></p>
 
   <div algorithm>
   <p>To <dfn>enqueue an element on the appropriate element queue</dfn>, given an element
@@ -85295,7 +85300,7 @@ interface <dfn interface>VisibilityStateEntry</dfn> : <span>PerformanceEntry</sp
   &lt;/div>
 &lt;/section></code></pre>
 
-   <img src="/images/inert-example-loading-section.png" width="947" height="243" alt="Screenshot of Population by City content with an overlaid loading message which visually obscures the form controls and data table which have not fully rendered, and thus are in the inert state.">
+   <img loading="lazy" src="/images/inert-example-loading-section.png" width="947" height="243" alt="Screenshot of Population by City content with an overlaid loading message which visually obscures the form controls and data table which have not fully rendered, and thus are in the inert state.">
 
    <p>The "loading" overlay obscures the inert content, making it visually apparent that the inert
    content is not presently accessible. Notice that the heading and "loading" text are not
@@ -85885,7 +85890,7 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
    would have as its children the various links and text controls, as well as the dialog. The dialog
    itself would have as its children the text control and the button.</p>
 
-   <p><img src="/images/focus-tree.png" alt="" width=800 height=450> <!-- purely decorative: it repeats the previous
+   <p><img loading="lazy" src="/images/focus-tree.png" alt="" width=800 height=450> <!-- purely decorative: it repeats the previous
    paragraph, in graphical form -->
 
    <p>If the widget with <span data-x="focused">focus</span> in this example was the text control in
@@ -139644,7 +139649,7 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
   <h4>Overview of the parsing model</h4>
 
-  <p class="overview"><img src="/images/parsing-model-overview.svg" width="345" height="535" alt="" class="darkmode-aware"></p>
+  <p class="overview"><img loading="lazy" src="/images/parsing-model-overview.svg" width="345" height="535" alt="" class="darkmode-aware"></p>
 
   <p>The input to the HTML parsing process consists of a stream of <span data-x="code point">code
   points</span>, which is passed through a <span>tokenization</span> stage followed by a <span>tree
@@ -153341,7 +153346,8 @@ progress { appearance: auto; }</code></pre>
 
   <!-- https://software.hixie.ch/utilities/js/canvas/?c.clearRect(0%2C%200%2C%20640%2C%20480)%3B%0Ac.save()%3B%0Atry%20%7B%0A%20%20c.fillStyle%20%3D%20%27black%27%3B%0A%20%20c.font%20%3D%20%278px%20sans-serif%27%3B%0A%20%20c.fillText(%27Horizontal%20ltr%27%2C%2030%2C105)%3B%0A%20%20c.fillText(%27Horizontal%20rtl%27%2C125%2C105)%3B%0A%20%20c.fillText(%27Vertical%20ltr%27%2C%20192%2C105)%3B%0A%20%20c.fillText(%27Vertical%20rtl%27%2C%20233%2C105)%3B%0A%20%20c.font%20%3D%20%27700%2010px%20sans-serif%27%3B%0A%20%20c.fillText(%27Progress%20Bars%27%2C%2013%2C30)%3B%0A%20%20c.font%20%3D%20%27100%2010px%20sans-serif%27%3B%0A%20%20c.fillText(%27(80%25)%27%2C%2037%2C45)%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(10%2C0%2C80%2C0)%3B%0A%20%20g.addColorStop(0%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.8%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.9%2C%20%27%23FFFF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(10%2C80%2C80%2C15)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(105%2C0%2C175%2C0)%3B%0A%20%20g.addColorStop(0%2C%20%27%23FFFF00%27)%3B%0A%20%20g.addColorStop(0.2%2C%20%27%23FFFF00%27)%3B%0A%20%20g.addColorStop(0.4%2C%20%27%2300FF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(105%2C80%2C80%2C15)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(0%2C80%2C0%2C20)%3B%0A%20%20g.addColorStop(0%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.75%2C%20%27%2300FF00%27)%3B%0A%20%20g.addColorStop(0.85%2C%20%27%23FFFF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(203%2C15%2C15%2C80)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%0A%20%20c.beginPath()%3B%0A%20%20var%20g%20%3D%20c.createLinearGradient(0%2C80%2C0%2C20)%3B%0A%20%20g.addColorStop(0%2C%20%27%23FFFF00%27)%3B%0A%20%20g.addColorStop(0.15%2C%20%27%2300FF00%27)%3B%0A%20%20c.fillStyle%20%3D%20g%3B%0A%20%20c.rect(242%2C15%2C15%2C80)%3B%0A%20%20c.fill()%3B%0A%20%20c.strokeStyle%20%3D%20%27black%27%3B%0A%20%20c.stroke()%3B%0A%7D%20finally%20%7B%0A%20%20c.restore()%3B%0A%7D%0A -->
 
-  <p> <img src="/images/sample-progress.png" alt="" width=276 height=115 class="extra"> When this
+  <p> <img loading="lazy" src="/images/sample-progress.png" alt="" width=276 height=115
+  class="extra"> When this
   element has a <span>horizontal writing mode</span>, the element is <span>expected</span> to be
   depicted as a horizontal progress bar. The start is on the right and the end is on the left if
   the <span>'direction'</span> property on this element has a <span>computed value</span> of 'rtl',
@@ -154227,7 +154233,8 @@ select {
    ensure that the punctuation was the same both in the drop down, and in the box showing the
    current selection.</p>
 
-   <p><img src="/images/bidiselect.png" width="206" height="105" alt=""></p> <!-- no need for alt
+   <p><img loading="lazy" src="/images/bidiselect.png" width="206" height="105" alt=""></p>
+   <!-- no need for alt
    text, the previous paragraph describes it completely -->
 
   </div>


### PR DESCRIPTION
Add `loading="lazy"` to every `<img>` and `<iframe>` in the spec, except the WHATWG logo in the header, to improve page loading performance.

Six images had no dimensions to lay out with while unloaded, and so would have shifted layout on scroll. They now carry `width` and `height` attributes: the intrinsic sizes for `sample-bdi.png`, `sample-not-bdi.png`, `select-country-1.png`, and `select-country-2.png`, and sizes matching the `viewBox` aspect ratio for `asyncdefer.svg` and `custom-element-reactions.svg`, whose rendered size continues to come from their `style` attributes.

Part of #12782.
