### PR TITLE
Editorial: fix the closed getter's reference to "is closing"

### DIFF
--- a/source
+++ b/source
@@ -90916,7 +90916,7 @@ dictionary <dfn dictionary>WindowPostMessageOptions</dfn> : <span>StructuredSeri
   data-x="list size">size</span> is 1.</p>
 
   <p>The <dfn attribute for="Window"><code data-x="dom-window-closed">closed</code></dfn> getter
-  steps are to return true if <span>this</span>'s <span data-x="window bc">browsing context</span>
+  steps are to return true if <span>this</span>'s <span data-x="window navigable">navigable</span>
   is null or its <span>is closing</span> is true; otherwise false.</p>
 
   <p>The <dfn method for="Window"><code data-x="dom-window-stop">stop()</code></dfn> method steps


### PR DESCRIPTION
0a97a81d moved the flag to navigable, this reference was not updated.