### PR TITLE
Sanitizer: add javascriptURLs option to SanitizerConfig and Sanitizer

### DIFF
--- a/source
+++ b/source
@@ -126755,11 +126755,11 @@ interface <dfn interface>Sanitizer</dfn> {
   <div algorithm>
   <p>To <dfn export for="Sanitizer" data-x="configure a sanitizer">configure</dfn> a
   <code>Sanitizer</code> <var>sanitizer</var>, given a dictionary <var>configuration</var> and a
-  boolean <var>allowCommentsPIsAndDataAttributes</var>:</p>
+  boolean <var>permissiveDefaults</var>:</p>
 
   <ol>
    <li><p><span>Canonicalize the configuration</span> <var>configuration</var> with
-   <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
+   <var>permissiveDefaults</var>.</p></li>
 
    <li><p>If <var>configuration</var> is not <span data-x="dom-SanitizerConfig-valid">valid</span>,
    then throw a <code>TypeError</code>.</p></li>
@@ -126771,7 +126771,7 @@ interface <dfn interface>Sanitizer</dfn> {
 
   <div algorithm>
   <p>To <dfn>canonicalize the configuration</dfn> <span>SanitizerConfig</span>
-  <var>configuration</var> with a boolean <var>allowCommentsPIsAndDataAttributes</var>:</p>
+  <var>configuration</var> with a boolean <var>permissiveDefaults</var>:</p>
 
   <ol>
    <li><p>If neither <var>configuration</var>["<code
@@ -126795,8 +126795,7 @@ interface <dfn interface>Sanitizer</dfn> {
     <span data-x="map exists">exists</span>:</p>
 
     <ol>
-     <li><p>If <var>allowCommentsPIsAndDataAttributes</var> is true, then set
-     <var>configuration</var>["<code
+     <li><p>If <var>permissiveDefaults</var> is true, then set <var>configuration</var>["<code
      data-x="dom-SanitizerConfig-removeProcessingInstructions">removeProcessingInstructions</code>"]
      to an empty list.</p></li>
 
@@ -126873,17 +126872,17 @@ interface <dfn interface>Sanitizer</dfn> {
 
    <li><p>If <var>configuration</var>["<code data-x="dom-SanitizerConfig-comments">comments</code>"]
    does not <span data-x="map exists">exist</span>, then set it to
-   <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
+   <var>permissiveDefaults</var>.</p></li>
 
    <li><p>If <var>configuration</var>["<code
    data-x="dom-SanitizerConfig-attributes">attributes</code>"] <span data-x="map
    exists">exists</span> and <var>configuration</var>["<code
    data-x="dom-SanitizerConfig-dataAttributes">dataAttributes</code>"] does not <span data-x="map
-   exists">exist</span>, then set it to <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
+   exists">exist</span>, then set it to <var>permissiveDefaults</var>.</p></li>
 
    <li><p>If <var>configuration</var>["<code
    data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] does not <span data-x="map
-   exists">exist</span>, then set it to <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
+   exists">exist</span>, then set it to <var>permissiveDefaults</var>.</p></li>
   </ol>
   </div>
 
@@ -128065,11 +128064,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <ol>
      <li><p>Let <var>sanitizer</var> be a new <code>Sanitizer</code> object.</p></li>
 
-     <li><p>Let <var>allowCommentsPIsAndDataAttributes</var> be true if <var>safe</var> is false;
-     false otherwise.</p></li>
+     <li><p>Let <var>permissiveDefaults</var> be true if <var>safe</var> is false; false
+     otherwise.</p></li>
 
      <li><p><span data-x="configure a sanitizer">Configure</span> <var>sanitizer</var> given
-     <var>sanitizerSpec</var> and <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
+     <var>sanitizerSpec</var> and <var>permissiveDefaults</var>.</p></li>
 
      <li><p>Set <var>sanitizerSpec</var> to <var>sanitizer</var>.</p></li>
     </ol>

--- a/source
+++ b/source
@@ -126678,6 +126678,7 @@ interface <dfn interface>Sanitizer</dfn> {
   boolean <span data-x="dom-Sanitizer-removeAttribute">removeAttribute</span>(<span>SanitizerAttribute</span> attribute);
   boolean <span data-x="dom-Sanitizer-setComments">setComments</span>(boolean allow);
   boolean <span data-x="dom-Sanitizer-setDataAttributes">setDataAttributes</span>(boolean allow);
+  boolean <span data-x="dom-Sanitizer-setJavascriptURLs">setJavascriptURLs</span>(boolean allow);
 
   // Remove markup that executes script.
   boolean <span data-x="dom-Sanitizer-removeUnsafe">removeUnsafe</span>();
@@ -126716,6 +126717,10 @@ interface <dfn interface>Sanitizer</dfn> {
    <dt><code data-x=""><var>sanitizer</var>.<span data-x="dom-Sanitizer-setDataAttributes">setDataAttributes</span>(<var>allow</var>)</code></dt>
    <dd><p>Sets whether the sanitizer preserves custom data attributes (e.g., <code
    data-x="attr-data-*">data-*</code>).</p></dd>
+
+   <dt><code data-x=""><var>sanitizer</var>.<span data-x="dom-Sanitizer-setJavascriptURLs">setJavascriptURLs</span>(<var>allow</var>)</code></dt>
+   <dd><p>Sets whether the sanitizer preserves attributes containing <code data-x="javascript
+   protocol">javascript:</code> URLs.</p></dd>
 
    <dt><code data-x=""><var>sanitizer</var>.<span data-x="dom-Sanitizer-removeUnsafe">removeUnsafe</span>()</code></dt>
    <dd><p>Modifies the configuration to automatically remove elements and attributes that are
@@ -126874,6 +126879,10 @@ interface <dfn interface>Sanitizer</dfn> {
    data-x="dom-SanitizerConfig-attributes">attributes</code>"] <span data-x="map
    exists">exists</span> and <var>configuration</var>["<code
    data-x="dom-SanitizerConfig-dataAttributes">dataAttributes</code>"] does not <span data-x="map
+   exists">exist</span>, then set it to <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
+
+   <li><p>If <var>configuration</var>["<code
+   data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] does not <span data-x="map
    exists">exist</span>, then set it to <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
   </ol>
   </div>
@@ -127519,6 +127528,28 @@ interface <dfn interface>Sanitizer</dfn> {
 
   <div algorithm>
   <p>The <dfn method for="Sanitizer"><code
+  data-x="dom-Sanitizer-setJavascriptURLs">setJavascriptURLs(<var>allow</var>)</code></dfn> method
+  steps are:</p>
+
+  <ol>
+   <li><p>Let <var>configuration</var> be <span>this</span>'s <span>configuration</span>.</p></li>
+
+   <li><p><span>Assert</span>: <var>configuration</var> is <span
+   data-x="dom-SanitizerConfig-valid">valid</span>.</p></li>
+
+   <li><p>If <var>configuration</var>["<code
+   data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] <span data-x="map
+   exists">exists</span> and is equal to <var>allow</var>, then return false.</p></li>
+
+   <li><p>Set <var>configuration</var>["<code
+   data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] to <var>allow</var>.</p></li>
+
+   <li><p>Return true.</p></li>
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>The <dfn method for="Sanitizer"><code
   data-x="dom-Sanitizer-allowProcessingInstruction">allowProcessingInstruction(<var>pi</var>)</code></dfn>
   method steps are:</p>
 
@@ -127676,6 +127707,7 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
 
   boolean <dfn dict-member for="SanitizerConfig" data-x="dom-SanitizerConfig-comments">comments</dfn>;
   boolean <dfn dict-member for="SanitizerConfig" data-x="dom-SanitizerConfig-dataAttributes">dataAttributes</dfn>;
+  boolean <dfn dict-member for="SanitizerConfig" data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</dfn>;
 };</code></pre>
 
   <p><code>SanitizerElementNamespace</code>, <code>SanitizerAttributeNamespace</code>,
@@ -128033,11 +128065,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
     <ol>
      <li><p>Let <var>sanitizer</var> be a new <code>Sanitizer</code> object.</p></li>
 
-     <li><p>Let <var>allowCommentsAndDataAttributes</var> be true if <var>safe</var> is false; false
-     otherwise.</p></li>
+     <li><p>Let <var>allowCommentsPIsAndDataAttributes</var> be true if <var>safe</var> is false;
+     false otherwise.</p></li>
 
      <li><p><span data-x="configure a sanitizer">Configure</span> <var>sanitizer</var> given
-     <var>sanitizerSpec</var> and <var>allowCommentsAndDataAttributes</var>.</p></li>
+     <var>sanitizerSpec</var> and <var>allowCommentsPIsAndDataAttributes</var>.</p></li>
 
      <li><p>Set <var>sanitizerSpec</var> to <var>sanitizer</var>.</p></li>
     </ol>
@@ -128061,15 +128093,14 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
    <li><p>If <var>safe</var> is true, then <span>remove unsafe</span> from
    <var>configuration</var>.</p></li>
 
-   <li><p>Run the <span>inner sanitize steps</span> given <var>node</var>, <var>configuration</var>,
-   and <var>safe</var>.</p></li>
+   <li><p>Run the <span>inner sanitize steps</span> given <var>node</var> and
+   <var>configuration</var>.</p></li>
   </ol>
   </div>
 
   <div algorithm>
-  <p>To perform the <dfn>inner sanitize steps</dfn> given a <code>Node</code> <var>node</var>, a
-  <span>SanitizerConfig</span> <var>configuration</var>, and a boolean
-  <var>handleJavascriptNavigationUrls</var>:</p>
+  <p>To perform the <dfn>inner sanitize steps</dfn> given a <code>Node</code> <var>node</var> and a
+  <span>SanitizerConfig</span> <var>configuration</var>:</p>
 
   <ol>
    <li>
@@ -128146,8 +128177,8 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
         <ol>
          <li><p><span>Assert</span>: <var>node</var> is not a <code>Document</code>.</p></li>
 
-         <li><p>Run the <span>inner sanitize steps</span> given <var>child</var>,
-         <var>configuration</var>, and <var>handleJavascriptNavigationUrls</var>.</p></li>
+         <li><p>Run the <span>inner sanitize steps</span> given <var>child</var> and
+         <var>configuration</var>.</p></li>
 
          <li><p>Let <var>fragment</var> be the result of <span data-x="create a document
          fragment">creating a document fragment</span> given <var>node</var>'s
@@ -128197,12 +128228,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
        <var>elementName</var>["<code
        data-x="dom-SanitizerElementNamespace-namespace">namespace</code>"] is the <span>HTML
        namespace</span>, then run the <span>inner sanitize steps</span> given <var>child</var>'s
-       <span>template contents</span>, <var>configuration</var>, and
-       <var>handleJavascriptNavigationUrls</var>.</p></li>
+       <span>template contents</span> and <var>configuration</var>.</p></li>
 
        <li><p>If <var>child</var> is a <span>shadow host</span>, then run the <span>inner sanitize
-       steps</span> given <var>child</var>'s <span>shadow root</span>, <var>configuration</var>, and
-       <var>handleJavascriptNavigationUrls</var>.</p></li>
+       steps</span> given <var>child</var>'s <span>shadow root</span> and
+       <var>configuration</var>.</p></li>
 
        <li><p>Let <var>elementWithLocalAttributes</var> be «[ ]».</p></li>
 
@@ -128272,7 +128302,8 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
          </li>
 
          <li>
-          <p>If <var>handleJavascriptNavigationUrls</var> is true:</p>
+          <p>If <var>configuration</var>["<code
+          data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] is not true:</p>
 
           <ol>
            <li><p>If the pair (<var>elementName</var>, <var>attrName</var>) matches an entry in the
@@ -128281,11 +128312,11 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
            data-x="concept-element-attributes-remove">remove</span> <var>attribute</var>.</p></li>
 
            <li><p>If <var>child</var>'s <span data-x="concept-element-namespace">namespace</span> is
-           the <span>MathML Namespace</span>, <var>attribute</var>'s <span
+           the <span>MathML namespace</span>, <var>attribute</var>'s <span
            data-x="concept-attribute-local-name">local name</span> is "<code data-x="">href</code>",
            <var>attribute</var>'s <span data-x="concept-attribute-namespace">namespace</span> is
            null or the <span>XLink namespace</span>, and <var>attribute</var> <span>contains a
-           javascript: URL</span>, then <span
+           <code>javascript:</code> URL</span>, then <span
            data-x="concept-element-attributes-remove">remove</span> <var>attribute</var>.</p></li>
 
            <li><p>If the <span>built-in animating URL attributes list</span> <span data-x="list
@@ -128298,8 +128329,8 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
         </ol>
        </li>
 
-       <li><p>Run the <span>inner sanitize steps</span> given <var>child</var>,
-       <var>configuration</var>, and <var>handleJavascriptNavigationUrls</var>.</p></li>
+       <li><p>Run the <span>inner sanitize steps</span> given <var>child</var> and
+       <var>configuration</var>.</p></li>
       </ol>
      </li>
     </ol>
@@ -128533,6 +128564,18 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
      <li><p>If <span data-x="remove an attribute from sanitizer config">removing</span>
      <var>attribute</var> from <var>configuration</var> is true, then set <var>result</var> to
      true.</p></li>
+    </ol>
+   </li>
+
+   <li>
+    <p>If <var>configuration</var>["<code
+    data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] is true:</p>
+
+    <ol>
+     <li><p>Set <var>result</var> to true.</p></li>
+
+     <li><p>Set <var>configuration</var>["<code
+     data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] to false.</p></li>
     </ol>
    </li>
 
@@ -129008,6 +129051,9 @@ dictionary <dfn dictionary>SanitizerConfig</dfn> {
    <dd>false</dd>
 
    <dt><code data-x="dom-SanitizerConfig-dataAttributes">dataAttributes</code></dt>
+   <dd>false</dd>
+
+   <dt><code data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code></dt>
    <dd>false</dd>
 
    <dt><code data-x="dom-SanitizerConfig-elements">elements</code></dt>

--- a/source
+++ b/source
@@ -127458,8 +127458,7 @@ interface <dfn interface>Sanitizer</dfn> {
    data-x="dom-SanitizerConfig-valid">valid</span>.</p></li>
 
    <li><p>If <var>configuration</var>["<code data-x="dom-SanitizerConfig-comments">comments</code>"]
-   <span data-x="map exists">exists</span> and is equal to <var>allow</var>, then return
-   false.</p></li>
+   is <var>allow</var>, then return false.</p></li>
 
    <li><p>Set <var>configuration</var>["<code
    data-x="dom-SanitizerConfig-comments">comments</code>"] to <var>allow</var>.</p></li>
@@ -127537,8 +127536,8 @@ interface <dfn interface>Sanitizer</dfn> {
    data-x="dom-SanitizerConfig-valid">valid</span>.</p></li>
 
    <li><p>If <var>configuration</var>["<code
-   data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] <span data-x="map
-   exists">exists</span> and is equal to <var>allow</var>, then return false.</p></li>
+   data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] is <var>allow</var>, then
+   return false.</p></li>
 
    <li><p>Set <var>configuration</var>["<code
    data-x="dom-SanitizerConfig-javascriptURLs">javascriptURLs</code>"] to <var>allow</var>.</p></li>


### PR DESCRIPTION
Instead of the "remove JS URLs" directive rely solely on the method being "Safe", keep it in the configuration.
That makes it apply also in the `removeUnsafe()` case.

It follows the exact same logic as data attributes and comments.

Closes #12686

- [x] At least two implementers are interested (and none opposed):
   * Blink
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62421
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/556269543
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2068934
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=303808
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/862
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
