### PR TITLE
Align frame connection steps with iframe

### DIFF
--- a/source
+++ b/source
@@ -155229,13 +155229,11 @@ interface <dfn interface>HTMLFrameSetElement</dfn> : <span>HTMLElement</span> {
   <!-- START of section that's very similar to <iframe> -->
 
   <div algorithm>
-  <p>The <code>frame</code> <span>HTML element insertion steps</span>, given
+  <p>The <code>frame</code> <span>HTML element post-connection steps</span>, given
   <var>insertedNode</var>, are:</p>
 
   <ol>
-   <li><p>If <var>insertedNode</var> is not <span>in a document tree</span>, then return.</p></li>
-
-   <li><p>If <var>insertedNode</var>'s <span>root</span>'s <span
+   <li><p>If <var>insertedNode</var>'s <span>node document</span>'s <span
    data-x="concept-document-bc">browsing context</span> is null, then return.</p></li>
 
    <li><p><span>Create a new child navigable</span> for <var>insertedNode</var>.</p></li>


### PR DESCRIPTION
Create a frame's child navigable during post-connection steps instead of insertion steps, which must not create browsing contexts or fire events. Use the node document to check for a browsing context, allowing connected frames in shadow trees to create child navigables as iframes do.

The timing matches Chromium and WebKit; Firefox currently creates both frame and iframe windows before earlier scripts run during atomic insertion. All three engines create frame windows in connected shadow trees.

Tests: https://github.com/web-platform-tests/wpt/pull/62622

---

PR contents and commit message (and tests) above written by GPT-6 Astra Extra High. The below was done manually.

<!--
Thank you for contributing to the HTML Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Matches existing Chromium + WebKit behavior
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/whatwg/html/issues/763
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: basically part of https://bugzilla.mozilla.org/show_bug.cgi?id=1907731 and https://bugzilla.mozilla.org/show_bug.cgi?id=1882938 , which are about iframes; this is just the frame version.
   * WebKit: N/A
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): N/A
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A, MDN does not go into this level of detail on the frame element
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
