### PR TITLE
Meta: set commit-snapshot-link title attribute in markup

### DIFF
--- a/source
+++ b/source
@@ -78,7 +78,7 @@
    <nav w-nosplit w-nodev w-noreview>
     <!-- Note: be sure to keep an even number of <a>s, for small screens where they appear in two columns. -->
     <div>
-     <a w-nohtml href="/" id="commit-snapshot-link"><span data-x=""><strong>One-Page Version</strong> <code data-x="">html.spec.whatwg.org</code></span></a>
+     <a w-nohtml href="/" id="commit-snapshot-link" title="You can also press the 'y' key"><span data-x=""><strong>One-Page Version</strong> <code data-x="">html.spec.whatwg.org</code></span></a>
      <a w-nosnap href="/"><span data-x=""><strong>One-Page Version</strong> <code data-x="">html.spec.whatwg.org</code></span></a>
      <a href="/multipage/" id="multipage-link" onclick="setLinkFragment(this);"><span data-x=""><strong>Multipage Version</strong> <code data-x="">/multipage</code></span></a>
      <a href="/dev/" onclick="setLinkFragment(this);"><span data-x=""><strong>Version for Web Devs</strong> <code data-x="">/dev</code></span></a>
@@ -92,7 +92,7 @@
     <div>
      <a class="changes" href="https://github.com/whatwg/html"><span data-x=""><strong>Contribute on GitHub</strong> <code data-x="">whatwg/html repository</code></span></a>
      <a class="changes" href="https://github.com/whatwg/html/commits"><span data-x=""><strong>Commits</strong> <code data-x="">on GitHub</code></span></a>
-     <a w-nosnap class="changes" href="/commit-snapshots/[SHA]" id="commit-snapshot-link"><span data-x=""><strong>Snapshot</strong> <code data-x="">as of this commit</code></span></a>
+     <a w-nosnap class="changes" href="/commit-snapshots/[SHA]" id="commit-snapshot-link" title="You can also press the 'y' key"><span data-x=""><strong>Snapshot</strong> <code data-x="">as of this commit</code></span></a>
     </div>
     <div>
      <a class="feedback" href="https://github.com/whatwg/html/issues"><span data-x=""><strong>Open Issues</strong> <code data-x="">filed on GitHub</code></span></a>


### PR DESCRIPTION
This attribute was set by `commit-snapshot-shortcut-key.js` with `defer` timing, which caused a style invalidation.

Part of #12782.
