### PR TITLE
Reset frameset-ok when the body element is inserted implicitly

### DIFF
--- a/source
+++ b/source
@@ -141970,7 +141970,8 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   </dl>
 
   <p>The <dfn>frameset-ok flag</dfn> is set to "ok" when the parser is created. It is set to "not
-  ok" after certain tokens are seen.</p>
+  ok" after certain tokens are seen, and back to "ok" when the <code>body</code> element is
+  inserted implicitly.</p>
 
 
   <h4><dfn>Tokenization</dfn></h4>
@@ -146259,8 +146260,10 @@ document.body.appendChild(text);
 
    <dt>Anything else</dt>
    <dd>
-    <!-- fake <body>, but without resetting frameset-ok -->
+    <!-- fake <body> -->
     <p><span>Insert an HTML element</span> for a "body" start tag token with no attributes.</p>
+
+    <p>Set the <span>frameset-ok flag</span> to "ok".</p>
 
     <p>Switch the <span>insertion mode</span> to "<span data-x="insertion mode: in body">in
     body</span>".</p>


### PR DESCRIPTION
Reset frameset-ok when the body element is inserted implicitly

The `<template>` start tag sets the frameset-ok flag to "not ok" in the
"in head" insertion mode and nothing ever sets it back, so the standard
says the `<frameset>` is ignored in
`<head><template></template></head><p><frameset>`, whereas engines create
a frameset document. The same goes for anything inside a head-level
template that sets the flag, such as `<template>x</template><p><frameset>`.

The "after head" insertion mode's "anything else" entry now sets the flag
back to "ok" when it inserts the body element. Nothing seen up to that
point can have been body content; before template there was no way to set
the flag to "not ok" while still in the head, which is presumably why this
was missed.

A `<frameset>` inside a template stays ignored. The flag is read in exactly
one place, the `<frameset>` start tag in the "in body" insertion mode, and
it can now only be reset at the moment the body element is inserted. A
template element can never be on the stack of open elements at that moment,
so whenever a template is open and the second element on the stack of open
elements is a body element the flag is still "not ok".

Tests: https://github.com/web-platform-tests/wpt/pull/62485

Fixes #3178.

---

- [x] At least two implementers are interested (and none opposed):
   * Chromium, Gecko, and WebKit already behave as proposed
   * no engine implements the current text
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62485
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): N/A
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
