### PR TITLE
Clarify ordering between popover and popover trigger's shadow root.

### DIFF
--- a/source
+++ b/source
@@ -86310,6 +86310,38 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
   </ol>
   </div>
 
+  <div algorithm>
+    <p>A focusable area <var>first</var> precedes a focusable area <var>second</var> in
+    <dfn>focus scope order</dfn> if the following algorithm returns true:</p>
+    <ol>
+      <li><p>Let <var>owner</var> be the <span>focus navigation scope owner</span> of
+      <var>first</var>.</p></li>
+      <li>
+        <p><span>Assert</span>: <var>owner</var> is the <span>focus navigation scope
+        owner</span> of <var>second</var>.</p>
+        <p class="note">This algorithm is only intended to compare
+        two elements with the same <span>focus navigation scope owner</span>.</p>
+      </li>
+      <li><p>Set <var>firstIsPopover</var> to false.</p></li>
+      <li><p>If <var>first</var>'s <span>DOM anchor</span> is in the
+      <span data-x="popover-showing-state">popover showing
+      state</span> and <var>first</var>'s <span>DOM anchor</span>'s <span>popover trigger</span>
+      is <var>owner</var>, then set <var>firstIsPopover</var> to true.</p></li>
+      <li><p>If <var>second</var>'s <span>DOM anchor</span> is in the
+      <span data-x="popover-showing-state">popover showing
+      state</span> and <var>second</var>'s <span>DOM anchor</span>'s <span>popover trigger</span>
+      is <var>owner</var>, then:</p></li>
+      <ol><li><p>If <var>firstIsPopover</var> is false, then return false.</p></li></ol>
+      <li><p>Otherwise, if <var>firstIsPopover</var> is true, then return true.</p></li>
+      <li><p>If <var>first</var> precedes <var>second</var> in
+      <span>shadow-including tree order</span>, then return true.</p></li>
+      <li><p>Return false.</p></li>
+    </ol>
+    <p class="note">This algorithm ensures that focus navigation goes from a <span>popover
+    trigger</span> to its popover(s) before visiting the <span>popover trigger</span>'s
+    <span>shadow root</span> if it has one.</p>
+  </div>
+
   </div>
 
   <h4>The <code data-x="attr-tabindex">tabindex</code> attribute</h4>
@@ -86400,7 +86432,7 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
     <p>The relative ordering within a <span>tabindex-ordered focus navigation scope</span> for
     elements and <span data-x="focusable area">focusable areas</span> that belong to the same
     <span>focus navigation scope</span> and whose <span>tabindex value</span> is null should be in
-    <span>shadow-including tree order</span>.</p>
+    <span>focus scope order</span>.</p>
 
     <p>Modulo platform conventions, it is suggested that the following elements should be considered
     as <span data-x="focusable area">focusable areas</span> and be <span>sequentially
@@ -86456,7 +86488,7 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
     <p>The relative ordering within a <span>tabindex-ordered focus navigation scope</span> for
     elements and <span data-x="focusable area">focusable areas</span> that belong to the same
     <span>focus navigation scope</span> and whose <span>tabindex value</span> is zero should be in
-    <span>shadow-including tree order</span>.</p>
+    <span>focus scope order</span>.</p>
    </dd>
 
    <dt>If the value is greater than zero</dt>
@@ -86486,12 +86518,12 @@ dictionary <dfn dictionary>CommandEventInit</dfn> : <span>EventInit</span> {
      <li>after any <span>focusable area</span> whose <span>DOM anchor</span> is an element whose <code
      data-x="attr-tabindex">tabindex</code> attribute has a value equal to the value of the <code
      data-x="attr-tabindex">tabindex</code> attribute on <var>candidate</var> but that is
-     located earlier than <var>candidate</var> in <span>shadow-including tree order</span>,</li>
+     located earlier than <var>candidate</var> in <span>focus scope order</span>,</li>
 
      <li>before any <span>focusable area</span> whose <span>DOM anchor</span> is an element whose <code
      data-x="attr-tabindex">tabindex</code> attribute has a value equal to the value of the <code
      data-x="attr-tabindex">tabindex</code> attribute on <var>candidate</var> but that is
-     located later than <var>candidate</var> in <span>shadow-including tree order</span>, and</li>
+     located later than <var>candidate</var> in <span>focus scope order</span>, and</li>
 
      <li>before any <span>focusable area</span> whose <span>DOM anchor</span> is an element whose <code
      data-x="attr-tabindex">tabindex</code> attribute has a value greater than the value of the


### PR DESCRIPTION
Well it's a bit wordier than I had hoped ☹. Maybe someone will have some idea of how to make it clearer?

Fixes #12871

- [ ] At least two implementers are interested (and none opposed):
   * Gecko
   * …
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written at:
   * `html/semantics/popovers/popover-focus-invoker-with-children.tentative.html` (has to be tentative since this whole thing is wrapped in "should")
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: TODO
   * Gecko: (already implementing)
   * WebKit: TODO
