### PR TITLE
Trigger media element resource selection algorithm from source element moving steps

### DIFF
--- a/source
+++ b/source
@@ -31028,6 +31028,13 @@ interface <dfn interface>HTMLSourceElement</dfn> : <span>HTMLElement</span> {
   <var>isSubtreeRoot</var>, and <var>oldAncestor</var> are:</p>
 
   <ol>
+   <li><p>If <var>movedNode</var>'s <span>parent</span> is a <span>media element</span> that has no
+   <code data-x="attr-media-src">src</code> attribute and whose <code
+   data-x="dom-media-networkState">networkState</code> has the value <code
+   data-x="dom-media-NETWORK_EMPTY">NETWORK_EMPTY</code>, then invoke that <span>media
+   element</span>'s <span data-x="concept-media-load-algorithm">resource selection
+   algorithm</span>.</p></li>
+
    <li><p>If <var>isSubtreeRoot</var> is true and <var>oldAncestor</var> is a <code>picture</code>
    element, then <span data-x="list iterate">for each</span> <var>child</var> of
    <var>oldAncestor</var>'s <span data-x="concept-tree-child">children</span>: if <var>child</var>


### PR DESCRIPTION
<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Trigger media element resource selection algorithm from source element moving steps

Fixes #12879 

- [x] At least two implementers are interested (and none opposed):
   * Already implemented in Gecko, Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62424
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=320463
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
