### PR TITLE
Set opaque-response blocking metadata on media and script requests

### DIFF
--- a/source
+++ b/source
@@ -2696,6 +2696,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://fetch.spec.whatwg.org/#potentially-free-deferred-fetch-quota">potentially free deferred fetch quota</dfn></li>
      <li><dfn data-x-href="https://fetch.spec.whatwg.org/#is-offline">is offline</dfn></li>
      <li><dfn data-x-href="https://fetch.spec.whatwg.org/#navigation-tao-check">navigation TAO check</dfn></li>
+     <li><dfn data-x-href="https://fetch.spec.whatwg.org/#opaque-response-safelist-check">opaque-response-safelist check</dfn></li>
      <li>
       <dfn data-x="concept-response"
       data-x-href="https://fetch.spec.whatwg.org/#concept-response">response</dfn> and its
@@ -2757,6 +2758,8 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
        <li><dfn data-x="concept-request-history-navigation-flag" data-x-href="https://fetch.spec.whatwg.org/#concept-request-history-navigation-flag">history-navigation flag</dfn></li>
        <li><dfn data-x="concept-request-user-activation" data-x-href="https://fetch.spec.whatwg.org/#request-user-activation">user-activation</dfn></li>
        <li><dfn data-x="concept-request-render-blocking" data-x-href="https://fetch.spec.whatwg.org/#request-render-blocking">render-blocking</dfn></li>
+       <li><dfn data-x="concept-request-no-cors-media-request-state" data-x-href="https://fetch.spec.whatwg.org/#request-no-cors-media-request-state">no-cors media request state</dfn></li>
+       <li><dfn data-x="concept-request-no-cors-javascript-fallback-encoding" data-x-href="https://fetch.spec.whatwg.org/#request-no-cors-javascript-fallback-encoding">no-cors JavaScript fallback encoding</dfn></li>
        <li><dfn data-x="concept-request-initiator-type" data-x-href="https://fetch.spec.whatwg.org/#request-initiator-type">initiator type</dfn></li>
        <li><dfn data-x="concept-request-service-workers-mode" data-x-href="https://fetch.spec.whatwg.org/#request-service-workers-mode">service-workers mode</dfn></li>
        <li><dfn data-x="concept-request-traversable-for-user-prompts" data-x-href="https://fetch.spec.whatwg.org/#concept-request-window">traversable for user prompts</dfn></li>
@@ -39275,86 +39278,119 @@ interface <dfn interface>MediaError</dfn> {
         </ol>
        </li>
 
-       <li><p>Let <var>destination</var> be "<code data-x="">audio</code>" if the <span>media
-       element</span> is an <code>audio</code> element, or "<code data-x="">video</code>"
-       otherwise.</p>
-
-       <li><p>Let <var>request</var> be the result of <span
-       data-x="create a potential-CORS request">creating a potential-CORS request</span> given
-       <var>current media resource</var>'s <span>URL record</span>, <var>destination</var>, and the
-       current state of the <span>media element</span>'s
-       <code data-x="attr-script-crossorigin">crossorigin</code> content attribute.</p></li>
-
-       <li><p>Set <var>request</var>'s <span data-x="concept-request-client">client</span> to the
-       <span>media element</span>'s <span>node document</span>'s <span>relevant settings
-       object</span>.</p></li>
-
-       <li><p>Set <var>request</var>'s <span data-x="concept-request-initiator-type">initiator
-       type</span> to <var>destination</var>.</p></li>
-
-       <li><p>Let <var>byteRange</var>, which is "<code data-x="">entire resource</code>" or a
-       (number, number or "<code data-x="">until end</code>") tuple, be the byte range required to satisfy
-       missing data in <span>media data</span>. This value is <span>implementation-defined</span>
-       and may rely on codec, network conditions or other heuristics. The user-agent may determine
-       to fetch the resource in full, in which case <var>byteRange</var> would be
-       "<code data-x="">entire resource</code>", to fetch from a byte offset until the end,
-       in which case <var>byteRange</var> would be
-       (number, "<code data-x="">until end</code>"), or to fetch a range between two byte offsets,
-       in which case <var>byteRange</var> would be a (number, number) tuple representing the two
-       offsets.</p></li>
-
        <li>
-        <p>If <var>byteRange</var> is not "<code data-x="">entire resource</code>":</p>
-        <ol>
-         <li><p>If <var>byteRange</var>[1] is "<code data-x="">until end</code>", then
-         <span>add a range header</span> to <var>request</var> given
-         <var>byteRange</var>[0].</p></li>
+        <p>Let <var>fetchByteRange</var>, given "<code data-x="">entire resource</code>" or a
+        (number, number or "<code data-x="">until end</code>") tuple <var>byteRange</var> and a
+        <span data-x="concept-request-no-cors-media-request-state">no-cors media request
+        state</span> <var>mediaRequestState</var>, be the following steps:</p>
 
-         <li><p>Otherwise, <span>add a range header</span> to <var>request</var> given
-         <var>byteRange</var>[0] and <var>byteRange</var>[1].</p></li>
+        <ol>
+         <li><p>Let <var>destination</var> be "<code data-x="">audio</code>" if the <span>media
+         element</span> is an <code>audio</code> element, or "<code data-x="">video</code>"
+         otherwise.</p>
+
+         <li><p>Let <var>request</var> be the result of <span data-x="create a potential-CORS
+         request">creating a potential-CORS request</span> given <var>current media resource</var>'s
+         <span>URL record</span>, <var>destination</var>, and the current state of the <span>media
+         element</span>'s <code data-x="attr-script-crossorigin">crossorigin</code> content
+         attribute.</p></li>
+
+         <li><p>Set <var>request</var>'s <span data-x="concept-request-client">client</span> to the
+         <span>media element</span>'s <span>node document</span>'s <span>relevant settings
+         object</span>.</p></li>
+
+         <li><p>Set <var>request</var>'s <span data-x="concept-request-initiator-type">initiator
+         type</span> to <var>destination</var>.</p></li>
+
+         <li>
+          <p>Set <var>request</var>'s <span
+          data-x="concept-request-no-cors-media-request-state">no-cors media request state</span> to
+          <var>mediaRequestState</var>.</p>
+
+          <p class="note">This is used by the <span>opaque-response-safelist check</span>, which
+          allows subsequent ranges of a <span>media resource</span> whose initial range was sniffed
+          as audio or video. <ref>FETCH</ref></p>
+         </li>
+
+         <li>
+          <p>If <var>byteRange</var> is not "<code data-x="">entire resource</code>":</p>
+
+          <ol>
+           <li><p>If <var>byteRange</var>[1] is "<code data-x="">until end</code>", then <span>add a
+           range header</span> to <var>request</var> given <var>byteRange</var>[0].</p></li>
+
+           <li><p>Otherwise, <span>add a range header</span> to <var>request</var> given
+           <var>byteRange</var>[0] and <var>byteRange</var>[1].</p></li>
+          </ol>
+         </li>
+
+         <li>
+          <!--FETCH--><p><span data-x="concept-fetch">Fetch</span> <var>request</var>, with <i
+          data-x="processResponse">processResponse</i> set to the following steps given <span
+          data-x="concept-response">response</span> <var>response</var>:</p>
+
+          <ol>
+           <li><p>Let <var>global</var> be the <span>media element</span>'s <span>node
+           document</span>'s <span>relevant global object</span>.</p></li>
+
+           <li><p>Let <var>updateMedia</var> be to <span>queue a media element task</span> given the
+           <span>media element</span> to run the first appropriate steps from the <span>media data
+           processing steps list</span> below. (A new task is used for this so that the work
+           described below occurs relative to the appropriate <span>media element event task
+           source</span> rather than using the <span>networking task source</span>.)</p>
+
+           <li><p>Let <var>processEndOfMedia</var> be the following step: If the fetching process
+           has completed without errors, including decoding the media data, and if all of the data
+           is available to the user agent without network access, then, the user agent must move on
+           to the <i>final step</i> below. This might never happen, e.g. when streaming an infinite
+           resource such as web radio, or if the resource is longer than the user agent's ability to
+           cache data.</p></li>
+
+           <li><p>If the result of <span data-x="verify a media response">verifying</span>
+           <var>response</var> given the <var>current media resource</var> and <var>byteRange</var>
+           is false, then abort these steps.</p></li>
+
+           <li><p>Otherwise, <span data-x="body-incrementally-read">incrementally read</span>
+           <var>response</var>'s <span data-x="concept-response-body">body</span> given
+           <var>updateMedia</var>, <var>processEndOfMedia</var>, an empty algorithm, and
+           <var>global</var>.</p></li>
+
+           <li><p>Update the <span>media data</span> with the contents of <var>response</var>'s
+           <span>unsafe response</span> obtained in this fashion. <var>response</var> can be
+           <span>CORS-same-origin</span> or <span>CORS-cross-origin</span>; this affects whether
+           subtitles referenced in the <span>media data</span> are exposed in the API and, for
+           <code>video</code> elements, whether a <code>canvas</code> gets tainted when the video is
+           drawn on it.</p></li>
+          </ol>
+         </li>
         </ol>
        </li>
 
        <li>
-        <!--FETCH--><p><span data-x="concept-fetch">Fetch</span> <var>request</var>, with
-        <i data-x="processResponse">processResponse</i> set to the following steps given
-        <span data-x="concept-response">response</span> <var>response</var>:</p>
+        <p>Let <var>initialByteRange</var>, which is "<code data-x="">entire resource</code>" or a
+        (0, number or "<code data-x="">until end</code>") tuple, be the byte range to fetch first.
+        This value is <span>implementation-defined</span> and may rely on codec, network conditions
+        or other heuristics. The user agent may determine to fetch the resource in full, in which
+        case <var>initialByteRange</var> would be "<code data-x="">entire resource</code>", to fetch
+        from the start of the resource until the end, in which case <var>initialByteRange</var>
+        would be (0, "<code data-x="">until end</code>"), or to fetch from the start of the resource
+        until a byte offset, in which case <var>initialByteRange</var> would be a (0, number)
+        tuple.</p>
 
-        <ol>
-         <li><p>Let <var>global</var> be the <span>media element</span>'s
-         <span>node document</span>'s <span>relevant global object</span>.</p></li>
+        <p class="note">The initial fetch has to start at the beginning of the resource, as the
+        <span>opaque-response-safelist check</span> otherwise cannot determine whether the resource
+        is audio or video. <ref>FETCH</ref></p>
+       </li>
 
-         <li><p>Let <var>updateMedia</var> be to <span>queue a media element task</span> given
-         the <span>media element</span> to run the first appropriate steps from the
-         <span>media data processing steps list</span> below. (A new task is used for
-         this so that the work described below occurs relative to the appropriate
-         <span>media element event task source</span> rather than using the
-         <span>networking task source</span>.)</p>
+       <li><p>Run <var>fetchByteRange</var> given <var>initialByteRange</var> and "<code
+       data-x="">initial</code>".</p></li>
 
-         <li><p>Let <var>processEndOfMedia</var> be the following step: If the fetching process has
-         completed without errors, including decoding the media data, and if all of the data is
-         available to the user agent without network access, then, the user agent must move on to
-         the <i>final step</i> below. This might never happen, e.g. when streaming an infinite
-         resource such as web radio, or if the resource is longer than the user agent's ability to
-         cache data.</p></li>
+       <li><p>Whenever the user agent needs <span>media data</span> from the <var>current media
+       resource</var> that it does not have, e.g. as playback progresses or as a result of a <span
+       data-x="dom-media-seek">seek</span>, it must run <var>fetchByteRange</var> given the byte
+       range required to satisfy the missing data and "<code data-x="">subsequent</code>".</p></li>
 
-         <li><p>If the result of <span data-x="verify a media response">verifying</span>
-         <var>response</var> given the <var>current media resource</var> and <var>byteRange</var>
-         is false, then abort these steps.</p></li>
-
-         <li><p>Otherwise, <span data-x="body-incrementally-read">incrementally read</span>
-         <var>response</var>'s <span data-x="concept-response-body">body</span> given
-         <var>updateMedia</var>, <var>processEndOfMedia</var>, an empty algorithm, and
-         <var>global</var>.</p></li>
-
-         <li><p>Update the <span>media data</span> with the contents of <var>response</var>'s
-         <span>unsafe response</span> obtained in this fashion. <var>response</var> can be
-         <span>CORS-same-origin</span> or <span>CORS-cross-origin</span>; this affects whether
-         subtitles referenced in the <span>media data</span> are exposed in the API and, for
-         <code>video</code> elements, whether a <code>canvas</code> gets tainted when the video is
-         drawn on it.</p></li>
-        </ol>
-
+       <li>
         <p>The <dfn export id="stall-timeout">media element stall timeout</dfn> is an
         <span>implementation-defined</span> length of time, which should be about three seconds.
         When a <span>media element</span> that is actively attempting to obtain <span>media
@@ -118585,6 +118621,16 @@ document.querySelector("button").addEventListener("click", bound);
 
    <li><p><span>Set up the classic script request</span> given <var>request</var> and
    <var>options</var>.</p></li>
+
+   <li>
+    <p>Set <var>request</var>'s <span
+    data-x="concept-request-no-cors-javascript-fallback-encoding">no-cors JavaScript fallback
+    encoding</span> to <var>encoding</var>.</p>
+
+    <p class="note">This is used as the fallback encoding by the <span>opaque-response-safelist
+    check</span>, which decodes the response before determining whether it parses as JavaScript.
+    <ref>FETCH</ref></p>
+   </li>
 
    <!--FETCH-->
    <li>


### PR DESCRIPTION
Opaque-response blocking needs media element requests to distinguish the initial range fetch of a media resource from the subsequent ones, and it needs classic script requests to carry the fallback encoding that would be used to decode the script, so that it can determine whether the response parses as JavaScript.

The request creation and fetch in the resource fetch algorithm are therefore factored out into `fetchByteRange`, which is run once for the initial byte range and again whenever the media element needs media data it does not have. The initial byte range now has to start at the beginning of the resource, since the opaque-response-safelist check cannot sniff for audio or video otherwise.

Depends on whatwg/fetch#1755.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): …
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): …
- [ ] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs:
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
