### PR TITLE
Meta: remove the `dfnEnabled` class on `body`

### DIFF
--- a/html-dfn.js
+++ b/html-dfn.js
@@ -188,7 +188,6 @@ function restoreOrClosePanelOnNav(event) {
   }
 }
 
-document.body.classList.add('dfnEnabled');
 document.addEventListener('click', handleClick);
 if (isMultipage) {
   document.addEventListener('DOMContentLoaded', restoreOrClosePanelOnNav);

--- a/styles.css
+++ b/styles.css
@@ -239,11 +239,13 @@ td.eg { border-width: thin; text-align: center; }
 }
 
 /* Elements that trigger a dfn panel when clicked. */
-body.dfnEnabled dfn,
-body.dfnEnabled h2[data-dfn-type],
-body.dfnEnabled h3[data-dfn-type],
-body.dfnEnabled h4[data-dfn-type],
-body.dfnEnabled h5[data-dfn-type],
-body.dfnEnabled h6[data-dfn-type] {
-  cursor: pointer;
+@media (scripting: enabled) {
+ dfn,
+ h2[data-dfn-type],
+ h3[data-dfn-type],
+ h4[data-dfn-type],
+ h5[data-dfn-type],
+ h6[data-dfn-type] {
+   cursor: pointer;
+ }
 }


### PR DESCRIPTION
This attribute was set by `html-dfn.js` with `defer` timing, which caused a style invalidation.

Part of #12782.
