### PR TITLE
Fix placeholder label option to allow wrapper elements

### DIFF
--- a/source
+++ b/source
@@ -57244,9 +57244,10 @@ interface <dfn interface>HTMLSelectElement</dfn> : <span>HTMLElement</span> {
   attribute specified, and has a <span data-x="concept-select-size">display size</span> of 1; and if
   the <span data-x="concept-option-value">value</span> of the first <code>option</code> element in
   the <code>select</code> element's <span data-x="concept-select-option-list">list of options</span>
-  (if any) is the empty string, and that <code>option</code> element's parent node is the
-  <code>select</code> element (and not an <code>optgroup</code> element), then that
-  <code>option</code> is the <code>select</code> element's <dfn>placeholder label option</dfn>.</p>
+  (if any) is the empty string, and that <code>option</code> element does not have an
+  <span>ancestor</span> <code>optgroup</code> in between itself and the <code>select</code>
+  element, then that <code>option</code> is the <code>select</code> element's <dfn>placeholder
+  label option</dfn>.</p>
   </div>
 
   <div algorithm>


### PR DESCRIPTION
This changes the check for an ancestor optgroup instead.

Fixes #12892.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Mozilla
   * Chromium (already ships)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://phabricator.services.mozilla.com/differential/changeset/?ref=13669072
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: (Already fixed)
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2068707
   * WebKit: (Already fixed)
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): N/A
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/html/12893/form-elements.html" title="Last updated on Sep 14, 2026, 2:36 PM UTC (176615d)">/form-elements.html</a>  ( <a href="https://whatpr.org/html/12893/8d14932...176615d/form-elements.html" title="Last updated on Sep 14, 2026, 2:36 PM UTC (176615d)">diff</a> )