### PR TITLE
Editorial: use Fetch's response redirect taint

### DIFF
--- a/source
+++ b/source
@@ -2712,7 +2712,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
        <li><dfn data-x="concept-response-location-url" data-x-href="https://fetch.spec.whatwg.org/#concept-response-location-url">location URL</dfn></li>
        <li><dfn data-x="concept-response-timing-info" data-x-href="https://fetch.spec.whatwg.org/#concept-response-timing-info">timing info</dfn></li>
        <li><dfn data-x="concept-response-service-worker-timing-info" data-x-href="https://fetch.spec.whatwg.org/#response-service-worker-timing-info">service worker timing info</dfn></li>
-       <li><dfn data-x="concept-response-has-cross-origin-redirects" data-x-href="https://fetch.spec.whatwg.org/#response-has-cross-origin-redirects">has-cross-origin-redirects</dfn></li>
+       <li><dfn data-x="concept-response-redirect-taint" data-x-href="https://fetch.spec.whatwg.org/#response-redirect-taint">redirect taint</dfn></li>
        <li><dfn data-x="concept-response-timing-allow-passed" data-x-href="https://fetch.spec.whatwg.org/#concept-response-timing-allow-passed">timing allow passed</dfn></li>
        <li>
         <dfn data-x-href="https://wicg.github.io/background-fetch/#extract-content-range-values">extract content-range values</dfn>
@@ -113295,9 +113295,10 @@ location.href = '#foo';</code></pre>
      <dd><var>loadTimingInfo</var></dd>
 
      <dt><span>was created via cross-origin redirects</span></dt>
-     <dd><var>navigationParams</var>'s <span data-x="navigation-params-response">response</span>'s
-     <span data-x="concept-response-has-cross-origin-redirects">has cross-origin
-     redirects</span></dd>
+     <dd>true if <var>navigationParams</var>'s <span
+     data-x="navigation-params-response">response</span>'s <span
+     data-x="concept-response-redirect-taint">redirect taint</span> is not "<code
+     data-x="">same-origin</code>"; otherwise false</dd>
 
      <dt><span data-x="concept-document-navigation-id">during-loading navigation ID for WebDriver BiDi</span></dt>
      <dd><var>navigationParams</var>'s <span data-x="navigation-params-id">id</span></dd>
@@ -113374,8 +113375,8 @@ location.href = '#foo';</code></pre>
      <li>
       <p>If <var>navigationParams</var>'s <span
       data-x="navigation-params-response">response</span>'s <span
-      data-x="concept-response-has-cross-origin-redirects">has cross-origin redirects</span> is
-      false, or all of the following are true:</p>
+      data-x="concept-response-redirect-taint">redirect taint</span> is "<code
+      data-x="">same-origin</code>", or all of the following are true:</p>
 
       <ul>
        <li><p><var>navigationParams</var>'s <span


### PR DESCRIPTION
Fetch replaced a response's has-cross-origin-redirects boolean with a
redirect taint enum in
https://github.com/whatwg/fetch/commit/1d9380b52934145c884cde19a9f202a5ca0de480,
where the former being true corresponds to the latter not being
"same-origin".

Fixes #12885.
