### PR TITLE
Ignore the form element pointer throughout template contents

### DIFF
--- a/source
+++ b/source
@@ -141928,6 +141928,10 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
   make form controls associate with forms in the face of dramatically bad markup, for historical
   reasons. It is ignored inside <code>template</code> elements.</p>
 
+  <p>An <span>HTML parser</span> is <dfn>parsing template contents</dfn> if there is a
+  <code>template</code> element on the <span>stack of open elements</span>, or the parser's
+  <span>fragment context element</span> is a <code>template</code> element.</p>
+
 
   <h5>Other parsing state flags</h5>
 
@@ -144955,14 +144959,15 @@ dictionary <dfn dictionary>StorageEventInit</dfn> : <span>EventInit</span> {
 
    <li><p>If <var>element</var> is a <span>form-associated element</span> and not a
    <span>form-associated custom element</span>, the
-   <span><code data-x="">form</code> element pointer</span> is not null, there is no
-   <code>template</code> element on the <span>stack of open elements</span>, <var>element</var> is
-   either not <span data-x="category-listed">listed</span> or doesn't have a <code
-   data-x="attr-fae-form">form</code> attribute, and the <var>intendedParent</var> is in the same
-   <span>tree</span> as the element pointed to by the <span><code data-x="">form</code> element
-   pointer</span>, then <span data-x="concept-form-association">associate</span> <var>element</var>
-   with the <code>form</code> element pointed to by the <span><code data-x="">form</code> element
-   pointer</span> and set <var>element</var>'s <span>parser inserted flag</span>.</p></li>
+   <span><code data-x="">form</code> element pointer</span> is not null, the parser is not
+   <span>parsing template contents</span>, the parser's <span>fragment context element</span> is
+   null, <var>element</var> is either not <span data-x="category-listed">listed</span> or doesn't
+   have a <code data-x="attr-fae-form">form</code> attribute, and the <var>intendedParent</var> is
+   in the same <span>tree</span> as the element pointed to by the <span><code
+   data-x="">form</code> element pointer</span>, then <span
+   data-x="concept-form-association">associate</span> <var>element</var> with the <code>form</code>
+   element pointed to by the <span><code data-x="">form</code> element pointer</span> and set
+   <var>element</var>'s <span>parser inserted flag</span>.</p></li>
 
    <li><p>Return <var>element</var>.</p></li>
   </ol>
@@ -146522,9 +146527,9 @@ document.body.appendChild(text);
    <!-- as normal, but interacts with the form element pointer -->
    <dt>A start tag whose tag name is "form"</dt>
    <dd>
-    <p>If the <span><code data-x="form">form</code> element pointer</span> is not null, and there is
-    no <code>template</code> element on the <span>stack of open elements</span>, then this is a
-    <span>parse error</span>; ignore the token.</p>
+    <p>If the <span><code data-x="form">form</code> element pointer</span> is not null, and the
+    parser is not <span>parsing template contents</span>, then this is a <span>parse error</span>;
+    ignore the token.</p>
 
     <p>Otherwise:</p>
 
@@ -146533,8 +146538,8 @@ document.body.appendChild(text);
      a <code>p</code> element in button scope</span>, then <span>close a <code>p</code>
      element</span>.</p></li>
 
-     <li><p><span>Insert an HTML element</span> for the token, and, if there is no <code>template</code>
-     element on the <span>stack of open elements</span>, set the <span><code
+     <li><p><span>Insert an HTML element</span> for the token, and, if the parser is not
+     <span>parsing template contents</span>, set the <span><code
      data-x="form">form</code> element pointer</span> to point to the element created.</p></li>
     </ol>
    </dd>
@@ -146734,8 +146739,7 @@ document.body.appendChild(text);
    <!-- removes the form element pointer instead of the matching node -->
    <dt>An end tag whose tag name is "form"</dt>
    <dd>
-    <p>If there is no <code>template</code> element on the <span>stack of open elements</span>, then
-    run these substeps:</p>
+    <p>If the parser is not <span>parsing template contents</span>:</p>
 
     <ol>
      <li><p>Let <var>node</var> be the element that the <span><code data-x="">form</code>
@@ -146755,8 +146759,7 @@ document.body.appendChild(text);
      <li><p>Remove <var>node</var> from the <span>stack of open elements</span>.</p></li>
     </ol>
 
-    <p>If there <em>is</em> a <code>template</code> element on the <span>stack of open
-    elements</span>, then run these substeps instead:</p>
+    <p>Otherwise:</p>
 
     <ol>
      <li><p>If the <span>stack of open elements</span> does not <span data-x="has an element in
@@ -147852,15 +147855,15 @@ document.body.appendChild(text);
    <dd>
     <p><span>Parse error</span>.</p>
 
-    <p>If there is a <code>template</code> element on the <span>stack of open elements</span>, or if
-    the <span><code data-x="form">form</code> element pointer</span> is not null, ignore the
-    token.</p> <!-- in a <template>, the <form> would have no effect and thus be a waste of time... -->
+    <p>If the <span><code data-x="form">form</code> element pointer</span> is not null, and the
+    parser is not <span>parsing template contents</span>, then ignore the token.</p>
 
     <p>Otherwise:</p>
 
     <ol>
-     <li><p><span>Insert an HTML element</span> for the token, and set the <span><code
-     data-x="form">form</code> element pointer</span> to point to the element created.</p></li>
+     <li><p><span>Insert an HTML element</span> for the token, and, if the parser is not
+     <span>parsing template contents</span>, set the <span><code data-x="form">form</code> element
+     pointer</span> to point to the element created.</p></li>
 
      <li><p>Pop that <code>form</code> element off the <span>stack of open elements</span>.</p></li>
     </ol>


### PR DESCRIPTION
The form element pointer is deliberately not used inside template
contents, but the conditions expressing that only tested the stack of
open elements. A fragment parse whose context element is a `template`
element produces template contents without ever pushing a `template`
element onto that stack, so the pointer was seeded from the context
element's ancestors and then used: a nested `<form>` was dropped, and
controls could be associated with a form outside the template.

Introduce "parsing template contents", which covers that case as well,
and use it for the `<form>` start and end tags and when associating a
control with the form element pointer.

While there, the "in table" `<form>` start tag dropped the element
entirely while parsing template contents. It now inserts the element and
skips only the pointer assignment, as the "in body" one already did.

Also require the parser's fragment context element to be null when
associating a control with the form element pointer. No implementation
does this during a fragment parse, where the pointer either comes from the
context element's ancestors or points into the fragment being built.
Association by ancestry is unaffected, so only markup that leaves a
control outside its form can tell the difference.

Tests: https://github.com/web-platform-tests/wpt/pull/62488

Fixes #12257.


- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Chromium 
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62488 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-(
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2069921
   * WebKit:  https://bugs.webkit.org/show_bug.cgi?id=323586
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
