### PR TITLE
Expose elements from any namespace by ID on the Window object

### DIFF
--- a/source
+++ b/source
@@ -97701,10 +97701,9 @@ dictionary <dfn dictionary>WindowPostMessageOptions</dfn> : <span>StructuredSeri
    tree</span> with <var>window</var>'s <span data-x="concept-document-window">associated
    <code>Document</code></span> as their <span>root</span>; and</p></li>
 
-   <li><p>the value of the <code data-x="attr-id">id</code> content attribute for all <span>HTML
-   elements</span> that have a non-empty <code data-x="attr-id">id</code> content attribute and are
-   <span>in a document tree</span> with <var>window</var>'s <span
-   data-x="concept-document-window">associated <code>Document</code></span> as their
+   <li><p>the <span data-x="concept-id">ID</span> of all elements that have an <span
+   data-x="concept-id">ID</span> and are <span>in a document tree</span> with <var>window</var>'s
+   <span data-x="concept-document-window">associated <code>Document</code></span> as their
    <span>root</span>.</p></li>
   </ul>
   </div>
@@ -97765,9 +97764,9 @@ dictionary <dfn dictionary>WindowPostMessageOptions</dfn> : <span>StructuredSeri
    data-x="concept-document-window">associated <code>Document</code></span> as their
    <span>root</span>; and</p></li>
 
-   <li><p><span>HTML elements</span> that have an <code data-x="attr-id">id</code> content attribute
-   whose value is <var>name</var> and are <span>in a document tree</span> with <var>window</var>'s
-   <span data-x="concept-document-window">associated <code>Document</code></span> as their
+   <li><p>elements whose <span data-x="concept-id">ID</span> is <var>name</var> and that are
+   <span>in a document tree</span> with <var>window</var>'s <span
+   data-x="concept-document-window">associated <code>Document</code></span> as their
    <span>root</span>.</p></li>
   </ul>
   </div>


### PR DESCRIPTION
Expose elements from any namespace by ID on the Window object

All engines expose any element with an ID, not just HTML elements, so
use DOM's ID concept for these two lists. This matches how the
"all"-named element(s) of an HTMLAllCollection are already defined.

Tests: https://github.com/web-platform-tests/wpt/pull/62350

Fixes #9766.

---

- [x] At least two implementers are interested (and none opposed); N/A, already implemented (except for one minor bug in Gecko)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62350
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   - [x] Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2068116 
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.
