### PR TITLE
Allow a Window as the target of "fire a focus event"

### DIFF
--- a/source
+++ b/source
@@ -86936,18 +86936,18 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
 
   <div algorithm>
   <p>To <dfn>fire a focus event</dfn> named <var>e</var> at an element or a <code>Window</code>
-  object <var>t</var> given a related target <var>r</var>:</p>
+  object <var>target</var> given a related target <var>relatedTarget</var>:</p>
 
   <ol>
-   <li><p>If <var>t</var> is a <code>Window</code> object, then let <var>view</var> be <var>t</var>.
-   Otherwise, let <var>view</var> be <var>t</var>'s <span>node document</span>'s <span>relevant
-   global object</span>.</p></li>
+   <li><p>Let <var>view</var> be <var>target</var> if <var>target</var> is a <code>Window</code>
+   object; otherwise <var>target</var>'s <span>node document</span>'s <span>relevant global
+   object</span>.</p></li>
 
-   <li><p><span data-x="concept-event-fire">Fire an event</span> named <var>e</var> at <var>t</var>,
-   using <code>FocusEvent</code>, with the <code
-   data-x="dom-FocusEvent-relatedTarget">relatedTarget</code> attribute initialized to <var>r</var>,
-   the <code data-x="dom-UIEvent-view">view</code> attribute initialized to <var>view</var>, and the
-   <span>composed flag</span> set.</p></li>
+   <li><p><span data-x="concept-event-fire">Fire an event</span> named <var>e</var> at
+   <var>target</var>, using <code>FocusEvent</code>, with the <code
+   data-x="dom-FocusEvent-relatedTarget">relatedTarget</code> attribute initialized to
+   <var>relatedTarget</var>, the <code data-x="dom-UIEvent-view">view</code> attribute initialized
+   to <var>view</var>, and the <span>composed flag</span> set.</p></li>
   </ol>
   </div>
 

--- a/source
+++ b/source
@@ -86935,13 +86935,20 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
   </div>
 
   <div algorithm>
-  <p>To <dfn>fire a focus event</dfn> named <var>e</var> at an element <var>t</var> with a given
-  related target <var>r</var>, <span data-x="concept-event-fire">fire an event</span> named
-  <var>e</var> at <var>t</var>, using <code>FocusEvent</code>, with the <code
-  data-x="dom-FocusEvent-relatedTarget">relatedTarget</code> attribute initialized to <var>r</var>,
-  the <code data-x="dom-UIEvent-view">view</code> attribute initialized to <var>t</var>'s
-  <span>node document</span>'s <span>relevant global object</span>, and the <span>composed
-  flag</span> set.</p>
+  <p>To <dfn>fire a focus event</dfn> named <var>e</var> at an element or a <code>Window</code>
+  object <var>t</var> given a related target <var>r</var>:</p>
+
+  <ol>
+   <li><p>If <var>t</var> is a <code>Window</code> object, then let <var>view</var> be <var>t</var>.
+   Otherwise, let <var>view</var> be <var>t</var>'s <span>node document</span>'s <span>relevant
+   global object</span>.</p></li>
+
+   <li><p><span data-x="concept-event-fire">Fire an event</span> named <var>e</var> at <var>t</var>,
+   using <code>FocusEvent</code>, with the <code
+   data-x="dom-FocusEvent-relatedTarget">relatedTarget</code> attribute initialized to <var>r</var>,
+   the <code data-x="dom-UIEvent-view">view</code> attribute initialized to <var>view</var>, and the
+   <span>composed flag</span> set.</p></li>
+  </ol>
   </div>
 
   <hr>


### PR DESCRIPTION
"Fire a focus event" was defined as taking an element, but the focus update steps invoke it with a `Window` object when the entry is a `Document`, and a `Window` has no node document to get the `view` attribute's value from.

Fixes #12866.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko (already passes the test)
   * Chromium (https://issues.chromium.org/issues/557343011#comment2)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62344
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/557343011
   * Gecko: N/A
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=323595
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Wattsi server error :boom: ###

[PR Preview](https://github.com/specinfra/pr-preview#pr-preview) failed to build. _(Last tried on Sep 7, 2026, 10:02 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Wattsi Server](https://github.com/domenic/wattsi-server) - Wattsi Server is the web service used to build the WHATWG HTML spec.

:link: [Related URL](https://build.whatwg.org/wattsi)

**Error output:**

```
      <!DOCTYPE html>
      <html>
      <head>
          <meta name="viewport" content="width=device-width, initial-scale=1">
          <meta name="robots" content="noindex">
          <style>body,html{height:100%;margin:0}body{display:flex;align-items:center;justify-content:center;flex-direction:column;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}p{text-align:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;color:#000;font-size:14px;margin-top:-50px}p.code{font-size:24px;font-weight:500;border-bottom:1px solid #e0e1e2;padding:0 20px 15px}p.text{margin:0}a,a:visited{color:#aaa}</style>
      </head>
      <body>
      <p class="code">
        Error code: 503      </p>
      <p class="text">
        Well, This is unexpected. An Error has occurred, and we are working to fix the problem! We will be up and running shortly. Try refreshing the page or try again in a few minutes.
      </p>
        <div style="display:none;">
          <h1>
    upstream_reset_before_response_started{connection_termination} (503 UC)      </h1>
          <p data-translate="connection_timed_out">App Platform failed to forward this request to the application.</p>
      </div>
      </body>
      </html>
    
```

_This seems to be an issue with the [Wattsi Server](https://github.com/domenic/wattsi-server) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Wattsi Server](https://github.com/domenic/wattsi-server/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Wattsi Server, you can [file an issue with PR Preview](https://github.com/specinfra/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/html%2312875.)._

</details>
