### PR TITLE
Fire traverse navigate events at descendants whose entry changes

### DIFF
--- a/source
+++ b/source
@@ -111583,15 +111583,15 @@ location.href = '#foo';</code></pre>
       <p>If all of the following are true:</p>
 
       <ul>
+       <li><p><var>navigationType</var> is "<code
+       data-x="dom-NavigationType-traverse">traverse</code>";</p></li>
+
        <li><p><var>navigable</var> is not <var>traversable</var>;</p></li>
 
-       <li><p><var>targetEntry</var> is not <var>navigable</var>'s <span
-       data-x="nav-current-history-entry">current session history entry</span>; and</p></li>
+       <li><p><var>targetEntry</var> is not <var>displayedEntry</var>; and</p></li>
 
        <li><p><var>oldOrigin</var> is the <span data-x="same origin">same</span> as
-       <var>navigable</var>'s <span
-       data-x="nav-current-history-entry">current session history entry</span>'s <span
-       data-x="she-document-state">document state</span>'s <span
+       <var>displayedEntry</var>'s <span data-x="she-document-state">document state</span>'s <span
        data-x="document-state-origin">origin</span>,</p></li>
       </ul>
 


### PR DESCRIPTION
Fixes #12859.

Outside of switching to "displayedEntry" so this is actually reachable, the "traverse" condition is also added here to prevent spurious events being fired (covered by navigate-cross-document-event-order.html as one example).

- [x] At least two implementers are interested (and none opposed):
   * Firefox (implements)
   * Webkit (implements)
   * Chromium (implements)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/navigation-api/navigate-event/navigation-traverseTo-navigates-top-and-same-doc-child-and-cross-doc-child.html
   * https://github.com/web-platform-tests/wpt/blob/master/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
   * https://github.com/web-platform-tests/wpt/blob/master/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html
   * https://github.com/web-platform-tests/wpt/blob/master/navigation-api/navigation-methods/back-forward-multiple-frames.html
   * https://github.com/web-platform-tests/wpt/blob/master/navigation-api/ordering-and-transition/navigate-cross-document-event-order.html
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
   * Deno (only for timers, structured clone, base64 utils, channel messaging, module resolution, web workers, and web storage): N/A
   * Node.js (only for timers, structured clone, base64 utils, channel messaging, and module resolution): N/A
- [x] Corresponding [HTML AAM](https://w3c.github.io/html-aam/) & [ARIA in HTML](https://w3c.github.io/html-aria/) issues & PRs: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
