### PR TITLE
Move away from Fetch's synchronous flag

### DIFF
--- a/source
+++ b/source
@@ -2741,7 +2741,6 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
        <li><dfn data-x="concept-request-priority" data-x-href="https://fetch.spec.whatwg.org/#request-priority">priority</dfn></li>
        <li><dfn data-x="concept-request-origin" data-x-href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</dfn></li>
        <li><dfn data-x="concept-request-referrer" data-x-href="https://fetch.spec.whatwg.org/#concept-request-referrer">referrer</dfn></li>
-       <li><dfn data-x-href="https://fetch.spec.whatwg.org/#synchronous-flag">synchronous flag</dfn></li>
        <li><dfn data-x="concept-request-mode" data-x-href="https://fetch.spec.whatwg.org/#concept-request-mode">mode</dfn></li>
        <li><dfn data-x="concept-request-credentials-mode" data-x-href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">credentials mode</dfn></li>
        <li><dfn data-x-href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">use-URL-credentials flag</dfn></li>
@@ -17052,8 +17051,6 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
 
    <li><p>If <var>request</var> is null, then return.</p></li>
 
-   <li><p>Set <var>request</var>'s <span>synchronous flag</span>.</p></li>
-
    <li><p>Run the <span>linked resource fetch setup steps</span>, given <var>el</var> and
    <var>request</var>. If the result is false, then return.</p></li>
 
@@ -27390,23 +27387,22 @@ document.body.appendChild(wbr);</code></pre>
     </ol>
    </li>
 
+   <li><p>Optionally, the user agent may return, if it believes doing so would safeguard the user
+   from a potentially hostile download.</p></li>
+
+   <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose <span
+   data-x="concept-request-url">URL</span> is <var>urlString</var>, <span
+   data-x="concept-request-client">client</span> is <span>entry settings object</span>, <span
+   data-x="concept-request-initiator">initiator</span> is "<code data-x="">download</code>", <span
+   data-x="concept-request-destination">destination</span> is the empty string, and whose
+   <span>use-URL-credentials flag</span> is set.</p></li>
+
    <li>
-    <p>Run these steps <span>in parallel</span>:</p>
+    <p><span data-x="concept-fetch">Fetch</span> <var>request</var>, with <i
+    data-x="processResponse">processResponse</i> set to the following steps given <span
+    data-x="concept-response">response</span> <var>response</var>:</p>
 
     <ol>
-     <li><p>Optionally, the user agent may abort these steps, if it believes doing so would
-     safeguard the user from a potentially hostile download.</p></li>
-
-     <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose
-     <span data-x="concept-request-url">URL</span> is <var>urlString</var>, <span
-     data-x="concept-request-client">client</span> is <span>entry settings object</span>, <span
-     data-x="concept-request-initiator">initiator</span> is "<code data-x="">download</code>", <span
-     data-x="concept-request-destination">destination</span> is the empty string, and whose
-     <span>synchronous flag</span> and <span>use-URL-credentials flag</span> are set.</p></li>
-
-     <li><p>Let <var>response</var> be the result of <span data-x="concept-fetch">fetching</span>
-     <var>request</var>.</p></li>
-
      <!--FETCH--><li><p><span>Handle as a download</span> <var>response</var> with
      <var>subject</var>'s <span>node navigable</span> and null.</p></li>
     </ol>
@@ -28653,7 +28649,7 @@ document.body.appendChild(wbr);</code></pre>
   <p>In the absence of a <code>link</code> with the <code data-x="rel-icon">icon</code> keyword, for
   <code>Document</code> objects whose <span data-x="concept-document-url">URL</span>'s
   <span data-x="concept-url-scheme">scheme</span> is an <span>HTTP(S) scheme</span>, user agents may
-  instead run these steps <span>in parallel</span>:</p>
+  instead run these steps:</p>
 
   <ol>
    <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose
@@ -28662,16 +28658,20 @@ document.body.appendChild(wbr);</code></pre>
    <code>Document</code> object's <span data-x="concept-document-url">URL</span>, <span
    data-x="concept-request-client">client</span> is the <code>Document</code> object's
    <span>relevant settings object</span>, <span
-   data-x="concept-request-destination">destination</span> is "<code data-x="">image</code>",
-   <span>synchronous flag</span> is set, <span data-x="concept-request-credentials-mode">credentials
-   mode</span> is "<code data-x="">include</code>", and whose <span>use-URL-credentials flag</span>
-   is set.</p></li>
+   data-x="concept-request-destination">destination</span> is "<code data-x="">image</code>", <span
+   data-x="concept-request-credentials-mode">credentials mode</span> is "<code
+   data-x="">include</code>", and whose <span>use-URL-credentials flag</span> is set.</p></li>
 
-   <!--FETCH--><li><p>Let <var>response</var> be the result of <span
-   data-x="concept-fetch">fetching</span> <var>request</var>.</p></li>
+   <!--FETCH--><li>
+    <p><span data-x="concept-fetch">Fetch</span> <var>request</var>, with <i
+    data-x="processResponse">processResponse</i> set to the following steps given <span
+    data-x="concept-response">response</span> <var>response</var>:</p>
 
-   <li><p>Use <var>response</var>'s <span>unsafe response</span> as an icon as if it had been
-   declared using the <code data-x="rel-icon">icon</code> keyword.</p></li>
+    <ol>
+     <li><p>Use <var>response</var>'s <span>unsafe response</span> as an icon as if it had been
+     declared using the <code data-x="rel-icon">icon</code> keyword.</p></li>
+    </ol>
+   </li>
   </ol>
   </div>
 
@@ -34225,52 +34225,7 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
    <span>in parallel</span>.</p></li>
 
    <li>
-    <p>If the <span>list of available images</span> contains an entry for <var>key</var>,
-    then set <var>image request</var>'s <span data-x="img-req-data">image data</span> to that of the entry.
-    Continue to the next step.</p>
-
-    <p>Otherwise:</p>
-
-    <ol>
-     <li><p>Let <var>request</var> be the result of <span
-     data-x="create a potential-CORS request">creating a potential-CORS request</span> given
-     <var>urlString</var>, "<code data-x="">image</code>", and
-     <var>corsAttributeState</var>.</p></li>
-
-     <li><p>Set <var>request</var>'s <span data-x="concept-request-client">client</span> to
-     <var>client</var>, set <var>request</var>'s <span data-x="concept-request-initiator">initiator</span> to "<code
-     data-x="">imageset</code>", and set <var>request</var>'s <span>synchronous
-     flag</span>.</p></li>
-
-     <li><p>Set <var>request</var>'s
-     <span data-x="concept-request-referrer-policy">referrer policy</span> to the current state of
-     the element's <code data-x="attr-img-referrerpolicy">referrerpolicy</code> attribute.</p></li>
-
-     <li><p>Set <var>request</var>'s <span
-     data-x="concept-request-priority">priority</span> to the current state of the element's <code
-     data-x="attr-img-fetchpriority">fetchpriority</code> attribute.</p></li>
-
-     <!--FETCH--><li><p>Let <var>response</var> be the result of <span
-     data-x="concept-fetch">fetching</span> <var>request</var>.</p></li>
-
-     <li><p>If <var>response</var>'s <span>unsafe response</span> is a <span>network error</span> or
-     if the image format is unsupported (as determined by applying the <span
-     data-x="Content-Type sniffing: image">image sniffing rules</span>, again as mentioned earlier),
-     or if the user agent is able to determine that <var>image request</var>'s image is corrupted in
-     some fatal way such that the image dimensions cannot be obtained, or if the resource type is
-     <code>multipart/x-mixed-replace</code>, then set the <span>pending request</span> to null and abort
-     these steps.</p></li>
-
-     <li><p>Otherwise, <var>response</var>'s <span>unsafe response</span> is <var>image
-     request</var>'s <span data-x="img-req-data">image data</span>. It can be either
-     <span>CORS-same-origin</span> or <span>CORS-cross-origin</span>; this affects the image's
-     interaction with other APIs (e.g., when used on a <code>canvas</code>).</p></li>
-    </ol>
-   </li>
-
-   <li>
-    <p><span>Queue an element task</span> on the <span>DOM manipulation task source</span> given
-    the <code>img</code> element and the following steps:</p>
+    <p>Let <var>finishUpdate</var> be the following steps:</p>
 
     <ol>
      <li><p>If the <code>img</code> element has experienced <span>relevant mutations</span>
@@ -34294,6 +34249,66 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
 
      <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
      data-x="event-load">load</code> at the <code>img</code> element.</p></li>
+    </ol>
+   </li>
+
+   <li>
+    <p>If the <span>list of available images</span> contains an entry for <var>key</var>:</p>
+
+    <ol>
+     <li><p>Set <var>image request</var>'s <span data-x="img-req-data">image data</span> to that of
+     the entry.</p></li>
+
+     <li><p><span>Queue an element task</span> on the <span>DOM manipulation task source</span>
+     given the <code>img</code> element and <var>finishUpdate</var>.</p></li>
+    </ol>
+   </li>
+
+   <li>
+    <p>Otherwise:</p>
+
+    <ol>
+     <li><p>Let <var>request</var> be the result of <span
+     data-x="create a potential-CORS request">creating a potential-CORS request</span> given
+     <var>urlString</var>, "<code data-x="">image</code>", and
+     <var>corsAttributeState</var>.</p></li>
+
+     <li><p>Set <var>request</var>'s <span data-x="concept-request-client">client</span> to
+     <var>client</var> and set <var>request</var>'s <span
+     data-x="concept-request-initiator">initiator</span> to "<code
+     data-x="">imageset</code>".</p></li>
+
+     <li><p>Set <var>request</var>'s
+     <span data-x="concept-request-referrer-policy">referrer policy</span> to the current state of
+     the element's <code data-x="attr-img-referrerpolicy">referrerpolicy</code> attribute.</p></li>
+
+     <li><p>Set <var>request</var>'s <span
+     data-x="concept-request-priority">priority</span> to the current state of the element's <code
+     data-x="attr-img-fetchpriority">fetchpriority</code> attribute.</p></li>
+
+     <!--FETCH--><li>
+      <p><span data-x="concept-fetch">Fetch</span> <var>request</var>, with <i
+      data-x="processResponse">processResponse</i> set to the following steps given <span
+      data-x="concept-response">response</span> <var>response</var>:</p>
+
+      <ol>
+       <li><p>If <var>response</var>'s <span>unsafe response</span> is a <span>network error</span>
+       or if the image format is unsupported (as determined by applying the <span
+       data-x="Content-Type sniffing: image">image sniffing rules</span>, again as mentioned
+       earlier), or if the user agent is able to determine that <var>image request</var>'s image is
+       corrupted in some fatal way such that the image dimensions cannot be obtained, or if the
+       resource type is <code>multipart/x-mixed-replace</code>, then set the <span>pending
+       request</span> to null and return.</p></li>
+
+       <li><p>Otherwise, <var>response</var>'s <span>unsafe response</span> is <var>image
+       request</var>'s <span data-x="img-req-data">image data</span>. It can be either
+       <span>CORS-same-origin</span> or <span>CORS-cross-origin</span>; this affects the image's
+       interaction with other APIs (e.g., when used on a <code>canvas</code>).</p></li>
+
+       <li><p><span>Queue an element task</span> on the <span>DOM manipulation task source</span>
+       given the <code>img</code> element and <var>finishUpdate</var>.</p></li>
+      </ol>
+     </li>
     </ol>
    </li>
   </ol>


### PR DESCRIPTION
Fetch removed a request's synchronous flag in
https://github.com/whatwg/fetch/commit/12dd6fa8ca76bd3bdff0c65a0c5a84b3ca870c3d,
making blocking a thread the caller's responsibility, but four callers
still set it. Three of them also still expected fetch to return a
response, so they now pass processResponse instead:

* 'Download the hyperlink' and the default favicon steps. As fetch no
  longer blocks, the surrounding "in parallel" is gone as well.

* 'React to changes in the environment', whose steps following the fetch
  are now nested. The tail shared with the cached branch is factored out
  as finishUpdate.

'Default fetch and process the linked resource' was already given
processResponseConsumeBody in c196f1bca137b37e4ab420dc79dac2360e5dadec;
only the flag was left over.
