### PR TITLE
Editorial: fix broken cross-specification references

### DIFF
--- a/source
+++ b/source
@@ -2534,7 +2534,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      data-x-href="https://www.rfc-editor.org/rfc/rfc6694#section-2"><code>about:</code></dfn> scheme
      <ref>ABOUT</ref></li>
      <li>The <dfn data-x="blob protocol"
-     data-x-href="https://w3c.github.io/FileAPI/#DefinitionOfScheme"><code>blob:</code></dfn> scheme
+     data-x-href="https://w3c.github.io/FileAPI/#blob-url"><code>blob:</code></dfn> scheme
      <ref>FILEAPI</ref></li>
      <li>The <dfn data-x="data protocol"
      data-x-href="https://www.rfc-editor.org/rfc/rfc2397#section-2"><code>data:</code></dfn> scheme
@@ -3378,7 +3378,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <dfn data-x="concept-event-dispatch" data-x-href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</dfn> algorithm</li>
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#dictdef-eventinit"><code>EventInit</code></dfn> dictionary type</li>
      <li><dfn data-x="dom-Event-type" data-x-href="https://dom.spec.whatwg.org/#dom-event-type"><code>type</code></dfn> attribute</li>
-     <li>An event's <dfn data-x="concept-event-target" data-x-href="https://dom.spec.whatwg.org/#concept-event-target">target</dfn></li>
+     <li>An event's <dfn data-x="concept-event-target" data-x-href="https://dom.spec.whatwg.org/#event-target">target</dfn></li>
      <li><dfn data-x="dom-Event-currentTarget" data-x-href="https://dom.spec.whatwg.org/#dom-event-currenttarget"><code>currentTarget</code></dfn> attribute</li>
      <li><dfn data-x="dom-Event-bubbles" data-x-href="https://dom.spec.whatwg.org/#dom-event-bubbles"><code>bubbles</code></dfn> attribute</li>
      <li><dfn data-x="dom-Event-cancelable" data-x-href="https://dom.spec.whatwg.org/#dom-event-cancelable"><code>cancelable</code></dfn> attribute</li>
@@ -3668,7 +3668,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
     <p>The following features are defined in <cite>Battery Status API</cite>: <ref>BATTERY</ref></p>
 
     <ul class="brief">
-     <li><dfn data-x="dom-navigator-getBattery" data-x-href="https://w3c.github.io/battery/#widl-Navigator-getBattery-Promise-BatteryManager"><code>getBattery()</code></dfn> method</li>
+     <li><dfn data-x="dom-navigator-getBattery" data-x-href="https://w3c.github.io/battery/#dom-navigator-getbattery"><code>getBattery()</code></dfn> method</li>
     </ul>
    </dd>
 
@@ -3907,8 +3907,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-align-items">'align-items'</dfn> property</li>
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-align-self">'align-self'</dfn> property</li>
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-justify-self">'justify-self'</dfn> property</li>
-     <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-propdef-justify-content">'justify-content'</dfn> property</li>
-     <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-propdef-justify-items">'justify-items'</dfn> property</li>
+     <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-justify-content">'justify-content'</dfn> property</li>
+     <li>The <dfn data-x-href="https://drafts.csswg.org/css-align/#propdef-justify-items">'justify-items'</dfn> property</li>
     </ul>
 
     <p>The following terms and features are defined in <cite>CSS Display</cite>:
@@ -4190,7 +4190,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
     <ref>CSSSYNTAX</ref></p>
 
     <ul class="brief">
-     <li><dfn data-x-href="https://drafts.csswg.org/css-syntax/#conform-classes">conformant style sheet</dfn></li>
+     <li><dfn data-x-href="https://drafts.csswg.org/css-syntax/#w3c-conformance-classes">conformant style sheet</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/css-syntax/#parse-a-list-of-component-values">parse a list of component values</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/css-syntax/#parse-a-comma-separated-list-of-component-values">parse a comma-separated list of component values</dfn></li>
      <li><dfn data-x-href="https://drafts.csswg.org/css-syntax/#component-value">component value</dfn></li>
@@ -4227,7 +4227,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-values/#in">'in'</dfn> unit</li>
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-values/#px">'px'</dfn> unit</li>
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-values/#pt">'pt'</dfn> unit</li>
-     <li>The <dfn data-x-href="https://drafts.csswg.org/css-values/#funcdef-attr">'attr()'</dfn> function</li>
+     <li>The <dfn data-x-href="https://drafts.csswg.org/css-values-5/#funcdef-attr">'attr()'</dfn> function</li>
      <li>The <dfn data-x-href="https://drafts.csswg.org/css-values/#math-function">math functions</dfn></li>
     </ul>
 
@@ -4405,7 +4405,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
 
     <ul class="brief">
      <li><dfn data-x-href="https://w3c.github.io/webvtt/#webvtt-file">WebVTT file</dfn></li>
-     <li><dfn data-x-href="https://w3c.github.io/webvtt/#webvtt-file-using-cue-text">WebVTT file using cue text</dfn></li>
+     <li><dfn data-x-href="https://w3c.github.io/webvtt/#webvtt-file-using-caption-or-subtitle-cue-text">WebVTT file using caption or subtitle cue text</dfn></li>
      <li><dfn data-x-href="https://w3c.github.io/webvtt/#webvtt-file-using-only-nested-cues">WebVTT file using only nested cues</dfn></li>
      <li><dfn data-x-href="https://w3c.github.io/webvtt/#webvtt-parser">WebVTT parser</dfn></li>
      <li>The <dfn data-x-href="https://w3c.github.io/webvtt/#rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn></li>
@@ -4443,12 +4443,23 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
 
     <ul class="brief">
      <li><dfn data-x-href="https://w3c.github.io/aria/#dfn-role">role</dfn></li>
-     <li><dfn data-x-href="https://w3c.github.io/aria/#dfn-accessible-name" data-x="concept-accessible-name">accessible name</dfn></li>
      <li>The <dfn data-x-href="https://w3c.github.io/aria/#ARIAMixin"><code>ARIAMixin</code></dfn> interface, with its associated
              <dfn data-x-href="https://w3c.github.io/aria/#dfn-ariamixin-getter-steps"><code>ARIAMixin</code> getter steps</dfn> and
              <dfn data-x-href="https://w3c.github.io/aria/#dfn-ariamixin-setter-steps"><code>ARIAMixin</code> setter steps</dfn> hooks, and its
              <dfn data-x="dom-ARIAMixin-role" data-x-href="https://w3c.github.io/aria/#idl-def-ariamixin-role"><code>role</code></dfn> and
              <dfn data-x="dom-ARIAMixin-aria*" data-x-href="https://w3c.github.io/aria/#idl-def-ariamixin-ariaactivedescendantelement"><code>aria*</code></dfn> attributes</li>
+    </ul>
+   </dd>
+
+
+   <dt>Accessible Name and Description Computation</dt>
+
+   <dd>
+    <p>The following term is defined in <cite>Accessible Name and Description
+    Computation</cite>: <ref>ACCNAME</ref></p>
+
+    <ul class="brief">
+     <li><dfn data-x-href="https://w3c.github.io/accname/#dfn-accessible-name" data-x="concept-accessible-name">accessible name</dfn></li>
     </ul>
    </dd>
 
@@ -37852,7 +37863,7 @@ interface <dfn interface>HTMLTrackElement</dfn> : <span>HTMLElement</span> {
   data-x="attr-track-kind">kind</code> attribute is not in the <span
   data-x="attr-track-kind-chapters">chapters metadata</span> or <span
   data-x="attr-track-kind-metadata">metadata</span> state, then the WebVTT file must be a
-  <span>WebVTT file using cue text</span>. <ref>WEBVTT</ref></p>
+  <span>WebVTT file using caption or subtitle cue text</span>. <ref>WEBVTT</ref></p>
 
   <p>The <dfn element-attr for="track"><code data-x="attr-track-srclang">srclang</code></dfn>
   attribute gives the language of the text track data. The value must be a valid BCP 47 language
@@ -161027,6 +161038,9 @@ INSERT INTERFACES HERE
 
    <dt id="refsABOUT">[ABOUT]</dt>
    <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc6694">The 'about' URI scheme</a></cite>, S. Moonesamy. IETF.</dd>
+
+   <dt id="refsACCNAME">[ACCNAME]</dt>
+   <dd><cite><a href="https://w3c.github.io/accname/">Accessible Name and Description Computation</a></cite>, B. Garaventa, M. Sumner. W3C.</dd>
 
    <dt id="refsAPNG">[APNG]</dt>
    <dd>(Non-normative) <cite><a href="https://wiki.mozilla.org/APNG_Specification">APNG Specification</a></cite>. S. Parmenter, V. Vukicevic, A. Smith. Mozilla.</dd>


### PR DESCRIPTION
The referenced specifications moved or renamed these anchors:

* DOM renamed the event target concept to `#event-target`.
* File API folded its `blob:` scheme definition into its blob URLs definition.
* Battery Status API no longer uses WebIDL-style anchors.
* CSS Box Alignment's `justify-content` and `justify-items` anchors were written with a duplicated "propdef-" prefix.
* Bikeshed gave its W3C boilerplate anchors a "w3c-" prefix, so CSS Syntax's conformance classes section moved.
* `attr()` was deferred to CSS Values and Units Level 5.
* WebVTT renamed "WebVTT file using cue text" to "WebVTT file using caption or subtitle cue text".
* ARIA no longer defines "accessible name" and now defers to Accessible Name and Description Computation, so cite that instead.

Part of #8272. The two remaining entries on that issue's checklist are `#synchronous-flag` (being handled separately) and `#concept-response-timing-info` (tracked by its own issue).