### PR TITLE
Give documents created by the HTML parsing APIs an origin

### DIFF
--- a/source
+++ b/source
@@ -125781,11 +125781,16 @@ enum <dfn enum>DOMParserSupportedType</dfn> {
    object</span>, <var>string</var>, "<code data-x="">DOMParser parseFromString</code>", and "<code
    data-x="">script</code>".</p></li>
 
+   <li><p>Let <var>relevantDocument</var> be <span>this</span>'s <span>relevant global
+   object</span>'s <span data-x="concept-document-window">associated
+   <code>Document</code></span>.</p></li>
+
    <li>
     <p>Let <var>document</var> be a new <code>Document</code>, whose <span
-    data-x="concept-document-content-type">content type</span> is <var>type</var> and <span
-    data-x="concept-document-URL">URL</span> is <span>this</span>'s <span>relevant global object</span>'s <span
-    data-x="concept-document-window">associated <code>Document</code></span>'s <span
+    data-x="concept-document-content-type">content type</span> is <var>type</var>, <span
+    data-x="concept-document-origin">origin</span> is <var>relevantDocument</var>'s <span
+    data-x="concept-document-origin">origin</span>, and <span
+    data-x="concept-document-URL">URL</span> is <var>relevantDocument</var>'s <span
     data-x="concept-document-URL">URL</span>.</p>
     <!-- When https://github.com/whatwg/html/issues/4792 gets fixed we need to investigate which of
          HTMLDocument vs. XMLDocument gets returned, and when, with tests. In particular we'll want
@@ -126018,7 +126023,10 @@ enum <dfn enum>DOMParserSupportedType</dfn> {
    <li>
     <p>Let <var>document</var> be a new <code>Document</code>, whose <span
     data-x="concept-document-content-type">content type</span> is "<code
-    data-x="">text/html</code>".</p>
+    data-x="">text/html</code>" and <span data-x="concept-document-origin">origin</span> is
+    <span>this</span>'s <span>relevant global object</span>'s <span
+    data-x="concept-document-window">associated <code>Document</code></span>'s <span
+    data-x="concept-document-origin">origin</span>.</p>
 
     <p class="note">Since <var>document</var> does not have a <span
     data-x="concept-document-bc">browsing context</span>, <span data-x="concept-n-script">scripting
@@ -126057,7 +126065,10 @@ enum <dfn enum>DOMParserSupportedType</dfn> {
    <li>
     <p>Let <var>document</var> be a new <code>Document</code>, whose <span
     data-x="concept-document-content-type">content type</span> is "<code
-    data-x="">text/html</code>".</p>
+    data-x="">text/html</code>" and <span data-x="concept-document-origin">origin</span> is
+    <span>this</span>'s <span>relevant global object</span>'s <span
+    data-x="concept-document-window">associated <code>Document</code></span>'s <span
+    data-x="concept-document-origin">origin</span>.</p>
 
     <p class="note">Since <var>document</var> does not have a <span
     data-x="concept-document-bc">browsing context</span>, <span data-x="concept-n-script">scripting


### PR DESCRIPTION
DOMParser's parseFromString(), Document.parseHTML(), and
Document.parseHTMLUnsafe() created "a new Document" without setting its origin,
leaving it opaque. That is observable through document.domain and it makes the
document open steps throw a "SecurityError" DOMException, as an opaque origin is
never same origin with the entry document.

DOM's createDocument(), createHTMLDocument(), and the Document constructor all
inherit the origin of the document that created them, so do the same here.

Fixes #11429 & #12878. 

- [x] At least two implementers are interested (and none opposed):
   * Chromium presumably
   * Gecko presumably
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/declarative/declarative-shadow-dom-opt-in.html
   * https://github.com/web-platform-tests/wpt/pull/62388
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit:  https://bugs.webkit.org/show_bug.cgi?id=323212
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
